### PR TITLE
fix: checkout flow preserves redirect and closes cart drawer

### DIFF
--- a/app/(site)/_components/cart/ShoppingCart.tsx
+++ b/app/(site)/_components/cart/ShoppingCart.tsx
@@ -210,7 +210,8 @@ export function ShoppingCart() {
           );
           setIsCheckingOut(false);
           setIsOpen(false);
-          router.push("/auth/signin");
+          // Include callbackUrl so user returns to checkout after auth
+          router.push("/auth/signin?callbackUrl=/checkout/resume");
           return;
         }
 
@@ -255,6 +256,7 @@ export function ShoppingCart() {
 
       // Redirect to Stripe Checkout
       if (data.url) {
+        setIsOpen(false); // Close drawer before redirect to prevent it opening on return
         window.location.href = data.url;
       }
     } catch (error) {

--- a/app/(site)/checkout/resume/page.tsx
+++ b/app/(site)/checkout/resume/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, Suspense } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
+import { useCartStore } from "@/lib/store/cart-store";
+import { PageContainer } from "@/components/shared/PageContainer";
+
+function CheckoutResumeContent() {
+  const router = useRouter();
+  const items = useCartStore((state) => state.items);
+  const setCartOpen = useCartStore((state) => state.setCartOpen);
+
+  useEffect(() => {
+    // If cart has items, open the cart drawer and redirect to home
+    // so user can complete checkout
+    if (items.length > 0) {
+      setCartOpen(true);
+      router.replace("/");
+    } else {
+      // No items in cart, just go home
+      router.replace("/");
+    }
+  }, [items.length, setCartOpen, router]);
+
+  return (
+    <PageContainer className="flex flex-col items-center justify-center min-h-[60vh]">
+      <Loader2 className="w-16 h-16 text-primary animate-spin mb-4" />
+      <p className="text-lg text-text-muted">Resuming your checkout...</p>
+    </PageContainer>
+  );
+}
+
+export default function CheckoutResumePage() {
+  return (
+    <Suspense
+      fallback={
+        <PageContainer className="py-16 flex flex-col items-center justify-center min-h-[60vh]">
+          <Loader2 className="w-16 h-16 text-primary animate-spin mb-4" />
+          <p className="text-lg text-text-muted">Loading...</p>
+        </PageContainer>
+      }
+    >
+      <CheckoutResumeContent />
+    </Suspense>
+  );
+}

--- a/app/(site)/checkout/success/page.tsx
+++ b/app/(site)/checkout/success/page.tsx
@@ -13,11 +13,13 @@ function CheckoutSuccessContent() {
   const sessionId = searchParams.get("session_id");
   const [verifying, setVerifying] = useState(true);
   const clearCart = useCartStore((state) => state.clearCart);
+  const setCartOpen = useCartStore((state) => state.setCartOpen);
 
   useEffect(() => {
-    // Clear the cart after successful checkout
+    // Clear the cart and close drawer after successful checkout
     if (sessionId) {
       clearCart();
+      setCartOpen(false); // Ensure cart drawer is closed
       // Simulate verification delay
       const timer = setTimeout(() => setVerifying(false), 1500);
       return () => clearTimeout(timer);
@@ -25,7 +27,7 @@ function CheckoutSuccessContent() {
     // Only set verifying to false in timeout to avoid sync setState
     const timer = setTimeout(() => setVerifying(false), 0);
     return () => clearTimeout(timer);
-  }, [sessionId, clearCart]);
+  }, [sessionId, clearCart, setCartOpen]);
 
   if (verifying) {
     return (

--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -96,6 +96,7 @@ export async function signInPublic(
 }> {
   const email = formData.get("email");
   const password = formData.get("password");
+  const redirectTo = (formData.get("redirectTo") as string | null) || "/account";
 
   try {
     const validated = credentialsSchema.safeParse({ email, password });
@@ -117,7 +118,7 @@ export async function signInPublic(
     await signIn("credentials", {
       email: validated.data.email,
       password: validated.data.password,
-      redirectTo: "/account",
+      redirectTo,
     });
   } catch (error) {
     if (error instanceof AuthError) {
@@ -266,6 +267,7 @@ export async function signUpPublic(
   const password = (formData.get("password") as string | null) ?? "";
   const confirmPassword =
     (formData.get("confirmPassword") as string | null) ?? "";
+  const redirectTo = (formData.get("redirectTo") as string | null) || "/account";
 
   const validated = signupSchema.safeParse({
     name: name || undefined,
@@ -324,7 +326,7 @@ export async function signUpPublic(
     await signIn("credentials", {
       email: validated.data.email,
       password: validated.data.password,
-      redirectTo: "/account",
+      redirectTo,
     });
   } catch (error) {
     if (error instanceof AuthError) {

--- a/app/auth/signin/signin-content.tsx
+++ b/app/auth/signin/signin-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState, useMemo } from "react";
+import { useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -8,8 +9,20 @@ import Link from "next/link";
 import { LoginForm } from "@/components/auth/LoginForm";
 import { DemoSignInButtons } from "@/components/auth/DemoSignInButtons";
 import { signInPublic } from "@/app/auth/actions";
+import { Spinner } from "@/components/ui/spinner";
 
-export function SignInContent() {
+function SignInContentInner() {
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl") || "/account";
+
+  const signUpHref = useMemo(() => {
+    const url = new URL("/auth/signup", window.location.origin);
+    if (callbackUrl !== "/account") {
+      url.searchParams.set("callbackUrl", callbackUrl);
+    }
+    return url.pathname + url.search;
+  }, [callbackUrl]);
+
   const [checkoutNotice] = useState(() => {
     if (typeof window === "undefined") return "";
     const stored = window.localStorage.getItem("artisan-roast-checkout-notice");
@@ -33,11 +46,11 @@ export function SignInContent() {
 
       {process.env.NEXT_PUBLIC_DEMO_MODE === "true" && <Separator className="my-4" />}
 
-      <LoginForm signInAction={signInPublic} />
+      <LoginForm signInAction={signInPublic} redirectTo={callbackUrl} />
 
       <div className="text-center text-sm">
         <Link
-          href="/auth/signup"
+          href={signUpHref}
           className="text-primary hover:underline font-medium"
         >
           Don&apos;t have an account? Sign up
@@ -54,7 +67,7 @@ export function SignInContent() {
         <Button
           className="w-full"
           variant="outline"
-          onClick={() => signIn("google", { callbackUrl: "/" })}
+          onClick={() => signIn("google", { callbackUrl })}
         >
           <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
             <path
@@ -80,7 +93,7 @@ export function SignInContent() {
         <Button
           className="w-full"
           variant="outline"
-          onClick={() => signIn("github", { callbackUrl: "/" })}
+          onClick={() => signIn("github", { callbackUrl })}
         >
           <svg className="mr-2 h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
             <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
@@ -98,5 +111,19 @@ export function SignInContent() {
         </Link>
       </p>
     </div>
+  );
+}
+
+export function SignInContent() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center py-8">
+          <Spinner />
+        </div>
+      }
+    >
+      <SignInContentInner />
+    </Suspense>
   );
 }

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -25,14 +25,18 @@ interface LoginFormProps {
     passwordError?: string;
     email?: string;
   }>;
+  redirectTo?: string;
 }
 
-export function LoginForm({ signInAction }: LoginFormProps) {
+export function LoginForm({ signInAction, redirectTo }: LoginFormProps) {
   const [state, action, isPending] = useActionState(signInAction, undefined);
   const [showPassword, setShowPassword] = useState(false);
 
   return (
     <form action={action}>
+      {redirectTo && (
+        <input type="hidden" name="redirectTo" value={redirectTo} />
+      )}
       <FieldGroup>
         <Field>
           <FormHeading


### PR DESCRIPTION
## Summary
- Fix checkout redirect after sign-up: users now return to checkout instead of account page
- Fix cart drawer auto-opening after successful order: drawer is closed before Stripe redirect

## Changes
- Pass `callbackUrl` through sign-in/sign-up flow for subscription checkout
- Add `redirectTo` support to `signInPublic` and `signUpPublic` auth actions
- Close cart drawer before redirecting to Stripe checkout
- Close cart drawer on checkout success page after clearing cart
- Add `/checkout/resume` page that opens cart drawer after authentication

## Test plan
- [ ] Add subscription to cart as guest, click checkout
- [ ] Verify redirect to sign-in with `callbackUrl=/checkout/resume`
- [ ] Create account, verify redirect to home with cart drawer open
- [ ] Complete checkout, verify cart drawer doesn't auto-open on success page
- [ ] Sign-in link from sign-up preserves callbackUrl
- [ ] OAuth buttons use correct callbackUrl