### PR TITLE
fix: fetch git tags on Vercel build for correct version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "node scripts/build-resilient.js",
     "build:no-migrate": "node scripts/build-resilient.js --no-migrate",
-    "vercel-build": "DATABASE_URL=$DIRECT_URL PRISMA_MIGRATE_ADVISORY_LOCK_TIMEOUT=180000 node scripts/build-resilient.js",
+    "vercel-build": "git fetch --tags --depth=1 origin && DATABASE_URL=$DIRECT_URL PRISMA_MIGRATE_ADVISORY_LOCK_TIMEOUT=180000 node scripts/build-resilient.js",
     "postinstall": "prisma generate",
     "prepare": "husky",
     "start": "next start",


### PR DESCRIPTION
Vercel does a shallow clone without git tags. This caused the app version to fall back to package.json (0.80.1) instead of the actual git tag.

Fix: Add `git fetch --tags` before the build command.