### PR TITLE
feat: add /release skill and enhance release script

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: release
+description: Git release workflow for creating patches and releases with proper versioning
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Bash, Read, Edit, Grep, Glob
+argument-hint: [patch|minor|major] [--github-release]
+---
+
+# Release Workflow Skill
+
+This skill guides you through the proper release workflow for this project, ensuring all versioning artifacts stay in sync.
+
+## Arguments
+
+- `$1` - Version bump type: `patch` (default), `minor`, or `major`
+- `--github-release` - Also create a GitHub Release (triggers upgrade notice in app)
+- `--docs-only` - Skip version changes (for documentation-only PRs)
+
+## Workflow Overview
+
+The release workflow depends on the current git state:
+
+### Scenario A: Changes on a Feature Branch (Pre-PR)
+
+If on a feature branch with uncommitted or committed changes:
+
+1. **Update CHANGELOG.md** with the next version and changes
+2. **Update package.json** with the next version (required for Vercel)
+3. **Commit** the version changes
+4. **Push** and create PR
+5. After PR merges, run `/release` again to create the tag
+
+### Scenario B: On Main Branch After Merge (Tag Creation)
+
+If on main branch with no uncommitted changes:
+
+1. **Verify** package.json matches the version to tag
+2. If not, create a quick PR to sync package.json
+3. **Create git tag** pointing to current HEAD
+4. **Push tag** to origin
+5. Optionally **create GitHub Release** (if `--github-release` specified)
+
+### Scenario C: Docs-Only Changes (No Version Needed)
+
+If `--docs-only` is specified:
+
+1. Skip all version-related steps
+2. Just commit and create PR
+3. CI will skip build for docs-only changes
+
+## Step-by-Step Instructions
+
+### Step 1: Determine Current State
+
+```bash
+# Check current branch
+git rev-parse --abbrev-ref HEAD
+
+# Check for uncommitted changes
+git status --porcelain
+
+# Get latest tag
+git tag -l v* --sort=-version:refname | head -1
+
+# Get package.json version
+grep '"version"' package.json
+```
+
+### Step 2: Calculate Next Version
+
+Based on the bump type ($ARGUMENTS or default to patch):
+
+- **patch**: 0.82.5 → 0.82.6
+- **minor**: 0.82.5 → 0.83.0
+- **major**: 0.82.5 → 1.0.0
+
+### Step 3: Pre-PR Checklist (if on feature branch)
+
+Before creating the PR, ensure:
+
+1. [ ] CHANGELOG.md updated with new version section
+2. [ ] package.json version updated to match
+3. [ ] Changes committed with conventional commit message
+4. [ ] Branch pushed to origin
+
+### Step 4: Create Tag (if on main after merge)
+
+```bash
+# Run the release script
+npm run release:patch -- -y --push --sync-package
+
+# Or for minor with GitHub release
+npm run release:minor -- -y --push --sync-package --github-release
+```
+
+### Step 5: Verify Release
+
+After release:
+
+1. Check GitHub for new tag: `https://github.com/yuens1002/ecomm-ai-app/tags`
+2. Verify Vercel deployment triggered
+3. If GitHub Release created, check upgrade notice in app
+
+## Common Commands
+
+```bash
+# Quick patch (most common)
+npm run release:patch -- -y --push --sync-package
+
+# Minor release with announcement
+npm run release:minor -- -y --push --sync-package --github-release
+
+# Check what would be released
+npm run release:patch
+```
+
+## Important Notes
+
+- **Vercel requires package.json** to match the tag version (git tags unavailable in build)
+- **Branch protection** prevents pushing directly to main
+- **GitHub Releases** trigger the upgrade notice banner in the app
+- **Docs-only PRs** (only .md files) automatically skip CI build
+
+## Troubleshooting
+
+### Package.json out of sync after merge
+
+The release script will detect this and offer to create a sync PR:
+
+```bash
+npm run release:patch -- --sync-package
+```
+
+### CI failing on version PR
+
+Wait for checks or use admin merge if urgent:
+
+```bash
+gh pr merge --admin --squash --delete-branch
+```
+
+### Need to undo a tag
+
+```bash
+git tag -d v0.82.6
+git push origin :refs/tags/v0.82.6
+```

--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,6 @@ next-env.d.ts
 # Uploaded images (keep folder structure, ignore contents)
 /public/images/*
 !/public/images/.gitkeep
-.claude/
+# Claude Code - ignore local settings, allow shared skills
+.claude/*
+!.claude/skills/

--- a/claude.md
+++ b/claude.md
@@ -224,14 +224,22 @@ This saves CI time and resources for docs-only PRs.
 
 #### Release Flow
 
+Use the `/release` skill (recommended) or follow manual steps:
+
+```bash
+/release patch              # Skill guides you through workflow
+# OR manually:
+npm run release:patch -- -y --push --sync-package
+```
+
 ```
 1. In feature PR: Update CHANGELOG.md AND package.json version
 2. Merge PR to main
-3. Run: npm run release:patch -- -y --push
+3. Run: npm run release:patch -- -y --push --sync-package
 4. Done!
 ```
 
-**Important:** Update both CHANGELOG.md AND package.json IN your feature PR before merging. Branch protection prevents pushing directly to main after merge. Vercel needs package.json version because git tags aren't available in its build environment.
+**Important:** Update both CHANGELOG.md AND package.json IN your feature PR before merging. If you forget, the `--sync-package` flag will create a PR to sync package.json before tagging. Vercel needs package.json version because git tags aren't available in its build environment.
 
 #### Changelog Updates
 
@@ -271,6 +279,7 @@ npm run release:minor -- -y --push --github-release
 
 - `--yes, -y` - Skip prompts
 - `--push` - Push tag to origin
+- `--sync-package` - Sync package.json version (creates PR if on main)
 - `--github-release` - Create GitHub Release (triggers upgrade notice)
 - `--message, -m` - Tag annotation message
 
@@ -328,10 +337,14 @@ When using `--github-release`, the script **automatically extracts** notes from 
 
 ```bash
 # Standard release (no user notification)
-npm run release:patch -- -y --push
+npm run release:patch -- -y --push --sync-package
 
 # User-facing release (shows upgrade notice)
-npm run release:minor -- -y --push --github-release
+npm run release:minor -- -y --push --sync-package --github-release
+
+# Or use the skill
+/release patch
+/release minor --github-release
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add `--sync-package` flag to release script to handle package.json sync
- Release script now creates a PR to update package.json when on main branch
- Add `/release` skill for guided release workflow
- Update CLAUDE.md with new workflow documentation
- Allow `.claude/skills/` in gitignore for shared team skills

## Changes

### Release Script (`scripts/release.ts`)
- New `--sync-package` flag
- `syncPackageJson()` function that:
  - Detects if on main (creates PR) or feature branch (updates locally)
  - Handles the full PR workflow: create branch, commit, push, create PR, wait for CI, merge

### `/release` Skill (`.claude/skills/release/SKILL.md`)
- Guides through proper release workflow
- Handles three scenarios:
  1. Pre-PR on feature branch
  2. Post-merge tag creation on main
  3. Docs-only changes
- Includes troubleshooting tips

### Documentation
- Updated CLAUDE.md with new `--sync-package` flag
- Added `/release` skill usage examples

## Test plan
- [ ] Test `npm run release:patch -- --sync-package` when package.json is out of sync
- [ ] Verify `/release` skill appears in Claude Code autocomplete
- [ ] Test release workflow end-to-end