### PR TITLE
feat: tag-only releases with build-time version

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -197,48 +197,59 @@ npm run precheck    # TypeScript + ESLint
 
 ### Versioning & Releases
 
-**Key concept:** Git tags track versions, but only **GitHub Releases** trigger upgrade notices in the app.
+#### How It Works
 
-| Action | Version Bump | Git Tag | Upgrade Notice |
-|--------|--------------|---------|----------------|
-| Merge PR | No | No | No |
-| `npm run release:patch` | Yes | Yes | No |
-| `npm run release:patch` + GitHub Release | Yes | Yes | **Yes** |
+- **Version is derived from git tags at build time** (see `next.config.ts`)
+- No version commits needed - just create and push tags
+- `package.json` version is for npm only, not the app
+- **GitHub Releases** (not tags) trigger upgrade notices in the app
+
+#### Release Flow
+
+```
+1. Merge PR to main
+2. Run: npm run release:patch -- -y --push
+3. Done! (No extra branches, no extra CI runs)
+```
+
+| Action | Creates Tag | Triggers Build | Upgrade Notice |
+|--------|-------------|----------------|----------------|
+| Merge PR | No | Yes | No |
+| `npm run release:patch --push` | Yes | No | No |
+| + `--github-release` | Yes | No | **Yes** |
 
 #### Release Commands
 
 ```bash
-# Interactive mode (for humans)
+# Interactive mode
 npm run release:patch
 npm run release:minor
 
-# Non-interactive mode (for Claude)
-npm run release:patch -- --yes --push --message "Fix webhook bug"
-npm run release:minor -- -y --push --github-release --message "Add log levels"
+# Non-interactive (Claude-friendly)
+npm run release:patch -- -y --push
+npm run release:minor -- -y --push --github-release
 ```
 
 **Flags:**
 
-- `--yes, -y` - Skip confirmation prompts
-- `--push` - Auto-push to origin
-- `--github-release` - Create GitHub Release (triggers upgrade notice!)
-- `--message, -m` - Release message for changelog
+- `--yes, -y` - Skip prompts
+- `--push` - Push tag to origin
+- `--github-release` - Create GitHub Release (triggers upgrade notice)
+- `--message, -m` - Tag annotation message
 
 #### When to Create GitHub Release
 
-- **Yes:** User-facing features, important bug fixes, breaking changes
-- **No:** Internal refactors, dev tooling, minor fixes
-
-The release script will prompt: `Create GitHub Release? (triggers upgrade notice)`
+- **Yes:** User-facing features, important fixes, breaking changes
+- **No:** Internal refactors, dev tooling, minor tweaks
 
 #### Quick Reference
 
 ```bash
-# After merging a PR - bump version, no upgrade notice
-npm run release:patch -- -y --push --message "Refactor webhook handlers"
+# Standard release (no user notification)
+npm run release:patch -- -y --push
 
-# After merging a user-facing feature - bump + notify users
-npm run release:minor -- -y --push --github-release --message "Add subscription management"
+# User-facing release (shows upgrade notice)
+npm run release:minor -- -y --push --github-release
 ```
 
 ---

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,9 +1,12 @@
 /**
  * Version management for Artisan Roast
  * Used for update notifications and telemetry
+ *
+ * APP_VERSION is derived from git tags at build time (see next.config.ts)
+ * Fallback for local dev when env var not set
  */
 
-export const APP_VERSION = "0.80.1";
+export const APP_VERSION = process.env.APP_VERSION || "0.0.0-dev";
 
 export type Edition = "community" | "pro";
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,33 @@
 import type { NextConfig } from "next";
+import { execSync } from "child_process";
+import { readFileSync } from "fs";
+
+// Get version from git tags at build time
+function getVersionFromGit(): string {
+  try {
+    // Get latest tag (e.g., "v0.80.1")
+    const tag = execSync("git describe --tags --abbrev=0", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    return tag.replace(/^v/, ""); // Remove 'v' prefix
+  } catch {
+    // Fallback to package.json version if no tags
+    try {
+      const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
+      return pkg.version || "0.0.0";
+    } catch {
+      return "0.0.0";
+    }
+  }
+}
+
+const APP_VERSION = getVersionFromGit();
 
 const nextConfig: NextConfig = {
+  env: {
+    APP_VERSION,
+  },
   serverExternalPackages: ["@prisma/client", "prisma"],
   images: {
     // We must whitelist the domains we'll be using for our product images.

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -2,6 +2,9 @@
 /**
  * Release script for Artisan Roast
  *
+ * Creates git tags for releases. Version is derived from tags at build time
+ * (see next.config.ts), so no file changes needed.
+ *
  * Usage:
  *   Interactive mode:
  *     npm run release:patch
@@ -9,29 +12,31 @@
  *
  *   Non-interactive (Claude-friendly):
  *     npm run release:patch -- --yes --push
- *     npm run release:minor -- -y --push --github-release --message "Add new feature"
+ *     npm run release:minor -- -y --push --github-release
  *
  * Flags:
  *   --yes, -y           Skip confirmation prompts
- *   --push              Push to origin after release
+ *   --push              Push tag to origin
  *   --github-release    Create GitHub Release (triggers upgrade notice in app)
- *   --message, -m       Release message for changelog and tag
+ *   --message, -m       Release message for tag annotation
  *
  * What it does:
- *   1. Bumps version in package.json and lib/version.ts
- *   2. Updates CHANGELOG.md with new version header
- *   3. Commits and creates annotated git tag
- *   4. Optionally pushes to origin
- *   5. Optionally creates GitHub Release (this triggers upgrade notices!)
+ *   1. Determines next version from latest tag
+ *   2. Creates annotated git tag
+ *   3. Optionally pushes tag to origin
+ *   4. Optionally creates GitHub Release (this triggers upgrade notices!)
+ *
+ * Note: No commits are created. The tag points to the current HEAD.
+ * APP_VERSION is derived from git tags at build time.
  */
 
 import { execSync } from "child_process";
-import { readFileSync, writeFileSync } from "fs";
 import { createInterface } from "readline";
 
 // Parse CLI arguments
 const args = process.argv.slice(2);
-const bumpType = args.find((a) => ["patch", "minor", "major"].includes(a)) || "patch";
+const bumpType =
+  args.find((a) => ["patch", "minor", "major"].includes(a)) || "patch";
 const flags = {
   yes: args.includes("--yes") || args.includes("-y"),
   push: args.includes("--push"),
@@ -78,7 +83,10 @@ const ask = (question: string): Promise<string> => {
 // Cross-platform exec helpers
 function exec(cmd: string): string {
   try {
-    return execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+    return execSync(cmd, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
   } catch {
     return "";
   }
@@ -103,184 +111,136 @@ function bumpVersion(version: string, type: BumpType): string {
   }
 }
 
-function getCurrentVersion(): string {
-  const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
-  return pkg.version;
-}
-
 function getLastTag(): string | null {
-  // Cross-platform: use git directly without shell redirects
   const tags = exec("git tag -l v* --sort=-v:refname");
   if (!tags) return null;
-  const firstTag = tags.split("\n")[0];
-  return firstTag || null;
+  return tags.split("\n")[0] || null;
+}
+
+function getVersionFromTag(tag: string | null): string {
+  if (!tag) return "0.0.0";
+  return tag.replace(/^v/, "");
 }
 
 function getCommitsSinceTag(tag: string | null): string {
   const range = tag ? `${tag}..HEAD` : "HEAD~10..HEAD";
-  return exec(`git log ${range} --oneline --no-decorate`) || "(no commits found)";
-}
-
-function updatePackageJson(newVersion: string) {
-  const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
-  pkg.version = newVersion;
-  writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
-}
-
-function updateVersionTs(newVersion: string) {
-  const path = "lib/version.ts";
-  let content = readFileSync(path, "utf-8");
-  content = content.replace(
-    /export const APP_VERSION = "[^"]+"/,
-    `export const APP_VERSION = "${newVersion}"`
-  );
-  writeFileSync(path, content);
-}
-
-function updateChangelog(newVersion: string, message?: string): string {
-  const path = "CHANGELOG.md";
-  const date = new Date().toISOString().split("T")[0];
-  const header = `## ${newVersion} - ${date}`;
-
-  // If message provided, use it directly; otherwise use template
-  const content_block = message
-    ? `${header}\n\n${message}\n\n`
-    : `${header}\n\n### Changes\n- \n\n`;
-
-  let content = readFileSync(path, "utf-8");
-  content = content.replace("# Changelog\n\n", `# Changelog\n\n${content_block}`);
-  writeFileSync(path, content);
-  return path;
+  return exec(`git log ${range} --oneline --no-decorate`) || "(no commits)";
 }
 
 function createGitHubRelease(version: string, message?: string) {
   const tag = `v${version}`;
   const repo = "yuens1002/ecomm-ai-app";
-  const title = encodeURIComponent(`Release ${tag}`);
-  const body = encodeURIComponent(message || `Release ${tag}`);
 
-  // Use gh CLI if available (works cross-platform)
+  // Use gh CLI if available
   const ghAvailable = exec("gh --version");
   if (ghAvailable) {
-    console.log("\n📦 Creating GitHub Release with gh CLI...");
+    console.log("\n📦 Creating GitHub Release...");
     const releaseBody = message || `Release ${tag}`;
     try {
-      run(`gh release create ${tag} --title "Release ${tag}" --notes "${releaseBody.replace(/"/g, '\\"')}"`);
-      console.log(`\n✅ GitHub Release created: https://github.com/${repo}/releases/tag/${tag}`);
+      run(
+        `gh release create ${tag} --title "Release ${tag}" --notes "${releaseBody.replace(/"/g, '\\"')}"`
+      );
+      console.log(
+        `\n✅ GitHub Release created: https://github.com/${repo}/releases/tag/${tag}`
+      );
       return true;
-    } catch (e) {
-      console.error("Failed to create release with gh CLI:", e);
+    } catch {
+      console.error("Failed to create release with gh CLI");
       return false;
     }
   }
 
-  // Fallback: print URL for manual creation
+  // Fallback: print URL
+  const title = encodeURIComponent(`Release ${tag}`);
+  const body = encodeURIComponent(message || `Release ${tag}`);
   const url = `https://github.com/${repo}/releases/new?tag=${tag}&title=${title}&body=${body}`;
-  console.log("\n📦 To create GitHub Release (triggers upgrade notice), visit:");
+  console.log("\n📦 Create GitHub Release at:");
   console.log(`   ${url}`);
   return false;
 }
 
 async function main() {
   if (!["patch", "minor", "major"].includes(bumpType)) {
-    console.error("Usage: release.ts [patch|minor|major] [--yes] [--push] [--github-release] [--message '...']");
+    console.error(
+      "Usage: release.ts [patch|minor|major] [--yes] [--push] [--github-release] [--message '...']"
+    );
     process.exit(1);
   }
 
-  // Check for clean working directory
-  const status = exec("git status --porcelain");
-  if (status) {
-    console.error("❌ Working directory not clean. Commit or stash changes first.");
-    console.log(status);
-    process.exit(1);
-  }
-
-  const currentVersion = getCurrentVersion();
-  const newVersion = bumpVersion(currentVersion, bumpType as BumpType);
   const lastTag = getLastTag();
+  const currentVersion = getVersionFromTag(lastTag);
+  const newVersion = bumpVersion(currentVersion, bumpType as BumpType);
+  const newTag = `v${newVersion}`;
 
-  console.log("\n📦 Release Script");
+  console.log("\n📦 Release Script (tag-only)");
   console.log("─".repeat(50));
-  console.log(`Current version: ${currentVersion}`);
-  console.log(`New version:     ${newVersion} (${bumpType})`);
-  console.log(`Last tag:        ${lastTag || "(none)"}`);
+  console.log(`Current tag:     ${lastTag || "(none)"}`);
+  console.log(`New tag:         ${newTag} (${bumpType})`);
   console.log(`Mode:            ${flags.yes ? "non-interactive" : "interactive"}`);
 
   // Show commits since last tag
-  console.log("\n📝 Commits since last release:");
+  console.log("\n📝 Commits to be included:");
   console.log("─".repeat(50));
   const commits = getCommitsSinceTag(lastTag);
   console.log(commits);
   console.log("─".repeat(50));
 
+  // Check if there are any commits to tag
+  if (commits === "(no commits)") {
+    console.log("\n⚠️  No new commits since last tag. Nothing to release.");
+    closeReadline();
+    process.exit(0);
+  }
+
   // Confirm
-  const confirm = await ask(`\nProceed with release v${newVersion}? (y/N) `);
+  const confirm = await ask(`\nCreate tag ${newTag}? (y/N) `);
   if (confirm.toLowerCase() !== "y") {
     console.log("Aborted.");
     closeReadline();
     process.exit(0);
   }
 
-  // Update files
-  console.log("\n📝 Updating version files...");
-  updatePackageJson(newVersion);
-  console.log("   ✓ package.json");
-  updateVersionTs(newVersion);
-  console.log("   ✓ lib/version.ts");
-  updateChangelog(newVersion, flags.message);
-  console.log("   ✓ CHANGELOG.md");
-
-  // If no message provided and interactive mode, pause for editing
-  if (!flags.message && !flags.yes) {
-    console.log("\n⚠️  Please edit CHANGELOG.md now with release notes.");
-    console.log("   Use the commits above as reference.\n");
-    await ask("Press Enter when done editing CHANGELOG.md...");
-  }
-
-  // Git operations
-  run("git add package.json lib/version.ts CHANGELOG.md");
-  run(`git commit -m "chore(release): v${newVersion}"`);
-  run(`git tag -a v${newVersion} -m "Release v${newVersion}"`);
-
-  console.log("\n✅ Release v" + newVersion + " prepared locally.");
+  // Create tag
+  const tagMessage = flags.message || `Release ${newVersion}`;
+  run(`git tag -a ${newTag} -m "${tagMessage.replace(/"/g, '\\"')}"`);
+  console.log(`\n✅ Tag ${newTag} created locally.`);
 
   // Push
   let shouldPush = flags.push;
   if (!flags.yes && !shouldPush) {
-    const pushAnswer = await ask("\nPush to origin? (y/N) ");
+    const pushAnswer = await ask("\nPush tag to origin? (y/N) ");
     shouldPush = pushAnswer.toLowerCase() === "y";
   }
 
   if (shouldPush) {
-    // Get current branch
-    const branch = exec("git rev-parse --abbrev-ref HEAD") || "main";
-    run(`git push origin ${branch}`);
-    run(`git push origin v${newVersion}`);
-    console.log("\n✅ Pushed to origin.");
+    run(`git push origin ${newTag}`);
+    console.log("\n✅ Tag pushed to origin.");
   } else {
-    const branch = exec("git rev-parse --abbrev-ref HEAD") || "main";
     console.log("\nTo push later:");
-    console.log(`   git push origin ${branch}`);
-    console.log(`   git push origin v${newVersion}`);
+    console.log(`   git push origin ${newTag}`);
   }
 
-  // GitHub Release (triggers upgrade notice!)
+  // GitHub Release info
   console.log("\n" + "─".repeat(50));
-  console.log("📢 UPGRADE NOTICE INFO:");
-  console.log("   Git tags alone do NOT trigger upgrade notices.");
-  console.log("   Only GitHub Releases trigger the in-app upgrade notice.");
+  console.log("📢 UPGRADE NOTICE:");
+  console.log("   Tags alone do NOT trigger upgrade notices.");
+  console.log("   Create a GitHub Release to notify users.");
   console.log("─".repeat(50));
 
   let shouldCreateRelease = flags.githubRelease;
   if (!flags.yes && !shouldCreateRelease && shouldPush) {
-    const releaseAnswer = await ask("\nCreate GitHub Release? (triggers upgrade notice) (y/N) ");
+    const releaseAnswer = await ask(
+      "\nCreate GitHub Release? (triggers upgrade notice) (y/N) "
+    );
     shouldCreateRelease = releaseAnswer.toLowerCase() === "y";
   }
 
-  if (shouldCreateRelease && shouldPush) {
-    createGitHubRelease(newVersion, flags.message);
-  } else if (!shouldPush && flags.githubRelease) {
-    console.log("\n⚠️  Skipping GitHub Release - must push first.");
+  if (shouldCreateRelease) {
+    if (!shouldPush) {
+      console.log("\n⚠️  Push tag first before creating GitHub Release.");
+    } else {
+      createGitHubRelease(newVersion, flags.message);
+    }
   }
 
   console.log("\n🎉 Done!");


### PR DESCRIPTION
## Summary

Simplifies the release process by deriving version from git tags at build time instead of committing version changes.

## Changes

- **next.config.ts**: Gets version from `git describe --tags` at build time, sets `APP_VERSION` env var
- **lib/version.ts**: Uses `process.env.APP_VERSION` instead of hardcoded version
- **scripts/release.ts**: Simplified to tag-only (no file changes, no commits)
- **claude.md**: Updated docs for new workflow

## New Release Flow

```bash
# After merging a PR:
npm run release:patch -- -y --push

# For user-facing releases (triggers upgrade notice):
npm run release:minor -- -y --push --github-release
```

## Benefits

- No extra branches/PRs for releases
- No extra CI builds for version bumps
- Tags point directly to merge commits
- Cleaner git history