### PR TITLE
fix: add DATABASE_URL fallback for prisma generate

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,7 +1,11 @@
 import { config } from "dotenv";
 config({ path: ".env.local" }); // This line is correct and loads .env.local
 
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
+
+// Fallback for prisma generate during npm install (doesn't need real DB)
+const databaseUrl =
+  process.env.DATABASE_URL || "postgresql://placeholder:placeholder@localhost:5432/placeholder";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -10,6 +14,6 @@ export default defineConfig({
     seed: "tsx prisma/seed/index.ts",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: databaseUrl,
   },
 });


### PR DESCRIPTION
Fixes Vercel preview build failure where DATABASE_URL isn't set during npm install. Prisma generate doesn't need a real DB connection, just the schema.