### PR TITLE
feat: add npm run upgrade command for self-hosted deployments

### DIFF
--- a/docs/architecture/UPGRADE-PATH.md
+++ b/docs/architecture/UPGRADE-PATH.md
@@ -25,6 +25,7 @@ DATABASE_URL=$DIRECT_URL PRISMA_MIGRATE_ADVISORY_LOCK_TIMEOUT=180000 node script
 ```
 
 **What happens:**
+
 1. `DIRECT_URL` (non-pooled Neon connection) is used for migrations
 2. `prisma migrate deploy` runs with retry logic
 3. `prisma generate` regenerates the client
@@ -174,55 +175,72 @@ git branch -D test/upgrade-path-verification
 
 ---
 
-## Future: `npm run upgrade` Command
+## `npm run upgrade` Command
 
-TODO: Create a dedicated upgrade command for self-hosted users:
+A dedicated upgrade command for self-hosted users:
 
 ```bash
-
 npm run upgrade
 ```
 
-**Proposed behavior:**
+**What it does:**
 
-```javascript
-// scripts/upgrade.js
-async function upgrade() {
-  console.log("🔄 Starting Artisan Roast upgrade...");
+1. Shows current version
+2. Checks database migration status
+3. Applies pending migrations (if any)
+4. Regenerates Prisma client
+5. Clears Next.js cache
 
-  // 1. Check current version
-  const currentVersion = require('../package.json').version;
-  console.log(`📦 Current version: ${currentVersion}`);
+**Example output (with pending migrations):**
 
-  // 2. Run migrations
-  console.log("🗄️  Running database migrations...");
-  execSync('npx prisma migrate deploy', { stdio: 'inherit' });
+```text
+========================================
+   Artisan Roast Upgrade
+========================================
 
-  // 3. Regenerate Prisma client
-  console.log("⚙️  Regenerating Prisma client...");
-  execSync('npx prisma generate', { stdio: 'inherit' });
+Current version: 0.79.0
 
-  // 4. Run any data migrations (future)
-  // await runDataMigrations();
+Checking database migration status...
 
-  // 5. Clear caches
-  console.log("🧹 Clearing caches...");
-  execSync('rm -rf .next', { stdio: 'inherit' });
+Found 3 pending migration(s).
 
-  console.log("✅ Upgrade complete!");
-  console.log("👉 Run 'npm run build && npm start' to start the application");
-}
+Applying database migrations...
+
+$ npx prisma migrate deploy
+...
+All migrations have been successfully applied.
+
+Migrations applied successfully.
+
+Regenerating Prisma client...
+
+========================================
+   Upgrade complete!
+========================================
+
+Next steps:
+  1. Run: npm run build
+  2. Run: npm start (or restart your process manager)
 ```
 
-**Package.json entry:**
+**Example output (already up to date):**
 
-```json
+```text
+========================================
+   Artisan Roast Upgrade
+========================================
 
-{
-  "scripts": {
-    "upgrade": "node scripts/upgrade.js"
-  }
-}
+Current version: 0.79.0
+
+Checking database migration status...
+
+Database is already up to date.
+
+Regenerating Prisma client...
+
+========================================
+   Upgrade complete!
+========================================
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "db:smoke": "tsx dev-tools/smoke-crud.ts",
     "create-admin": "tsx scripts/create-admin.ts",
     "setup": "tsx scripts/setup.ts",
+    "upgrade": "tsx scripts/upgrade.ts",
     "release:patch": "tsx scripts/release.ts patch",
     "release:minor": "tsx scripts/release.ts minor",
     "release:major": "tsx scripts/release.ts major"

--- a/scripts/upgrade.ts
+++ b/scripts/upgrade.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env npx tsx
+/**
+ * Upgrade script for Artisan Roast
+ *
+ * For self-hosted deployments to run database migrations and prepare the app.
+ *
+ * Usage:
+ *   npm run upgrade
+ *
+ * What it does:
+ *   1. Shows current version
+ *   2. Checks migration status
+ *   3. Runs pending database migrations
+ *   4. Regenerates Prisma client
+ *   5. Clears Next.js cache
+ */
+
+import { execSync } from "child_process";
+import { existsSync, rmSync, readFileSync } from "fs";
+import path from "path";
+
+interface PackageJson {
+  version: string;
+}
+
+const pkg: PackageJson = JSON.parse(
+  readFileSync(path.join(process.cwd(), "package.json"), "utf-8")
+);
+
+function run(cmd: string, allowFailure = false): boolean {
+  console.log(`$ ${cmd}`);
+  try {
+    execSync(cmd, { stdio: "inherit" });
+    return true;
+  } catch {
+    if (!allowFailure) {
+      throw new Error(`Command failed: ${cmd}`);
+    }
+    return false;
+  }
+}
+
+function runSilent(cmd: string): string | null {
+  try {
+    return execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+  } catch (error: unknown) {
+    const execError = error as { stdout?: Buffer; stderr?: Buffer };
+    if (execError.stdout) return execError.stdout.toString().trim();
+    if (execError.stderr) return execError.stderr.toString().trim();
+    return null;
+  }
+}
+
+async function main() {
+  console.log("\n========================================");
+  console.log("   Artisan Roast Upgrade");
+  console.log("========================================\n");
+
+  // 1. Show current version
+  console.log(`Current version: ${pkg.version}\n`);
+
+  // 2. Check migration status
+  console.log("Checking database migration status...\n");
+  const status = runSilent("npx prisma migrate status 2>&1");
+
+  if (status && status.includes("Database schema is up to date")) {
+    console.log("Database is already up to date.\n");
+  } else if (status && status.includes("Following migrations have not yet been applied")) {
+    // Extract pending migration count
+    const appliedMatch = status.match(/have not yet been applied:([\s\S]*?)To apply/);
+
+    if (appliedMatch) {
+      const pendingMigrations = appliedMatch[1].trim().split("\n").filter(Boolean);
+      console.log(`Found ${pendingMigrations.length} pending migration(s).\n`);
+    }
+
+    // 3. Run migrations
+    console.log("Applying database migrations...\n");
+    run("npx prisma migrate deploy");
+    console.log("\nMigrations applied successfully.\n");
+  } else if (status && status.includes("Error")) {
+    console.error("Error checking migration status:");
+    console.error(status);
+    process.exit(1);
+  }
+
+  // 4. Regenerate Prisma client
+  console.log("Regenerating Prisma client...\n");
+  run("npx prisma generate");
+
+  // 5. Clear Next.js cache
+  const nextCachePath = path.join(process.cwd(), ".next");
+  if (existsSync(nextCachePath)) {
+    console.log("\nClearing Next.js cache...");
+    rmSync(nextCachePath, { recursive: true, force: true });
+    console.log("Cache cleared.\n");
+  }
+
+  // Done
+  console.log("========================================");
+  console.log("   Upgrade complete!");
+  console.log("========================================\n");
+  console.log("Next steps:");
+  console.log("  1. Run: npm run build");
+  console.log("  2. Run: npm start (or restart your process manager)\n");
+}
+
+main().catch((err: Error) => {
+  console.error("\nUpgrade failed:", err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds a dedicated upgrade command for self-hosted users to easily apply database migrations after pulling new code.

## Changes
- New `scripts/upgrade.ts` - upgrade script
- Added `npm run upgrade` to package.json
- Updated `docs/architecture/UPGRADE-PATH.md` with implemented command documentation

## What `npm run upgrade` does
1. Shows current version
2. Checks database migration status
3. Applies pending migrations (if any)
4. Regenerates Prisma client
5. Clears Next.js cache

## Testing
Tested against fresh `artisan_upgrade_test` database:
- Applied 61 migrations successfully
- Correctly detects when database is already up to date
- All pre-commit checks pass