### PR TITLE
feat: display app version in admin footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.82.2 - 2026-02-04
+
+### Added
+
+- Display app version in admin footer
+
 ## 0.82.1 - 2026-02-04
 
 ### Added

--- a/app/admin/_components/dashboard/AdminFooter.tsx
+++ b/app/admin/_components/dashboard/AdminFooter.tsx
@@ -22,6 +22,7 @@ const GITHUB_ISSUES_URL = "https://github.com/yuens1002/ecomm-ai-app/issues";
 
 export function AdminFooter({ storeName, socialLinks }: AdminFooterProps) {
   const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const appVersion = process.env.APP_VERSION || "dev";
 
   return (
     <>
@@ -29,9 +30,10 @@ export function AdminFooter({ storeName, socialLinks }: AdminFooterProps) {
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           {/* Desktop Layout: 3 columns */}
           <div className="hidden sm:flex h-16 items-center justify-between">
-            {/* Left: Branding with copyright */}
+            {/* Left: Branding with copyright and version */}
             <div className="text-sm text-muted-foreground">
               © {new Date().getFullYear()} {storeName}
+              <span className="ml-2 text-xs opacity-60">v{appVersion}</span>
             </div>
 
             {/* Center: Links */}
@@ -75,9 +77,10 @@ export function AdminFooter({ storeName, socialLinks }: AdminFooterProps) {
 
           {/* Mobile Layout: Stacked */}
           <div className="sm:hidden py-4 space-y-3">
-            {/* Row 1: Branding with copyright */}
+            {/* Row 1: Branding with copyright and version */}
             <div className="text-sm text-muted-foreground text-center">
               © {new Date().getFullYear()} {storeName}
+              <span className="ml-2 text-xs opacity-60">v{appVersion}</span>
             </div>
 
             {/* Row 2: Links + Social */}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.82.1",
+  "version": "0.82.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Shows the app version (e.g., v0.82.2) in the admin footer next to the copyright.

Includes:
- CHANGELOG update for 0.82.2
- package.json version bump to 0.82.2