### PR TITLE
fix: restore category structure with regional groupings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.82.4 - 2026-02-04
+
+### Fixed
+
+- Restore category structure to use regional groupings instead of individual countries
+- Update product-category mappings to match original structure
+
 ## 0.82.3 - 2026-02-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.82.3",
+  "version": "0.82.4",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Restore category structure from backup (21 categories instead of 44)
- Replace individual country categories with regional groupings (Central America, South America, Africa, Asia, Islands)
- Add flavor profile categories (Nutty & Chocolatey, Fruity & Floral, Spicy & Earthy)
- Add blend type categories (Espresso Blends, Filter/Drip Blends, Cold Brew Blends)
- Update all product-category mappings to match backup
- Add cleanup step to remove old individual country categories on seed

## Test plan
- [x] Seed runs successfully
- [x] Neon DB has 21 categories (validated)
- [x] Neon DB has 42 products (validated)
- [x] Product-category links match backup structure