### PR TITLE
chore: add nul to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ next-env.d.ts
 # Claude Code - ignore local settings, allow shared skills
 .claude/*
 !.claude/skills/
+nul


### PR DESCRIPTION
Prevents Windows nul artifact from being tracked.