### PR TITLE
feat: add failed order handling with email notification

### DIFF
--- a/app/(site)/orders/OrdersPageClient.tsx
+++ b/app/(site)/orders/OrdersPageClient.tsx
@@ -110,6 +110,8 @@ export default function OrdersPageClient({
         return "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400";
       case "CANCELLED":
         return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400";
+      case "FAILED":
+        return "bg-red-200 text-red-900 dark:bg-red-900/50 dark:text-red-300";
       default:
         return "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400";
     }
@@ -121,6 +123,8 @@ export default function OrdersPageClient({
         return "Picked Up";
       case "CANCELLED":
         return "Canceled";
+      case "FAILED":
+        return "Failed";
       default:
         return status.charAt(0) + status.slice(1).toLowerCase();
     }
@@ -167,6 +171,9 @@ export default function OrdersPageClient({
             </SelectItem>
             <SelectItem value="completed">
               Completed ({getOrderCount("completed")})
+            </SelectItem>
+            <SelectItem value="failed">
+              Failed ({getOrderCount("failed")})
             </SelectItem>
             <SelectItem value="cancelled">
               Canceled ({getOrderCount("cancelled")})

--- a/app/api/admin/orders/[orderId]/fail/route.ts
+++ b/app/api/admin/orders/[orderId]/fail/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/admin";
+import { resend } from "@/lib/resend";
+import { render } from "@react-email/components";
+import FailedOrderNotification from "@/emails/FailedOrderNotification";
+
+/**
+ * PATCH /api/admin/orders/[orderId]/fail
+ * Mark order as failed with a reason and notify the customer
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ orderId: string }> }
+) {
+  try {
+    await requireAdmin();
+    const { orderId } = await params;
+    const body = await request.json();
+    const { reason } = body;
+
+    if (!reason || typeof reason !== "string" || reason.trim().length === 0) {
+      return NextResponse.json(
+        { error: "Failure reason is required" },
+        { status: 400 }
+      );
+    }
+
+    // Update order
+    const order = await prisma.order.update({
+      where: { id: orderId },
+      data: {
+        status: "FAILED",
+        failureReason: reason.trim(),
+        failedAt: new Date(),
+      },
+      include: {
+        items: {
+          include: {
+            purchaseOption: {
+              include: {
+                variant: {
+                  include: {
+                    product: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+        user: true,
+      },
+    });
+
+    // Send failure notification email
+    try {
+      if (!order.customerEmail) {
+        console.warn("No customer email found for order", order.id);
+        return NextResponse.json({
+          success: true,
+          order,
+          warning: "Order updated but email not sent (no customer email)",
+        });
+      }
+
+      // Fetch store name and support email
+      const [storeNameSetting, supportEmailSetting] = await Promise.all([
+        prisma.siteSettings.findUnique({ where: { key: "store_name" } }),
+        prisma.siteSettings.findUnique({ where: { key: "support_email" } }),
+      ]);
+      const storeName = storeNameSetting?.value || "Artisan Roast";
+      const supportEmail =
+        supportEmailSetting?.value || process.env.RESEND_FROM_EMAIL;
+
+      const emailHtml = await render(
+        FailedOrderNotification({
+          orderNumber: order.id.slice(-8),
+          customerName: order.user?.name || order.recipientName || "Customer",
+          failureReason: reason.trim(),
+          orderId: order.id,
+          storeName,
+          supportEmail,
+        })
+      );
+
+      await resend.emails.send({
+        from: process.env.RESEND_FROM_EMAIL!,
+        to: order.customerEmail,
+        subject: `Issue with your order #${order.id.slice(-8)}`,
+        html: emailHtml,
+      });
+
+      console.log("📧 Failed order notification email sent");
+    } catch (emailError) {
+      console.error("Failed to send failure notification email:", emailError);
+      // Don't fail the request if email fails
+    }
+
+    return NextResponse.json({
+      success: true,
+      order,
+    });
+  } catch (error: unknown) {
+    console.error("Mark as failed error:", error);
+
+    if (error instanceof Error && error.message.includes("Unauthorized")) {
+      return NextResponse.json(
+        { error: "Admin access required" },
+        { status: 403 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: "Failed to mark order as failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/emails/FailedOrderNotification.tsx
+++ b/emails/FailedOrderNotification.tsx
@@ -1,0 +1,224 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+
+interface FailedOrderNotificationProps {
+  orderNumber: string;
+  customerName: string;
+  failureReason: string;
+  orderId: string;
+  storeName?: string;
+  supportEmail?: string;
+}
+
+export default function FailedOrderNotification({
+  orderNumber,
+  customerName,
+  failureReason,
+  orderId,
+  storeName = "Artisan Roast",
+  supportEmail = "support@artisanroast.com",
+}: FailedOrderNotificationProps) {
+  const orderUrl = `${process.env.NEXT_PUBLIC_APP_URL}/orders/${orderId}`;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>
+        We&apos;re sorry - there was an issue with your order #{orderNumber}
+      </Preview>
+      <Body style={main}>
+        <Container style={container}>
+          <Heading style={h1}>We&apos;re Sorry</Heading>
+
+          <Section style={alertBanner}>
+            <Text style={alertBannerText}>
+              There was an issue with your order
+            </Text>
+          </Section>
+
+          <Text style={text}>Hi {customerName},</Text>
+
+          <Text style={text}>
+            Unfortunately, we were unable to fulfill your order{" "}
+            <strong>#{orderNumber}</strong>.
+          </Text>
+
+          <Section style={reasonBox}>
+            <Text style={reasonLabel}>Reason</Text>
+            <Text style={reasonText}>{failureReason}</Text>
+          </Section>
+
+          <Text style={text}>
+            If you were charged for this order, a refund will be processed
+            within 5-10 business days to your original payment method.
+          </Text>
+
+          <Section style={buttonContainer}>
+            <Button style={button} href={orderUrl}>
+              View Order Details
+            </Button>
+          </Section>
+
+          <Hr style={hr} />
+
+          <Text style={text}>
+            We sincerely apologize for any inconvenience this may have caused.
+            If you have any questions or would like to place a new order, please
+            don&apos;t hesitate to reach out.
+          </Text>
+
+          <Section style={buttonContainer}>
+            <Button style={buttonSecondary} href={`mailto:${supportEmail}`}>
+              Contact Support
+            </Button>
+          </Section>
+
+          <Text style={footer}>
+            Thank you for your understanding.
+            <br />
+            <Link href={process.env.NEXT_PUBLIC_APP_URL} style={link}>
+              {storeName}
+            </Link>
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+// Styles
+const main = {
+  backgroundColor: "#f6f9fc",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
+};
+
+const container = {
+  backgroundColor: "#ffffff",
+  margin: "0 auto",
+  padding: "20px 0 48px",
+  marginBottom: "64px",
+  maxWidth: "600px",
+  width: "100%",
+  boxSizing: "border-box" as const,
+};
+
+const h1 = {
+  color: "#333",
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "40px 0 16px 0",
+  padding: "0",
+  textAlign: "center" as const,
+};
+
+const alertBanner = {
+  backgroundColor: "#fef2f2",
+  borderLeft: "4px solid #dc2626",
+  padding: "12px 24px",
+  margin: "16px 24px 24px 24px",
+  borderRadius: "4px",
+};
+
+const alertBannerText = {
+  color: "#991b1b",
+  fontSize: "16px",
+  fontWeight: "600" as const,
+  lineHeight: "24px",
+  margin: "0",
+  textAlign: "center" as const,
+};
+
+const text = {
+  color: "#333",
+  fontSize: "16px",
+  lineHeight: "26px",
+  margin: "16px 24px",
+};
+
+const reasonBox = {
+  backgroundColor: "#fef2f2",
+  border: "1px solid #fecaca",
+  borderRadius: "8px",
+  margin: "24px 24px",
+  padding: "24px",
+  textAlign: "center" as const,
+  width: "auto",
+  maxWidth: "100%",
+  boxSizing: "border-box" as const,
+};
+
+const reasonLabel = {
+  color: "#991b1b",
+  fontSize: "12px",
+  fontWeight: "600",
+  textTransform: "uppercase" as const,
+  letterSpacing: "0.5px",
+  margin: "0 0 8px 0",
+};
+
+const reasonText = {
+  color: "#7f1d1d",
+  fontSize: "16px",
+  fontWeight: "500",
+  margin: "0",
+  lineHeight: "24px",
+};
+
+const buttonContainer = {
+  textAlign: "center" as const,
+  margin: "24px 0",
+};
+
+const button = {
+  backgroundColor: "#8B4513",
+  borderRadius: "5px",
+  color: "#fff",
+  fontSize: "16px",
+  fontWeight: "bold",
+  textDecoration: "none",
+  textAlign: "center" as const,
+  display: "inline-block",
+  padding: "12px 24px",
+};
+
+const buttonSecondary = {
+  backgroundColor: "#6c757d",
+  borderRadius: "5px",
+  color: "#fff",
+  fontSize: "14px",
+  fontWeight: "bold",
+  textDecoration: "none",
+  textAlign: "center" as const,
+  display: "inline-block",
+  padding: "10px 20px",
+};
+
+const hr = {
+  borderColor: "#e6ebf1",
+  margin: "32px 24px",
+};
+
+const link = {
+  color: "#8B4513",
+  textDecoration: "underline",
+};
+
+const footer = {
+  color: "#8898aa",
+  fontSize: "14px",
+  lineHeight: "24px",
+  textAlign: "center" as const,
+  margin: "32px 0",
+};

--- a/prisma/migrations/20260129204317_add_order_failure_fields/migration.sql
+++ b/prisma/migrations/20260129204317_add_order_failure_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Order" ADD COLUMN     "failedAt" TIMESTAMP(3),
+ADD COLUMN     "failureReason" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -259,6 +259,8 @@ model Order {
   carrier               String?
   shippedAt             DateTime?
   trackingNumber        String?
+  failureReason         String?
+  failedAt              DateTime?
   stripeSubscriptionId  String?        @unique
   user                  User?          @relation(fields: [userId], references: [id], onDelete: Restrict)
   items                 OrderItem[]


### PR DESCRIPTION
## Summary
Add ability for admins to mark orders as failed with a reason, and automatically notify customers via email.

## Changes
- `prisma/schema.prisma` - Added `failureReason` and `failedAt` fields to Order model
- `prisma/migrations/` - Migration for new fields
- `app/api/admin/orders/[orderId]/fail/route.ts` - PATCH endpoint to mark order as failed
- `emails/FailedOrderNotification.tsx` - Email template with failure reason and refund info
- `app/admin/orders/OrderManagementClient.tsx` - Fail dialog, reason input, and "Fail" button
- `app/(site)/orders/OrdersPageClient.tsx` - FAILED status styling in customer view

## Flow
1. Admin clicks "Fail" button on PENDING order
2. Dialog prompts for failure reason (required)
3. API updates order status to FAILED, sets failedAt timestamp
4. Customer receives email with reason and refund information

## Test plan
- [ ] Mark a pending order as failed with a reason
- [ ] Verify order status changes to FAILED
- [ ] Verify customer receives notification email
- [ ] Verify FAILED status appears correctly in admin and customer views
- [ ] Test validation (empty reason should fail)