### PR TITLE
perf: skip SSG in CI builds to reduce DB connections

### DIFF
--- a/.github/workflows/build-safe-main.yml
+++ b/.github/workflows/build-safe-main.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Run tests (Jest CI)
         run: npm run test:ci
 
-      - name: Build (no migrations)
+      - name: Build (no migrations, skip SSG)
         env:
           # Use direct connection for any DB-adjacent steps, but skip migrations in CI
           DATABASE_URL: ${{ secrets.DIRECT_URL }}
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
           BUILD_VERBOSE: "true"
+          # Skip static site generation to reduce DB connections during CI builds
+          # Pages will be generated via ISR on first request in production
+          SKIP_SSG: "true"
         run: npm run build:no-migrate
 
       - name: Save Next.js cache

--- a/app/(site)/[category]/page.tsx
+++ b/app/(site)/[category]/page.tsx
@@ -42,10 +42,19 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
   );
 }
 
+// Allow ISR for non-pre-rendered paths (works with SKIP_SSG in CI)
+export const dynamicParams = true;
+
 /**
  * This function pre-renders all category pages at build time
+ *
+ * Set SKIP_SSG=true in CI to skip static generation and reduce DB connections
  */
 export async function generateStaticParams() {
+  if (process.env.SKIP_SSG === "true") {
+    return [];
+  }
+
   const categories = await getCategorySlugs();
 
   // Returns: [{ category: 'blends' }, { category: 'single-origin' }, { category: 'light-roast' }]

--- a/app/(site)/pages/[...slug]/page.tsx
+++ b/app/(site)/pages/[...slug]/page.tsx
@@ -31,7 +31,19 @@ async function getPage(slug: string) {
   return page;
 }
 
+// Allow ISR for non-pre-rendered paths (works with SKIP_SSG in CI)
+export const dynamicParams = true;
+
+/**
+ * Pre-render published pages at build time
+ *
+ * Set SKIP_SSG=true in CI to skip static generation and reduce DB connections
+ */
 export async function generateStaticParams() {
+  if (process.env.SKIP_SSG === "true") {
+    return [];
+  }
+
   const pages = await prisma.page.findMany({
     where: { isPublished: true },
     select: { slug: true },

--- a/app/(site)/products/[slug]/page.tsx
+++ b/app/(site)/products/[slug]/page.tsx
@@ -82,11 +82,20 @@ export default async function ProductPage({
   );
 }
 
+// Allow ISR for non-pre-rendered paths (works with SKIP_SSG in CI)
+export const dynamicParams = true;
+
 /**
  * Generate static paths for all products (one path per product)
  * This is much more efficient than generating paths for every product-category combination
+ *
+ * Set SKIP_SSG=true in CI to skip static generation and reduce DB connections
  */
 export async function generateStaticParams() {
+  if (process.env.SKIP_SSG === "true") {
+    return [];
+  }
+
   const products = await prisma.product.findMany({
     select: { slug: true },
     where: { isDisabled: false },


### PR DESCRIPTION
## Summary

- Add `SKIP_SSG` environment variable check to `generateStaticParams` in category, product, and CMS pages routes
- Add `dynamicParams=true` to enable ISR fallback when SSG is skipped
- Set `SKIP_SSG=true` in GitHub Actions CI workflow only

## Why

CI builds were frequently failing with "Too many database connections" errors from Neon. During SSG, Next.js opens parallel database connections for each page being generated, which can exhaust Neon's connection limit.

## How it works

| Environment | SKIP_SSG | Static Pages |
|------------|----------|--------------|
| GitHub Actions CI | `true` | Skipped (ISR on first request) |
| Vercel Production | Not set | ✅ Generated normally |
| Local dev | Not set | ✅ Generated normally |

## Test plan

- [x] Local build with `SKIP_SSG=true` succeeds
- [x] TypeScript check passes
- [ ] CI build passes without DB connection errors