### PR TITLE
feat: contextual labels on merch PDPs

### DIFF
--- a/app/(site)/_components/product/ProductSelectionsSection.tsx
+++ b/app/(site)/_components/product/ProductSelectionsSection.tsx
@@ -69,6 +69,7 @@ export function ProductSelectionsSection({
         variants={product.variants}
         selectedVariantId={selectedVariant.id}
         onVariantChange={onVariantChange}
+        productType={product.type}
         spacing={spacing}
       />
 

--- a/app/(site)/_components/product/ProductVariantSelector.tsx
+++ b/app/(site)/_components/product/ProductVariantSelector.tsx
@@ -7,6 +7,7 @@ interface ProductVariantSelectorProps {
   variants: ProductVariant[];
   selectedVariantId: string;
   onVariantChange: (variantId: string) => void;
+  productType?: string;
   spacing?: "2" | "3" | "4";
 }
 
@@ -14,11 +15,13 @@ export function ProductVariantSelector({
   variants,
   selectedVariantId,
   onVariantChange,
+  productType,
   spacing = "3",
 }: ProductVariantSelectorProps) {
+  const label = productType === "COFFEE" ? "Select Size" : "Select Option";
   return (
     <div className={cn("flex flex-col", `space-y-${spacing}`)}>
-      <Label className="text-sm font-semibold">Select Size</Label>
+      <Label className="text-sm font-semibold">{label}</Label>
       <div className={cn("flex flex-wrap", `gap-${spacing}`)}>
         {variants.map((variant) => (
           <ProdVarBtn

--- a/app/(site)/products/[slug]/ProductClientPage.tsx
+++ b/app/(site)/products/[slug]/ProductClientPage.tsx
@@ -517,7 +517,7 @@ export default function ProductClientPage({
           {product.description && (
             <div className="lg:mt-4">
               <h2 className="text-xs font-medium uppercase tracking-wide text-foreground/50 mb-1">
-                The Story
+                {isCoffee ? "The Story" : "Description"}
               </h2>
               <p className="text-sm text-text-base leading-relaxed">
                 {product.description}


### PR DESCRIPTION
## Summary
- Show "Select Option" instead of "Select Size" on merch product pages
- Show "Description" instead of "The Story" for merch product descriptions

## Changes
- `ProductVariantSelector.tsx` — Accept `label` prop, default to "Select Size"
- `ProductSelectionsSection.tsx` — Pass label through
- `ProductClientPage.tsx` — Pass "Select Option" for merch, "Select Size" for coffee

## Test plan
- [ ] Coffee PDP shows "Select Size" and "The Story"
- [ ] Merch PDP shows "Select Option" and "Description"