### PR TITLE
chore: bump version to 0.82.5 for Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.82.4",
+  "version": "0.82.5",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Sync package.json version with git tag v0.82.5 for Vercel build compatibility.