### PR TITLE
fix: polish cart drawer UX and button group focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.83.1 - 2026-02-05
+
+### Changed
+
+- Widen shopping cart drawer to 500px on desktop
+- Rearrange cart item controls: quantity stepper + price on one line
+- Cart quantity stepper uses ButtonGroup with outline buttons for proper focus rings
+- Delivery method uses choice card pattern on desktop, compact inline on mobile
+- "Checkout Now" button state renamed to "View Cart" to match actual behavior
+- "Delivery Schedule" label shortened to "Schedule" on product page
+- Add to Cart button price now spaced apart with centered divider
+- Theme toggle icon shows what it switches to (Moon in light, Sun in dark)
+- Sign-in redirects back to current page instead of always to account page
+
+### Removed
+
+- Clear Cart button from cart footer
+- Shipping address picker from cart (Stripe Checkout collects natively)
+- Cart drawer border lines for cleaner look
+
+### Fixed
+
+- Page scrollbar no longer visible behind cart/dialog overlays
+- Cart quantity stepper buttons now have proper keyboard focus rings
+
 ## 0.83.0 - 2026-02-05
 
 ### Added

--- a/app/(site)/_components/layout/SiteHeader.tsx
+++ b/app/(site)/_components/layout/SiteHeader.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ShoppingCart } from "@/app/(site)/_components/cart/ShoppingCart";
 import { UserMenu } from "@/app/(site)/_components/navigation/UserMenu";
@@ -124,6 +124,7 @@ export default function SiteHeader({
   productMenuText = "Shop",
 }: SiteHeaderProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const [searchQuery, setSearchQuery] = useState("");
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isBannerDismissed, setIsBannerDismissed] = useState(false);
@@ -321,7 +322,7 @@ export default function SiteHeader({
                 <UserMenu user={user} />
               ) : (
                 <Button asChild variant="ghost" size="sm">
-                  <Link href="/auth/signin">
+                  <Link href={`/auth/signin?callbackUrl=${encodeURIComponent(pathname)}`}>
                     <User className="w-4 h-4 lg:mr-2" />
                     <span className="hidden lg:inline">Sign In</span>
                   </Link>

--- a/app/(site)/_components/layout/__tests__/SiteHeader.integration.test.tsx
+++ b/app/(site)/_components/layout/__tests__/SiteHeader.integration.test.tsx
@@ -7,6 +7,7 @@ jest.mock("next/navigation", () => ({
   useRouter: () => ({
     push: jest.fn(),
   }),
+  usePathname: () => "/",
 }));
 
 // Mock components that have external dependencies

--- a/app/(site)/_components/product/AddToCartButton.tsx
+++ b/app/(site)/_components/product/AddToCartButton.tsx
@@ -7,7 +7,6 @@ import {
   Loader2,
   Check,
   Zap,
-  ArrowRight,
 } from "lucide-react";
 import type { ButtonState } from "@/hooks/useAddToCartWithFeedback";
 
@@ -52,8 +51,8 @@ const stateConfig: Record<
     className: "bg-amber-500 hover:bg-amber-600 text-white animate-pulse",
   },
   "checkout-now": {
-    text: "Checkout Now",
-    Icon: ArrowRight,
+    text: "View Cart",
+    Icon: ShoppingCart,
     className: "bg-amber-500 hover:bg-amber-600 text-white",
   },
 };
@@ -112,10 +111,14 @@ export function AddToCartButton({
         <span>{config.text}</span>
       </span>
       {showPrice && (
-        <span className="flex items-center gap-2 shrink-0">
-          <span className="h-5 w-px bg-primary-foreground/30" />
-          <span className="font-semibold">${formatPrice(priceInCents)}</span>
-        </span>
+        <>
+          <span className="flex-1 flex justify-center">
+            <span className="h-5 w-px bg-primary-foreground/30" />
+          </span>
+          <span className="font-semibold shrink-0">
+            ${formatPrice(priceInCents)}
+          </span>
+        </>
       )}
     </Button>
   );

--- a/app/(site)/_components/product/ProductDeliverySchedule.tsx
+++ b/app/(site)/_components/product/ProductDeliverySchedule.tsx
@@ -28,7 +28,7 @@ export function ProductDeliverySchedule({
         align="inline-start"
         className="h-full px-4 text-sm font-semibold text-text-base"
       >
-        Delivery Schedule
+        Schedule
       </InputGroupAddon>
       <Select
         value={

--- a/app/(site)/_components/product/ProductQuantityCart.tsx
+++ b/app/(site)/_components/product/ProductQuantityCart.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { ButtonGroup, ButtonGroupText } from "@/components/ui/button-group";
+import { ButtonGroup } from "@/components/ui/button-group";
 import { cn } from "@/lib/utils";
 import { MinusIcon, PlusIcon } from "lucide-react";
 import { AddToCartButton } from "./AddToCartButton";
@@ -41,25 +41,29 @@ export function ProductQuantityCart({
       `gap-${spacing}`
     )}>
       {/* +/- stepper (all breakpoints) */}
-      <ButtonGroup className="w-full h-14 rounded-md border border-border bg-muted/60 overflow-hidden">
+      <ButtonGroup className="w-full">
         <Button
           type="button"
-          variant="ghost"
+          variant="outline"
           size="icon"
-          className="h-full w-14 rounded-none text-2xl font-semibold"
+          className="h-14 w-14"
           onClick={() => onQuantityChange(Math.max(1, quantity - 1))}
           disabled={isDisabled}
         >
           <MinusIcon />
         </Button>
-        <ButtonGroupText className="h-full flex-1 justify-center px-4 text-base font-semibold bg-transparent border-0 shadow-none">
-          {quantity}
-        </ButtonGroupText>
+        <input
+          type="text"
+          readOnly
+          tabIndex={-1}
+          value={quantity}
+          className="h-14 flex-1 min-w-0 text-center text-base font-semibold border border-border bg-transparent outline-none"
+        />
         <Button
           type="button"
-          variant="ghost"
+          variant="outline"
           size="icon"
-          className="h-full w-14 rounded-none text-2xl font-semibold"
+          className="h-14 w-14"
           onClick={() => onQuantityChange(quantity + 1)}
           disabled={isDisabled}
         >

--- a/app/(site)/_components/product/__tests__/AddToCartButton.test.tsx
+++ b/app/(site)/_components/product/__tests__/AddToCartButton.test.tsx
@@ -47,7 +47,7 @@ describe("AddToCartButton", () => {
     it("renders checkout-now state correctly", () => {
       render(<AddToCartButton {...defaultProps} buttonState="checkout-now" />);
 
-      expect(screen.getByRole("button")).toHaveTextContent("Checkout Now");
+      expect(screen.getByRole("button")).toHaveTextContent("View Cart");
       expect(screen.getByRole("button")).toHaveClass("bg-amber-500");
     });
   });

--- a/app/globals.css
+++ b/app/globals.css
@@ -132,6 +132,13 @@ We define CSS variables for each theme.
   html {
     overflow-y: scroll;
   }
+  /* Keep scrollbar space but make it invisible when dialog/sheet is open */
+  html:has(body[data-scroll-locked]) {
+    scrollbar-color: transparent transparent;
+    & * {
+      scrollbar-color: auto;
+    }
+  }
   body {
     @apply bg-background text-foreground;
   }

--- a/components/shared/ThemeSwitcher.tsx
+++ b/components/shared/ThemeSwitcher.tsx
@@ -17,8 +17,8 @@ export function ThemeSwitcher() {
       size="icon"
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
     >
-      <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-      <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <Moon className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Sun className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
       <span className="sr-only">Toggle theme</span>
     </Button>
   );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.83.0",
+  "version": "0.83.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Widen cart drawer to 500px, rearrange item controls (qty stepper + price on one line)
- Replace ghost buttons with outline ButtonGroup for proper keyboard focus rings
- Delivery method: choice cards on desktop, compact inline on mobile
- Remove shipping address picker (Stripe Checkout collects natively), Clear Cart button, and border lines
- Hide page scrollbar behind dialog overlays, fix theme toggle icon direction
- Rename "Checkout Now" → "View Cart", shorten "Delivery Schedule" → "Schedule"
- Sign-in redirects back to current page via callbackUrl
- Add to Cart button price divider centered with proper spacing

## Test plan
- [ ] Cart drawer opens wider (~500px) on desktop, full-width on mobile
- [ ] Qty stepper buttons show focus rings on keyboard tab
- [ ] Qty=1 left button shows X and removes item; qty>1 shows − and decrements
- [ ] Delivery method: compact on mobile, choice cards on desktop
- [ ] Page scrollbar hidden when cart/dialog is open, no content shift
- [ ] Theme toggle: Moon in light mode, Sun in dark mode
- [ ] Sign in from any page → redirects back to that page after auth
- [ ] "View Cart" button (after adding 2+ items) opens cart drawer