### PR TITLE
docs: test CI skip for docs-only changes

### DIFF
--- a/docs/navigation/README.md
+++ b/docs/navigation/README.md
@@ -126,3 +126,5 @@ The old functions in `admin-nav.ts` are deprecated:
 | `isNavChildActive()` | `useIsHrefActive()` |
 | `findActiveNavigation()` | `useBreadcrumbTrail()` |
 | `getActiveChild()` | `useIsHrefActive()` for each child |
+
+<!-- CI skip test -->


### PR DESCRIPTION
Testing that build-safe check passes quickly without running full build for docs-only PRs.