### PR TITLE
fix: remove cart store version to avoid migration error

### DIFF
--- a/lib/store/cart-store.ts
+++ b/lib/store/cart-store.ts
@@ -170,7 +170,6 @@ export const useCartStore = create<CartState>()(
     }),
     {
       name: "artisan-roast-cart", // localStorage key
-      version: 1,
     }
   )
 );


### PR DESCRIPTION
Remove Zustand persist `version` field — causes migration error when localStorage has stale version data. No versioning needed in private beta.