### PR TITLE
feat: add curated Unsplash placeholder images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,14 @@ GEMINI_API_KEY="your_gemini_api_key_here"
 GROK_API_KEY="your_grok_api_key_here"
 
 # ==============================================
+# UNSPLASH (Placeholder Images)
+# ==============================================
+# Get your API key from: https://unsplash.com/developers
+# Used for fetching placeholder image URLs (dev-tools script only)
+# This is only needed to run: npx tsx dev-tools/fetch-unsplash-images.ts
+UNSPLASH_ACCESS_KEY="your_unsplash_access_key_here"
+
+# ==============================================
 # STRIPE (Payment Processing)
 # ==============================================
 # Test keys from: https://dashboard.stripe.com/test/apikeys

--- a/app/(site)/_components/cart/AddOnCard.tsx
+++ b/app/(site)/_components/cart/AddOnCard.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { formatPrice } from "@/lib/utils";
+import { getPlaceholderImage } from "@/lib/placeholder-images";
 
 interface AddOnCardProps {
   addOn: {
@@ -50,9 +51,9 @@ export function AddOnCard({
   const hasDiscount =
     discountedPriceInCents && discountedPriceInCents < regularPrice;
 
+  // Add-ons are typically merch products, use "culture" category for coffee lifestyle images
   const imageUrl =
-    addOn.imageUrl ||
-    "https://placehold.co/300x200/CCCCCC/FFFFFF.png?text=No+Image";
+    addOn.imageUrl || getPlaceholderImage(addOn.product.name, 400, "culture");
 
   return (
     <div className="flex flex-row gap-4 w-full">

--- a/app/(site)/_components/product/ProductCard.tsx
+++ b/app/(site)/_components/product/ProductCard.tsx
@@ -6,6 +6,7 @@ import clsx from "clsx";
 import { ProductType } from "@prisma/client";
 import { ProductCardProps } from "@/lib/types"; // lib path stays the same
 import { useCartStore } from "@/lib/store/cart-store";
+import { getPlaceholderImage } from "@/lib/placeholder-images";
 
 // Import shadcn/ui components
 import {
@@ -41,12 +42,13 @@ export default function ProductCard({
     ? (oneTimePrice.priceInCents / 100).toFixed(2)
     : "N/A";
 
-  // Note: Image URLs are fixed to return .png for optimization
+  // Use product name as seed for consistent placeholder image selection
+  // Merch products use culture images (cups, equipment), coffee products use bean images
+  const placeholderCategory = product.type === ProductType.MERCH ? "culture" : "beans";
   const displayImage =
-    product.images[0]?.url ||
-    "https://placehold.co/600x400/CCCCCC/FFFFFF.png?text=Image+Not+Found";
+    product.images[0]?.url || getPlaceholderImage(product.name, 800, placeholderCategory);
   const altText =
-    product.images[0]?.altText || `A bag of ${product.name} coffee`;
+    product.images[0]?.altText || (product.type === ProductType.MERCH ? product.name : `A bag of ${product.name} coffee`);
 
   // Canonical product URL with optional ?from= to preserve navigation context
   const productUrl = categorySlug

--- a/app/(site)/products/[slug]/ProductClientPage.tsx
+++ b/app/(site)/products/[slug]/ProductClientPage.tsx
@@ -30,6 +30,7 @@ import { useCartStore, type CartItem } from "@/lib/store/cart-store";
 import { useActivityTracking } from "@/hooks/useActivityTracking";
 import { AddOnItem } from "./actions";
 import { Badge } from "@/components/ui/badge";
+import { getPlaceholderImage } from "@/lib/placeholder-images";
 import { ProductSelectionsSection } from "@/app/(site)/_components/product/ProductSelectionsSection";
 
 interface ProductClientPageProps {
@@ -172,11 +173,12 @@ export default function ProductClientPage({
       item.purchaseType === "SUBSCRIPTION"
   );
 
+  // Merch products use culture images (cups, equipment), coffee products use bean images
+  const placeholderCategory = product.type === ProductType.MERCH ? "culture" : "beans";
   const displayImage =
-    product.images[0]?.url ||
-    "https://placehold.co/600x400/CCCCCC/FFFFFF.png?text=Image+Not+Found";
+    product.images[0]?.url || getPlaceholderImage(product.name, 800, placeholderCategory);
   const altText =
-    product.images[0]?.altText || `A bag of ${product.name} coffee`;
+    product.images[0]?.altText || (product.type === ProductType.MERCH ? product.name : `A bag of ${product.name} coffee`);
   const galleryImages =
     product.images.length > 0
       ? product.images.map((img) => ({ url: img.url, alt: img.altText }))
@@ -290,9 +292,10 @@ export default function ProductClientPage({
       purchaseOptionId: addOn.variant.purchaseOptions[0].id,
       purchaseType: "ONE_TIME",
       priceInCents: addOn.discountedPriceInCents,
+      // Add-ons are merch products, use "culture" for coffee lifestyle images
       imageUrl:
         addOn.imageUrl ||
-        "https://placehold.co/300x300/CCCCCC/FFFFFF.png?text=No+Image",
+        getPlaceholderImage(addOn.product.name, 400, "culture"),
       quantity: 1,
     });
 

--- a/app/(site)/products/[slug]/actions.ts
+++ b/app/(site)/products/[slug]/actions.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { getWeightUnit } from "@/lib/config/app-settings";
 import { fromGrams, roundToInt, WeightUnitOption } from "@/lib/weight-unit";
 import { WeightUnit } from "@prisma/client";
+import { getPlaceholderImage } from "@/lib/placeholder-images";
 
 export interface AddOnItem {
   product: {
@@ -140,9 +141,10 @@ export async function getProductAddOns(
         },
         discountedPriceInCents:
           addOn.discountedPriceInCents ?? purchaseOption.priceInCents,
+        // Add-ons are merch products, use "culture" category for coffee lifestyle images
         imageUrl:
           addOn.addOnProduct.images[0]?.url ||
-          "https://placehold.co/300x300/CCCCCC/FFFFFF.png?text=No+Image",
+          getPlaceholderImage(addOn.addOnProduct.name, 400, "culture"),
         categorySlug: addOn.addOnProduct.categories[0]?.category.slug || "shop",
       };
     });

--- a/app/admin/products/product-form-client/ProductFormClient.tsx
+++ b/app/admin/products/product-form-client/ProductFormClient.tsx
@@ -244,7 +244,7 @@ export default function ProductFormClient({
 
       const payload = {
         ...data,
-        images: cleanImages.length > 0 ? cleanImages : undefined,
+        images: cleanImages,
         origin: isCoffee ? toList(data.origin) : [],
         tastingNotes: isCoffee ? toList(data.tastingNotes) : [],
         variety: isCoffee ? data.variety : "",

--- a/app/api/admin/products/[id]/route.ts
+++ b/app/api/admin/products/[id]/route.ts
@@ -136,22 +136,24 @@ export async function PUT(
         },
       });
 
-      // 2. Update Images (replace all images if provided)
-      if (images && images.length > 0) {
+      // 2. Update Images (replace all images if provided, including empty array to delete all)
+      if (images !== undefined) {
         // Delete existing images
         await tx.productImage.deleteMany({
           where: { productId: id },
         });
 
-        // Create new images
-        await tx.productImage.createMany({
-          data: images.map((img, index) => ({
-            productId: id,
-            url: img.url,
-            altText: img.alt || name,
-            order: index,
-          })),
-        });
+        // Create new images if any
+        if (images.length > 0) {
+          await tx.productImage.createMany({
+            data: images.map((img, index) => ({
+              productId: id,
+              url: img.url,
+              altText: img.alt || name,
+              order: index,
+            })),
+          });
+        }
       }
 
       // 3. Update categories

--- a/app/api/cart/addons/route.ts
+++ b/app/api/cart/addons/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { getPlaceholderImage } from "@/lib/placeholder-images";
 
 export async function POST(request: Request) {
   try {
@@ -91,9 +92,10 @@ export async function POST(request: Request) {
             name: addOn.addOnProduct.name,
             slug: addOn.addOnProduct.slug,
             description: addOn.addOnProduct.description,
+            // Add-ons are merch products, use "culture" for coffee lifestyle images
             imageUrl:
               addOn.addOnProduct.images[0]?.url ||
-              "https://placehold.co/300x300/CCCCCC/FFFFFF.png?text=No+Image",
+              getPlaceholderImage(addOn.addOnProduct.name, 400, "culture"),
             categorySlug:
               addOn.addOnProduct.categories[0]?.category.slug || "shop",
           },

--- a/docs/features/placeholder-images/README.md
+++ b/docs/features/placeholder-images/README.md
@@ -1,0 +1,92 @@
+# Placeholder Images
+
+Curated Unsplash images for products without uploaded images.
+
+## How It Works
+
+- Images are assigned at **runtime** based on product name
+- No database storage - lookup tables in `lib/placeholder-images.ts`
+- Each product gets a unique, hand-curated image
+
+## Image Categories
+
+| Category | Used For | Source |
+|----------|----------|--------|
+| `beans` | Coffee products | Raw coffee bean photos |
+| `culture` | Merch products | Coffee cups, equipment, lifestyle |
+| `cafe` | CMS pages (About, FAQ, Cafe) | Cafe interiors |
+
+## Updating Production
+
+**No database changes required.** Placeholder images are generated from code, not stored in the database.
+
+To update production:
+
+1. Merge changes to `main`
+2. Vercel auto-deploys
+3. New images appear immediately
+
+## Adding/Changing Images
+
+### Finding Unsplash Photos
+
+1. Browse [Unsplash](https://unsplash.com) for photos
+2. **Avoid Unsplash+ (premium)** photos - they use a different CDN
+3. Copy the photo slug from the URL (e.g., `9GnJ6YnkHp4` from `/photos/brown-coffee-beans-9GnJ6YnkHp4`)
+
+### Getting the Photo ID
+
+Use the Unsplash API to convert slug to photo ID:
+
+```bash
+curl -s "https://api.unsplash.com/photos/SLUG" \
+  -H "Authorization: Client-ID $UNSPLASH_ACCESS_KEY" \
+  | grep -o '"raw":"[^"]*"' | head -1
+```
+
+Extract the `photo-XXXXX` portion from the raw URL.
+
+### Verifying the Photo ID
+
+```bash
+curl -sI "https://images.unsplash.com/photo-XXXXX?w=50" | head -1
+# Should return: HTTP/1.1 200 OK
+```
+
+If you get 404, the photo may be:
+
+- Premium (Unsplash+) - use a different photo
+- Invalid ID - re-check the conversion
+
+### Updating the Lookup Table
+
+Edit `lib/placeholder-images.ts`:
+
+```typescript
+const COFFEE_PRODUCT_IMAGES: Record<string, string> = {
+  "Product Name": "photo-XXXXX-XXXXX",  // slug
+  // ...
+};
+```
+
+## URL Format
+
+```
+https://images.unsplash.com/{photo-id}?w={width}&h={height}&fit=crop&crop=entropy
+```
+
+## Unsplash+ (Premium) Photos
+
+Premium photos use a different domain and won't work with our URL pattern:
+
+- Regular: `https://images.unsplash.com/photo-XXXXX`
+- Premium: `https://plus.unsplash.com/premium_photo-XXXXX`
+
+**Always use free photos** to avoid CDN issues.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `lib/placeholder-images.ts` | Lookup tables and URL generation |
+| `.env.local` | `UNSPLASH_ACCESS_KEY` for API access |

--- a/lib/placeholder-images.ts
+++ b/lib/placeholder-images.ts
@@ -1,0 +1,196 @@
+/**
+ * Curated placeholder images using Unsplash
+ *
+ * Uses lookup tables to guarantee unique image assignment per product.
+ * All images are free to use under the Unsplash License.
+ */
+
+/**
+ * Coffee product name -> specific photo ID mapping
+ * Ensures each coffee product gets a unique image
+ */
+const COFFEE_PRODUCT_IMAGES: Record<string, string> = {
+  // Hand-curated from Unsplash collections - verified raw coffee beans only
+  "Midnight Espresso Blend": "photo-1541916194682-cbf2a0371d3d",  // AF4y8fsQkYQ
+  "Italian Roast": "photo-1520516472218-ed48f8ff3271",            // cbdPqbvNkJ8
+  "Sumatra Mandheling": "photo-1475333154578-0538252118ad",       // XpyD7z6AP4g
+  "French Roast": "photo-1525445842399-d8a6bec24be2",             // 68KjM0kfsVo
+  "Papua New Guinea Sigri Estate": "photo-1504538292323-20e79775474d", // QLkjP_W4d7c
+  "Decaf Colombian": "photo-1515471897120-85416077e011",          // PX1IrPsimHE
+  "Breakfast Blend": "photo-1555526533-25d5a4058d82",             // Bj8Fu4xfaQE
+  "Colombian Supremo": "photo-1527619675211-f7283b39fae4",        // dMl65P1Rgs4
+  "Guatemalan Antigua": "photo-1555118076-8248a6da45d6",          // ks5vYUoefhw
+  "Costa Rica Tarrazú": "photo-1518164483967-d6d558aa44df",       // P2X_zf9o094
+  "Brazil Santos": "photo-1524350876685-274059332603",            // obV_LM0KjxY
+  "Honduras Marcala": "photo-1490890870453-549b7f8d3bb5",         // DMpYt_kfqL4
+  "Mexican Altura": "photo-1587734195503-904fca47e0e9",           // lGl3spVIU0g
+  "Peruvian Organic": "photo-1630595478874-eefd5083f210",         // 3pgSRBU-uKk
+  "Nicaraguan SHG": "photo-1501492673258-2bcfc17241fd",           // 9rmnzkmydSY
+  "El Salvador Pacamara": "photo-1594934103593-d2615ce26ae2",     // XWQ15ixxRjE
+  "Ethiopian Yirgacheffe": "photo-1523247452367-d68f888d4b80",    // lgS6EZq1HGU
+  "Kenya AA": "photo-1522273777983-a0d924529b83",                 // MSlZyJwYJlw
+  "Ethiopian Sidamo": "photo-1587403206457-be9f1e357e55",         // 9GnJ6YnkHp4
+  "Rwanda Bourbon": "photo-1770081485131-d978211245aa",           // 1F7dL8tLHKs
+  "Burundi Kayanza": "photo-1612487458970-564127ec86f5",          // PDipEilB0b8
+  "Tanzania Peaberry": "photo-1690983324515-d0faf73de6ca",        // kfnLPPR0FzI
+  "Panama Geisha": "photo-1605116188332-c83cf910031c",            // VylPA_mm7AE
+  "Colombia Geisha": "photo-1602486742905-7c2fedd026ea",          // 0TSguCjilJQ
+  "Costa Rica Honey Process": "photo-1561480337-6645d95535b9",    // 3q3f1uDQk94
+  "Guatemala Huehuetenango": "photo-1611410255266-a1eaa3768021",  // r0Y7IHdVsw4
+  "Bolivia Caranavi": "photo-1671363927071-e0c24ed8f2c4",         // 9De7KR3irTg
+  "Yemen Mocha": "photo-1611787007489-9a19db1c9d04",              // bUdaT1WLScI
+  "India Monsooned Malabar": "photo-1717380046868-3deeab8191eb",  // fUH72rlijH4
+  "Hawaiian Kona": "photo-1671038988310-083c9d0942b1",            // 3RHrtBWKt0c
+};
+
+/**
+ * Merch product name -> specific photo ID mapping
+ * Ensures each merch product gets a unique image
+ */
+const MERCH_PRODUCT_IMAGES: Record<string, string> = {
+  "Heritage Diner Mug": "photo-1619970291267-0e61f239c59e",
+  "Everyday Camp Tumbler": "photo-1619970291696-81b56c59804b",
+  "Cold Brew Bottle": "photo-1619970291284-56d9b4de6472",
+  "Origami Air Dripper": "photo-1629991848910-2ab88d9cc52f",
+  "Origami Cone Filters (100ct)": "photo-1553578615-ee00f2db2c5c",
+  "Fellow Stagg EKG Kettle": "photo-1661761220121-75af77b126a0",
+  "Timemore Black Mirror Scale": "photo-1595984288728-7608c67f6e76",
+  "Airscape Coffee Canister": "photo-1630783397198-c64d9e87fb65",
+  "Cupping Spoon": "photo-1630783397237-3dc5caf9ded9",
+  "Roastery Script Tee": "photo-1646802435194-fc68ec690e88",
+  "Barista Towel 2-Pack": "photo-1763473821509-9a383b480844",
+  "Enamel Pin Set": "photo-1559001724-fbad036dbc9e",
+};
+
+/**
+ * Fallback photo IDs for products not in lookup tables
+ */
+const FALLBACK_BEAN_PHOTOS = [
+  "photo-1541916194682-cbf2a0371d3d",
+  "photo-1520516472218-ed48f8ff3271",
+  "photo-1555526533-25d5a4058d82",
+  "photo-1524350876685-274059332603",
+  "photo-1555118076-8248a6da45d6",
+];
+
+const FALLBACK_CULTURE_PHOTOS = [
+  "photo-1619970291267-0e61f239c59e",
+  "photo-1629991848910-2ab88d9cc52f",
+  "photo-1553578615-ee00f2db2c5c",
+  "photo-1661761220121-75af77b126a0",
+  "photo-1595984288728-7608c67f6e76",
+];
+
+/**
+ * Cafe interior photo IDs for CMS pages
+ */
+const CAFE_PHOTO_IDS = [
+  "photo-1544457070-4cd773b4d71e",
+  "photo-1504963642567-227b3bbd79de",
+  "photo-1576666045809-e4587d488518",
+  "photo-1667020080976-9dfee090458e",
+  "photo-1714328101501-3594de6cb80f",
+  "photo-1751076605132-b4172bb8c6a4",
+  "photo-1678233517592-657a186396b8",
+  "photo-1678233517591-1ca561b9fe45",
+  "photo-1521017432531-fbd92d768814",
+  "photo-1554118811-1e0d58224f24",
+  "photo-1559925393-8be0ec4767c8",
+  "photo-1501339847302-ac426a4a7cbb",
+  "photo-1445116572660-236099ec97a0",
+  "photo-1453614512568-c4024d13c247",
+  "photo-1559329007-40df8a9345d8",
+];
+
+type ImageCategory = "beans" | "cafe" | "culture";
+
+/**
+ * Simple hash function for fallback/banner selection
+ */
+function hashString(str: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.abs(hash >>> 0);
+}
+
+/**
+ * Get a consistent placeholder image URL based on a seed string.
+ * Uses lookup tables for known products to guarantee uniqueness.
+ *
+ * @param seed - Product name or identifier
+ * @param size - Image size for square crop (default: 800)
+ * @param category - "beans" for coffee, "culture" for merch, "cafe" for CMS
+ * @returns Unsplash image URL
+ */
+export function getPlaceholderImage(
+  seed: string = "",
+  size: number = 800,
+  category: ImageCategory = "beans"
+): string {
+  let photoId: string;
+
+  if (category === "beans") {
+    // Check lookup table first
+    photoId = COFFEE_PRODUCT_IMAGES[seed];
+    if (!photoId) {
+      // Fallback for unknown products
+      const index = hashString(seed) % FALLBACK_BEAN_PHOTOS.length;
+      photoId = FALLBACK_BEAN_PHOTOS[index];
+    }
+  } else if (category === "culture") {
+    // Check lookup table first
+    photoId = MERCH_PRODUCT_IMAGES[seed];
+    if (!photoId) {
+      // Fallback for unknown products
+      const index = hashString(seed) % FALLBACK_CULTURE_PHOTOS.length;
+      photoId = FALLBACK_CULTURE_PHOTOS[index];
+    }
+  } else {
+    // cafe category - use hash for banners
+    const index = hashString(seed) % CAFE_PHOTO_IDS.length;
+    photoId = CAFE_PHOTO_IDS[index];
+  }
+
+  return `https://images.unsplash.com/${photoId}?w=${size}&h=${size}&fit=crop&crop=entropy`;
+}
+
+/**
+ * Get a wide/banner placeholder image (for hero sections, headers)
+ *
+ * @param seed - A string to use for consistent image selection
+ * @param width - Image width (default: 1920)
+ * @param height - Image height (default: 800)
+ * @param category - Image category
+ * @returns Unsplash image URL
+ */
+export function getPlaceholderBanner(
+  seed: string = "",
+  width: number = 1920,
+  height: number = 800,
+  _category: ImageCategory = "cafe"
+): string {
+  // Banners always use cafe images
+  const photoIds = CAFE_PHOTO_IDS;
+  const index = hashString(seed) % photoIds.length;
+  const photoId = photoIds[index];
+
+  return `https://images.unsplash.com/${photoId}?w=${width}&h=${height}&fit=crop&crop=entropy`;
+}
+
+/**
+ * Default placeholder for product images (800x800)
+ */
+export const DEFAULT_PRODUCT_PLACEHOLDER = getPlaceholderImage("default");
+
+/**
+ * Default placeholder for add-on/thumbnail images (400x400)
+ */
+export const DEFAULT_ADDON_PLACEHOLDER = getPlaceholderImage("addon", 400, "culture");
+
+/**
+ * Default placeholder for CMS page banners
+ */
+export const DEFAULT_BANNER_PLACEHOLDER = getPlaceholderBanner("banner");

--- a/next.config.ts
+++ b/next.config.ts
@@ -44,6 +44,12 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: "https",
+        hostname: "images.unsplash.com",
+        port: "",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
         hostname: "lh3.googleusercontent.com",
         port: "",
         pathname: "/**",

--- a/prisma/seed/cms-pages.ts
+++ b/prisma/seed/cms-pages.ts
@@ -1,4 +1,8 @@
 import { PrismaClient } from "@prisma/client";
+import {
+  getPlaceholderImage,
+  getPlaceholderBanner,
+} from "../../lib/placeholder-images";
 
 export async function seedAboutPage(prisma: PrismaClient) {
   const aboutPage = await prisma.page.upsert({
@@ -46,7 +50,7 @@ export async function seedAboutPage(prisma: PrismaClient) {
       isDeleted: false,
       content: {
         heading: "Our Story",
-        imageUrl: "https://placehold.co/1920x800/8B4513/FFF?text=Our+Story",
+        imageUrl: getPlaceholderBanner("about-hero"),
         imageAlt: "Artisan Roast coffee roastery",
         caption: "Crafting exceptional coffee experiences since 2015",
       },
@@ -156,23 +160,23 @@ export async function seedCafePage(
         content: {
           slides: [
             {
-              url: "https://placehold.co/800x600/8B4513/FFF?text=Cozy+Interior",
+              url: getPlaceholderImage("cozy-interior", 800, "cafe"),
               alt: "Cozy interior seating",
             },
             {
-              url: "https://placehold.co/800x600/654321/FFF?text=Espresso+Bar",
+              url: getPlaceholderImage("espresso-bar", 800, "cafe"),
               alt: "Espresso bar",
             },
             {
-              url: "https://placehold.co/800x600/A0522D/FFF?text=Outdoor+Patio",
+              url: getPlaceholderImage("outdoor-patio", 800, "cafe"),
               alt: "Outdoor patio",
             },
             {
-              url: "https://placehold.co/800x600/8B4513/FFF?text=Brewing+Station",
+              url: getPlaceholderImage("brewing-station", 800, "cafe"),
               alt: "Brewing station",
             },
             {
-              url: "https://placehold.co/800x600/654321/FFF?text=Lounge+Area",
+              url: getPlaceholderImage("lounge-area", 800, "cafe"),
               alt: "Lounge area",
             },
           ],
@@ -202,15 +206,15 @@ export async function seedCafePage(
           ],
           images: [
             {
-              url: "https://placehold.co/600x400/8B4513/FFF?text=Cafe+Exterior",
+              url: getPlaceholderImage("cafe-exterior", 600, "cafe"),
               alt: "Café exterior",
             },
             {
-              url: "https://placehold.co/600x400/654321/FFF?text=Interior+Seating",
+              url: getPlaceholderImage("interior-seating", 600, "cafe"),
               alt: "Interior seating",
             },
             {
-              url: "https://placehold.co/600x400/A0522D/FFF?text=Espresso+Bar",
+              url: getPlaceholderImage("espresso-bar-detail", 600, "cafe"),
               alt: "Espresso bar",
             },
           ],
@@ -231,7 +235,7 @@ export async function seedCafePage(
       content: {
         slides: [
           {
-            url: "https://placehold.co/800x600/654321/FFF?text=Market+Street",
+            url: getPlaceholderImage("market-street", 800, "cafe"),
             alt: "Market Street location",
             title: "Market Street",
             description:
@@ -239,7 +243,7 @@ export async function seedCafePage(
             locationBlockId: "temp-1",
           },
           {
-            url: "https://placehold.co/800x600/8B4513/FFF?text=Pearl+Street",
+            url: getPlaceholderImage("pearl-street", 800, "cafe"),
             alt: "Pearl Street location",
             title: "Pearl Street",
             description:
@@ -247,7 +251,7 @@ export async function seedCafePage(
             locationBlockId: "temp-2",
           },
           {
-            url: "https://placehold.co/800x600/A0522D/FFF?text=Hawthorne+Blvd",
+            url: getPlaceholderImage("hawthorne-blvd", 800, "cafe"),
             alt: "Hawthorne Boulevard cafe",
             title: "Hawthorne Boulevard",
             description:
@@ -276,15 +280,15 @@ export async function seedCafePage(
       ],
       images: [
         {
-          url: "https://placehold.co/600x400/654321/FFF?text=Market+St+Exterior",
+          url: getPlaceholderImage("market-exterior", 600, "cafe"),
           alt: "Market Street exterior",
         },
         {
-          url: "https://placehold.co/600x400/8B4513/FFF?text=Market+St+Interior",
+          url: getPlaceholderImage("market-interior", 600, "cafe"),
           alt: "Interior seating",
         },
         {
-          url: "https://placehold.co/600x400/A0522D/FFF?text=Market+St+Bar",
+          url: getPlaceholderImage("market-bar", 600, "cafe"),
           alt: "Espresso bar",
         },
       ],
@@ -295,22 +299,22 @@ export async function seedCafePage(
       phone: "(303) 555-0198",
       mapsUrl: "https://maps.google.com/?q=1523+Pearl+St+Boulder+CO+80302",
       description:
-        "Discover a cozy retreat on Boulder’s historic Pearl Street. Known for our delicious house-baked pastries and welcoming neighborhood vibe, this café is the perfect place to warm up. Enjoy a handcrafted latte on our patio or relax inside with friends.",
+        "Discover a cozy retreat on Boulder's historic Pearl Street. Known for our delicious house-baked pastries and welcoming neighborhood vibe, this café is the perfect place to warm up. Enjoy a handcrafted latte on our patio or relax inside with friends.",
       schedule: [
         { day: "Monday - Friday", hours: "6AM - 6PM" },
         { day: "Saturday - Sunday", hours: "7AM - 5PM" },
       ],
       images: [
         {
-          url: "https://placehold.co/600x400/8B4513/FFF?text=Pearl+St+Storefront",
+          url: getPlaceholderImage("pearl-storefront", 600, "cafe"),
           alt: "Pearl Street storefront",
         },
         {
-          url: "https://placehold.co/600x400/654321/FFF?text=Pearl+St+Pastries",
+          url: getPlaceholderImage("pearl-pastries", 600, "cafe"),
           alt: "Pastry display",
         },
         {
-          url: "https://placehold.co/600x400/A0522D/FFF?text=Pearl+St+Patio",
+          url: getPlaceholderImage("pearl-patio", 600, "cafe"),
           alt: "Outdoor patio",
         },
       ],
@@ -322,7 +326,7 @@ export async function seedCafePage(
       mapsUrl:
         "https://maps.google.com/?q=812+SE+Hawthorne+Blvd+Portland+OR+97214",
       description:
-        "Immerse yourself in Portland’s creative spirit at our Hawthorne Boulevard café. With spacious seating and a relaxed atmosphere, it is the ultimate destination for students and remote workers. Settle in for a productive afternoon or a casual meetup in this community hub.",
+        "Immerse yourself in Portland's creative spirit at our Hawthorne Boulevard café. With spacious seating and a relaxed atmosphere, it is the ultimate destination for students and remote workers. Settle in for a productive afternoon or a casual meetup in this community hub.",
       schedule: [
         { day: "Monday - Thursday", hours: "7AM - 8PM" },
         { day: "Friday", hours: "7AM - 10PM" },
@@ -330,15 +334,15 @@ export async function seedCafePage(
       ],
       images: [
         {
-          url: "https://placehold.co/600x400/A0522D/FFF?text=Hawthorne+Entrance",
+          url: getPlaceholderImage("hawthorne-entrance", 600, "cafe"),
           alt: "Hawthorne Boulevard entrance",
         },
         {
-          url: "https://placehold.co/600x400/8B4513/FFF?text=Hawthorne+Seating",
+          url: getPlaceholderImage("hawthorne-seating", 600, "cafe"),
           alt: "Comfortable seating",
         },
         {
-          url: "https://placehold.co/600x400/654321/FFF?text=Hawthorne+Bar",
+          url: getPlaceholderImage("hawthorne-bar", 600, "cafe"),
           alt: "Coffee and tea bar",
         },
       ],
@@ -429,7 +433,7 @@ export async function seedFaqPage(prisma: PrismaClient) {
       isDeleted: false,
       content: {
         heading: "Frequently Asked Questions",
-        imageUrl: "https://placehold.co/1920x800/654321/FFF?text=FAQ",
+        imageUrl: getPlaceholderBanner("faq-hero"),
         imageAlt: "Coffee beans background",
         caption:
           "Find answers to common questions about our coffee, orders, shipping, and more.",

--- a/prisma/seed/merch.ts
+++ b/prisma/seed/merch.ts
@@ -275,10 +275,8 @@ export async function seedMerch(prisma: PrismaClient) {
         featuredOrder: item.featuredOrder,
         type: ProductType.MERCH,
         roastLevel: RoastLevel.MEDIUM,
-        images: {
-          deleteMany: {},
-          create: [{ url: item.imageUrl, altText: item.name, order: 1 }],
-        },
+        // Delete existing images so placeholders are used
+        images: { deleteMany: {} },
         categories: { deleteMany: {}, create: [primaryCategory] },
         // Do not delete/recreate variants on update to avoid breaking
         // existing OrderItem.purchaseOptionId foreign keys.
@@ -294,9 +292,6 @@ export async function seedMerch(prisma: PrismaClient) {
         featuredOrder: item.featuredOrder,
         type: ProductType.MERCH,
         roastLevel: RoastLevel.MEDIUM,
-        images: {
-          create: [{ url: item.imageUrl, altText: item.name, order: 1 }],
-        },
         categories: { create: [primaryCategory] },
         variants: { create: variants },
       },

--- a/prisma/seed/products.ts
+++ b/prisma/seed/products.ts
@@ -115,15 +115,6 @@ export async function seedProducts(prisma: PrismaClient) {
         isOrganic: false,
         isFeatured: true,
         featuredOrder: 1,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/1A1110/FFFFFF.png?text=Midnight+Espresso",
-              altText: "Midnight Espresso Blend bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -184,15 +175,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Bittersweet Chocolate", "Roasted Almond", "Smoky"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/2B1810/FFFFFF.png?text=Italian+Roast",
-              altText: "Italian Roast bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -223,15 +205,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Earthy", "Dark Chocolate", "Cedar"],
         isOrganic: true,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/3A2416/FFFFFF.png?text=Sumatra",
-              altText: "Sumatra Mandheling bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -262,15 +235,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Dark Chocolate", "Charred Wood", "Smooth"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/1C1410/FFFFFF.png?text=French+Roast",
-              altText: "French Roast bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -309,15 +273,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Dark Berry", "Cocoa", "Earthy"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/3D2820/FFFFFF.png?text=PNG+Sigri",
-              altText: "Papua New Guinea Sigri bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -348,15 +303,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Milk Chocolate", "Toasted Nuts", "Caramel"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/4A3426/FFFFFF.png?text=Decaf+Colombian",
-              altText: "Decaf Colombian bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -398,15 +344,6 @@ export async function seedProducts(prisma: PrismaClient) {
         isOrganic: false,
         isFeatured: true,
         featuredOrder: 2,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/8B5A3C/FFFFFF.png?text=Breakfast+Blend",
-              altText: "Breakfast Blend bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -467,15 +404,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Caramel", "Cocoa", "Sweet"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/7A5230/FFFFFF.png?text=Colombian",
-              altText: "Colombian Supremo bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -515,15 +443,6 @@ export async function seedProducts(prisma: PrismaClient) {
         isOrganic: true,
         isFeatured: true,
         featuredOrder: 3,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/6B4423/FFFFFF.png?text=Guatemala",
-              altText: "Guatemalan Antigua bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -568,15 +487,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Brown Sugar", "Stone Fruit", "Crisp"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/8A5C3A/FFFFFF.png?text=Costa+Rica",
-              altText: "Costa Rica Tarrazú bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -607,15 +517,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Nutty", "Chocolate", "Low Acidity"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/9B6B47/FFFFFF.png?text=Brazil+Santos",
-              altText: "Brazil Santos bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -654,15 +555,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Toffee", "Red Apple", "Citrus Zest"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/7E5835/FFFFFF.png?text=Honduras",
-              altText: "Honduras Marcala bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -693,15 +585,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Cocoa", "Roasted Nuts", "Spice"],
         isOrganic: true,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/8E6240/FFFFFF.png?text=Mexican+Altura",
-              altText: "Mexican Altura bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -732,15 +615,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Vanilla", "Caramel", "Floral"],
         isOrganic: true,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/8A5E3C/FFFFFF.png?text=Peruvian+Organic",
-              altText: "Peruvian Organic bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -779,15 +653,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Milk Chocolate", "Orange Marmalade", "Creamy"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/7C5638/FFFFFF.png?text=Nicaragua",
-              altText: "Nicaraguan SHG bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -818,15 +683,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Tropical Fruit", "Honey", "Wine-like"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/8D6142/FFFFFF.png?text=El+Salvador",
-              altText: "El Salvador Pacamara bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -860,15 +716,6 @@ export async function seedProducts(prisma: PrismaClient) {
         isOrganic: true,
         isFeatured: true,
         featuredOrder: 4,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/B8956A/FFFFFF.png?text=Yirgacheffe",
-              altText: "Ethiopian Yirgacheffe bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -914,15 +761,6 @@ export async function seedProducts(prisma: PrismaClient) {
         isOrganic: false,
         isFeatured: true,
         featuredOrder: 5,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/A67C52/FFFFFF.png?text=Kenya+AA",
-              altText: "Kenya AA bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -953,15 +791,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Blueberry", "Jasmine", "Dark Chocolate"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/B89968/FFFFFF.png?text=Sidamo",
-              altText: "Ethiopian Sidamo bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -992,15 +821,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Red Fruit", "Caramel", "Floral"],
         isOrganic: true,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/AA7F5A/FFFFFF.png?text=Rwanda",
-              altText: "Rwanda Bourbon bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -1031,15 +851,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Cherry", "Cocoa Nibs", "Tangy"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/A8825E/FFFFFF.png?text=Burundi",
-              altText: "Burundi Kayanza bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -1070,15 +881,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Black Currant", "Citrus", "Winey"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/AF8660/FFFFFF.png?text=Tanzania",
-              altText: "Tanzania Peaberry bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -1109,15 +911,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Jasmine", "Tropical Fruit", "Honey"],
         isOrganic: true,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/C9A676/FFFFFF.png?text=Panama+Geisha",
-              altText: "Panama Geisha bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -1148,15 +941,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Peach", "Lavender", "Brown Sugar"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/BDA279/FFFFFF.png?text=Colombia+Geisha",
-              altText: "Colombia Geisha bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -1187,15 +971,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Apricot", "Honey", "Syrupy"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/B8986E/FFFFFF.png?text=Honey+Process",
-              altText: "Costa Rica Honey Process bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -1226,15 +1001,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Apple", "Almond", "Clean"],
         isOrganic: true,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/B39471/FFFFFF.png?text=Huehuetenango",
-              altText: "Guatemala Huehuetenango bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -1265,15 +1031,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Milk Chocolate", "Orange", "Silky"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/B5906C/FFFFFF.png?text=Bolivia",
-              altText: "Bolivia Caranavi bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -1304,15 +1061,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Dried Fruit", "Chocolate", "Spice"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/C0A078/FFFFFF.png?text=Yemen+Mocha",
-              altText: "Yemen Mocha bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -1343,15 +1091,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Earthy", "Tobacco", "Spice"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/A88C67/FFFFFF.png?text=Monsooned+Malabar",
-              altText: "India Monsooned Malabar bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -1382,15 +1121,6 @@ export async function seedProducts(prisma: PrismaClient) {
         tastingNotes: ["Brown Sugar", "Macadamia Nut", "Clean"],
         isOrganic: false,
         isFeatured: false,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/D4AF7A/FFFFFF.png?text=Hawaiian+Kona",
-              altText: "Hawaiian Kona bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -1424,15 +1154,6 @@ export async function seedProducts(prisma: PrismaClient) {
         isOrganic: false,
         isFeatured: true,
         featuredOrder: 99,
-        images: {
-          create: [
-            {
-              url: "https://placehold.co/600x400/D9B166/0F0B05.png?text=Canvas+Tote",
-              altText: "Artisan Roast canvas tote bag",
-              order: 1,
-            },
-          ],
-        },
         variants: {
           create: [
             {
@@ -1528,10 +1249,8 @@ export async function seedProducts(prisma: PrismaClient) {
           featuredOrder: productInput.featuredOrder,
           type: productType,
           roastLevel,
-          images: {
-            deleteMany: {},
-            create: productInput.images.create,
-          },
+          // Delete existing images so placeholders are used
+          images: { deleteMany: {} },
           categories: {
             deleteMany: {},
             create: newCategories,
@@ -1552,7 +1271,6 @@ export async function seedProducts(prisma: PrismaClient) {
           featuredOrder: productInput.featuredOrder,
           type: productType,
           roastLevel,
-          images: productInput.images,
           variants: productInput.variants,
           categories: {
             create: newCategories,


### PR DESCRIPTION
## Summary

- Add curated Unsplash placeholder images for products without uploaded images
- 30 unique coffee bean photos for coffee products
- 12 coffee culture photos for merch products  
- Cafe interior photos for CMS pages (About, FAQ, Cafe)
- Lookup-table based assignment guarantees unique image per product

## Changes

- `lib/placeholder-images.ts` - New placeholder image utility with lookup tables
- Updated components to use correct image categories (beans/culture/cafe)
- Added `images.unsplash.com` to Next.js image domains
- Simplified seed files (removed hardcoded placeholder URLs)

## Production Update

No database changes required - images are generated at runtime from code. Merging to main will auto-deploy to Vercel.

## Test plan

- [x] Reset and reseed local database
- [x] Verify all 30 coffee products show unique coffee bean images
- [x] Verify merch products show coffee culture images
- [x] Verify CMS pages show cafe interior images