### PR TITLE
feat: add product heading field and variant ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.86.1 - 2026-02-08
+
+### Added
+
+- **Product Heading Field**: Customizable storefront heading (e.g., "The Story", "Description") replaces hardcoded labels on product detail page
+- **Variant Ordering**: Variants now have an `order` field for explicit sort control
+- **Processing Field Validation**: Coffee processing method now included in Zod validation schema
+
+### Changed
+
+- Storefront product page uses `product.heading` directly — null heading shows no label
+- Variant queries ordered by `order` field ascending
+
 ## 0.86.0 - 2026-02-07
 
 ### Added

--- a/app/(site)/products/[slug]/ProductClientPage.tsx
+++ b/app/(site)/products/[slug]/ProductClientPage.tsx
@@ -485,9 +485,11 @@ export default function ProductClientPage({
           {/* ---- Story / Description: full-width below ---- */}
           {product.description && (
             <div className="lg:mt-4">
-              <h2 className="text-xs font-medium uppercase tracking-wide text-foreground/50 mb-1">
-                {isCoffee ? "The Story" : "Description"}
-              </h2>
+              {product.heading && (
+                <h2 className="text-xs font-medium uppercase tracking-wide text-foreground/50 mb-1">
+                  {product.heading}
+                </h2>
+              )}
               <p className="text-text-base leading-relaxed">
                 {product.description}
               </p>

--- a/app/api/admin/products/[id]/route.ts
+++ b/app/api/admin/products/[id]/route.ts
@@ -28,6 +28,7 @@ export async function GET(
           },
         },
         variants: {
+          orderBy: { order: "asc" },
           include: {
             purchaseOptions: true,
           },

--- a/app/api/admin/products/[id]/variants/route.ts
+++ b/app/api/admin/products/[id]/variants/route.ts
@@ -27,7 +27,7 @@ export async function GET(
       include: {
         purchaseOptions: true,
       },
-      orderBy: { name: "asc" },
+      orderBy: { order: "asc" },
     });
 
     const currentUnit = await getWeightUnit();

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -77,6 +77,7 @@ export async function getProductBySlug(productSlug?: string | null) {
           orderBy: { order: "asc" },
         },
         variants: {
+          orderBy: { order: "asc" },
           include: {
             purchaseOptions: true,
           },

--- a/lib/validations/product.ts
+++ b/lib/validations/product.ts
@@ -10,6 +10,7 @@ const baseProductSchema = z.object({
   name: z.string().min(1, "Name is required"),
   slug: z.string().min(1, "Slug is required"),
   description: z.string().optional().nullable(),
+  heading: z.string().optional().nullable(),
   images: z
     .array(
       z.object({
@@ -41,6 +42,7 @@ const coffeeFieldsSchema = z.object({
   variety: z.string().optional().nullable(),
   altitude: z.string().optional().nullable(),
   tastingNotes: z.array(z.string().min(1)).default([]),
+  processing: z.string().optional().nullable(),
 });
 
 // Schema for merch product detail key-value pairs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/prisma/migrations/20260208140410_add_product_heading_and_variant_order/migration.sql
+++ b/prisma/migrations/20260208140410_add_product_heading_and_variant_order/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Product" ADD COLUMN     "heading" TEXT;
+
+-- AlterTable
+ALTER TABLE "ProductVariant" ADD COLUMN     "order" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model Product {
   type              ProductType            @default(COFFEE)
   sku               String?
   description       String?
+  heading           String?
   isDisabled        Boolean                @default(false)
   tastingNotes      String[]
   isOrganic         Boolean                @default(false)
@@ -129,6 +130,7 @@ model ProductVariant {
   sku               String?
   productId         String
   stockQuantity     Int              @default(0)
+  order             Int              @default(0)
   product           Product          @relation(fields: [productId], references: [id], onDelete: Cascade)
   purchaseOptions   PurchaseOption[]
   addOnLinksPrimary AddOnLink[]      @relation("PrimaryVariant")

--- a/prisma/seed/products.ts
+++ b/prisma/seed/products.ts
@@ -108,6 +108,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Midnight Espresso Blend",
         slug: "midnight-espresso-blend",
+        heading: "The Story" as string | undefined,
         processing: undefined as string | undefined,
         description:
           "Born in our roastery's late-night cupping sessions, this blend marries dry-processed Brazilian Cerrado beans with washed Colombian Huila and wet-hulled Sumatran Mandheling. The Brazilian base brings body and bittersweet chocolate depth, Colombian lots add structured sweetness, and Indonesian beans lend an earthy complexity that rounds the finish. We roast each origin separately to its peak before blending, ensuring layers of toasted hazelnut and caramelized sugar emerge in every espresso pull. Equally stunning as a flat white or cortado.",
@@ -172,6 +173,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Italian Roast",
         slug: "italian-roast",
+        heading: "The Story" as string | undefined,
         processing: undefined as string | undefined,
         description:
           "Our Italian Roast pays homage to the tradition of Southern Italian espresso bars, where bold flavor is non-negotiable. We source high-density Bourbon from Brazil's Sul de Minas highlands and Catuai from Guatemala's Atitlán slopes, then push both past second crack to unlock deep smoky caramelization. The result is a powerful, full-bodied cup with pronounced bittersweet chocolate, roasted almond, and a lingering campfire sweetness. Built for moka pots, Neapolitan flip brewers, and anyone who takes their coffee unapologetically dark.",
@@ -205,6 +207,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Sumatra Mandheling",
         slug: "sumatra-mandheling",
+        heading: "The Story" as string | undefined,
         processing: "Wet-Hulled (Giling Basah)",
         description:
           "From the volcanic highlands around Lake Toba in North Sumatra, this Mandheling is processed using the traditional Giling Basah wet-hull method unique to Indonesia. Smallholder farmers depulp cherries at their farms, then deliver parchment coffee still damp to local collectors, where it's hulled at high moisture. This unconventional technique produces the distinctively syrupy body and earthy complexity that defines Sumatran coffee. Expect layers of dark chocolate, aromatic cedar, and a lingering herbaceous quality that rewards slow sipping. Certified organic by the Gayo cooperative.",
@@ -238,6 +241,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "French Roast",
         slug: "french-roast",
+        heading: "The Story" as string | undefined,
         processing: undefined as string | undefined,
         description:
           "This is the roast that divides the room—and we love it for that. Sourced from cooperative farms in Colombia's Cauca department and Brazil's Mogiana region, we take these beans deep into second crack where sugars fully caramelize and oils rise to the surface. The result is a velvety, almost viscous body with pronounced dark chocolate, a whisper of charred oak, and a finish so smooth it lingers without bitterness. We sell more of this in our 5lb bulk bags than any other coffee—home baristas and office coffee stations can't get enough.",
@@ -279,6 +283,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Papua New Guinea Sigri Estate",
         slug: "papua-new-guinea-sigri",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "Sigri Estate sits in the Wahgi Valley of Papua New Guinea's Western Highlands, one of the most remote fine-coffee regions on Earth. At 1,500 meters, cool nights slow cherry maturation, concentrating sugars in each bean. The estate's meticulous washing process—72-hour underwater fermentation followed by raised-bed drying—produces a remarkably clean cup with unusual depth. Dark berry and cocoa dominate the profile, grounded by an earthy complexity inherited from volcanic soils. Each harvest is limited, and we secure just a few bags annually for our most curious customers.",
@@ -312,6 +317,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Decaf Colombian",
         slug: "decaf-colombian",
+        heading: "The Story" as string | undefined,
         processing: "Washed, Swiss Water Decaf",
         description:
           "Sourced from family farms in Colombia's Huila department, these Castillo and Caturra beans are fully washed at origin, then shipped green to the Swiss Water facility in Vancouver, where caffeine is removed using pure water—no chemicals, no compromise. The process preserves the inherent sweetness of Colombian highland coffee: silky milk chocolate, toasted hazelnuts, and a gentle caramel finish that makes you forget it's decaf. Perfect for evening pour-overs or anyone who wants great coffee on their own schedule. Subscribers tell us it's the first decaf they've actually looked forward to.",
@@ -355,6 +361,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Breakfast Blend",
         slug: "breakfast-blend",
+        heading: "The Story" as string | undefined,
         processing: undefined as string | undefined,
         description:
           "Our best-selling coffee exists because our head roaster couldn't stop tinkering with her morning cup. She blends washed Caturra from Colombia's Nariño region for sweetness, sun-dried Catuai from Guatemala's Cobán highlands for body, and honey-processed Costa Rican lots from the Tarrazú valley for brightness. The three-origin combination creates a medium roast that's smooth enough to drink on autopilot yet complex enough to reward attention—notes of wildflower honey, roasted almond, and a citrus sparkle on the finish. Our most subscribed coffee by a wide margin.",
@@ -419,6 +426,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Colombian Supremo",
         slug: "colombian-supremo",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "Supremo is Colombia's highest screen-size grade, meaning only the largest, densest beans make the cut. Ours comes from smallholder farms scattered across Huila's mountainous terrain, where volcanic soil and equatorial sun produce cherries bursting with sugar. After careful hand-picking, beans are fully washed and patio-dried over two weeks. The cup is everything you want from a classic Colombian—well-balanced medium body, a caramel sweetness that builds as it cools, clean cocoa undertones, and a finish that lingers pleasantly without overstaying. A staple that never disappoints, whether brewed as drip, Chemex, or Aeropress.",
@@ -460,6 +468,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Guatemalan Antigua",
         slug: "guatemalan-antigua",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "The Antigua valley sits cradled between three volcanoes—Agua, Fuego, and Acatenango—whose mineral-rich ash has enriched the soil for centuries. Our lot comes from a fourth-generation family estate at 1,600 meters, where shade-grown Bourbon and Caturra cherries ripen slowly under a canopy of Gravilea trees. After selective hand-picking, beans are fully washed in spring-fed channels and dried on clay patios under the Guatemalan sun. The cup reveals a rich body with dark stone fruit, milk chocolate sweetness, and a subtle volcanic smokiness that makes Antigua one of the world's most celebrated origins. Certified organic.",
@@ -508,6 +517,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Costa Rica Tarrazú",
         slug: "costa-rica-tarrazu",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "The Tarrazú canton in Costa Rica's Los Santos region consistently produces some of Central America's cleanest, brightest coffees. Our lot is sourced from the CoopeTarrazú cooperative, where over 3,500 smallholder families pool their harvests. Grown between 1,200 and 1,900 meters on steep volcanic hillsides, these Caturra and Catuai cherries benefit from dramatic temperature swings between day and night. Fully washed and sun-dried on raised African beds, the result is a sparkling cup with brown sugar sweetness, ripe stone fruit, and a crisp, almost tea-like finish that makes it ideal for pour-over brewing.",
@@ -541,6 +551,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Brazil Santos",
         slug: "brazil-santos",
+        heading: "The Story" as string | undefined,
         processing: "Natural (Dry Process)",
         description:
           "Named after the port of Santos through which most Brazilian coffee has shipped for centuries, this lot comes from fazendas in the Cerrado Mineiro region of Minas Gerais. The flat, sun-drenched plateaus here are ideal for natural processing, where whole cherries dry on concrete patios for three weeks, allowing fruit sugars to ferment gently into the bean. The result is a silky, low-acid cup with roasted peanut, milk chocolate, and a subtle dried fruit sweetness. We sell this in 5lb bulk bags because it's our most popular cold brew base—steep it overnight and you'll understand why.",
@@ -582,6 +593,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Honduras Marcala",
         slug: "honduras-marcala",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "Marcala was Honduras's first Denomination of Origin for coffee, and for good reason. Nestled in the department of La Paz at elevations above 1,300 meters, the region's cloud forests create a micro-climate where Catuai and Bourbon varieties develop slowly over nine months. Our lot comes from the COMSA cooperative, a group of indigenous Lenca farmers who practice agroforestry and shade-growing. Fully washed and dried on raised beds, this coffee delivers toffee sweetness, crisp red apple acidity, and a citrus zest finish that brightens any morning routine.",
@@ -615,6 +627,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Mexican Altura",
         slug: "mexican-altura",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "\"Altura\" means highland in Spanish, and this designation guarantees beans grown above 1,200 meters in Mexico's Sierra Madre mountains. Our lot comes from organic-certified cooperatives in Chiapas, near the Guatemalan border, where indigenous Mayan farming communities have cultivated coffee under native forest canopy for generations. The Typica and Bourbon varieties here produce a lighter body than most Latin American coffees, with bright acidity carrying notes of cocoa powder, toasted cashew, and a warming cinnamon-like spice on the finish. A crowd-pleaser that converts tea drinkers.",
@@ -648,6 +661,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Peruvian Organic",
         slug: "peruvian-organic",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "High in the Andes of Peru's Cajamarca region, the Cenfrocafé cooperative brings together over 2,000 smallholder families who farm organically by tradition as much as by certification. At these altitudes—above 1,400 meters—frost is a real risk, but the payoff is beans with extraordinary density and sweetness. Fully washed in mountain spring water and slow-dried on tarps at altitude, this coffee delivers a mellow, velvety cup: vanilla bean sweetness up front, a caramel mid-palate, and a fleeting jasmine-like floral note on the finish. Our go-to recommendation for anyone new to specialty coffee.",
@@ -689,6 +703,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Nicaraguan SHG",
         slug: "nicaraguan-shg",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "\"Strictly High Grown\" is the highest grade designation for Nicaraguan coffee, reserved for beans cultivated above 1,200 meters. Our SHG comes from the Jinotega highlands, where morning fog and afternoon rain create ideal growing conditions for Caturra and Bourbon varieties. Small family farms here often sit on former cloud forest land, and many are transitioning back to shade-grown systems. Washed and patio-dried, this coffee offers a beautifully balanced cup—creamy milk chocolate body, sticky orange marmalade sweetness, and a round, satisfying finish that works brilliantly as both drip and espresso.",
@@ -722,6 +737,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "El Salvador Pacamara",
         slug: "el-salvador-pacamara",
+        heading: "The Story" as string | undefined,
         processing: "Honey",
         description:
           "Pacamara is a hybrid variety bred in El Salvador in the 1950s—a cross between the giant-beaned Pacas and Maragogype cultivars. Our lot comes from Finca Santa Petrona on the slopes of the Santa Ana volcano, where the Pacas family has farmed coffee for five generations. These oversized beans are honey-processed: depulped but dried with their sticky mucilage intact, creating a natural sweetness that conventional washing would strip away. The cup is gloriously complex—ripe mango and passionfruit up front, raw honeycomb sweetness in the middle, and a burgundy wine-like acidity that keeps you reaching for another sip.",
@@ -757,6 +773,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Ethiopian Yirgacheffe",
         slug: "ethiopian-yirgacheffe",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "Yirgacheffe is where coffee's story begins—the Kaffa forests of southern Ethiopia, where Coffea arabica still grows wild. Our lot comes from washing stations in the Gedeo Zone, where thousands of garden farmers deliver hand-picked cherries from heirloom varieties that have never been formally catalogued. After 36-hour fermentation in stone tanks, beans are washed in channels fed by highland springs and dried slowly on raised beds. The result is ethereal: tea-like body, pronounced jasmine and honeysuckle florals, bright lemon acidity, and a bergamot finish that evokes Earl Grey. Certified organic by the Yirgacheffe Coffee Farmers Cooperative Union.",
@@ -805,6 +822,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Kenya AA",
         slug: "kenya-aa",
+        heading: "The Story" as string | undefined,
         processing: "Washed (Double Fermented)",
         description:
           "Kenya's AA designation refers to bean size—screen 17/18, the largest grade—but size alone doesn't explain why Kenyan coffee commands a premium. Our lot comes from cooperatives around Mount Kenya, where SL28 and SL34 cultivars (developed at the Scott Laboratories in the 1930s) thrive in the deep red volcanic soil. Kenya's signature double-fermentation wash process—24 hours dry, then 24 hours submerged—creates the intense, almost electric acidity the origin is famous for. Blackcurrant and pink grapefruit dominate the cup, with a savory tomato sweetness and syrupy body that competition judges consistently score in the 90s.",
@@ -839,6 +857,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Ethiopian Sidamo",
         slug: "ethiopian-sidamo",
+        heading: "The Story" as string | undefined,
         processing: "Natural (Dry Process)",
         description:
           "While neighboring Yirgacheffe gets the spotlight, Sidamo (now officially Sidama) has its own magic. Our natural-processed lot comes from smallholder farms near the town of Bensa, where cherries are dried whole on raised beds for up to three weeks. This patience pays off: the extended fruit contact produces an explosion of ripe blueberry flavor that's almost jam-like in intensity. Beneath that fruit-forward punch, you'll find delicate jasmine florals and a dark chocolate bass note that grounds the cup. This is the coffee that converts washed-coffee purists to the natural-process camp.",
@@ -872,6 +891,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Rwanda Bourbon",
         slug: "rwanda-bourbon",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "Rwanda's coffee industry has been transformed over the past two decades, and lots like this show why. Grown by members of the Buf Coffee cooperative near Lake Kivu, these Bourbon trees sit at nearly 2,000 meters in rich volcanic soil. Every cherry is hand-sorted for ripeness before going through a meticulous 18-hour fermentation and channel-wash process. The resulting cup has a silky, almost creamy body unusual for a washed African coffee, with bright cranberry and pomegranate acidity, a caramel sweetness that deepens as it cools, and a fleeting rose-petal floral note. Certified organic and Rainforest Alliance verified.",
@@ -905,6 +925,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Burundi Kayanza",
         slug: "burundi-kayanza",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "Kayanza province in northern Burundi shares a border and a terroir with Rwanda, but its coffees have a character all their own. Our lot is processed at the Mpanga washing station, where local farmers—many of them women who head their households—deliver cherry daily during the three-month harvest season. Beans are fermented for 12 hours, washed in fresh spring water from the Kibira forest, and dried on elevated tables under mesh shade cloth. The cup is pristine: tart Bing cherry acidity, bittersweet cocoa nib depth, and a tangy, almost citric finish that makes this one of our team's favorite pour-over picks.",
@@ -938,6 +959,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Tanzania Peaberry",
         slug: "tanzania-peaberry",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "Peaberries are a natural mutation where only one seed develops inside the coffee cherry instead of the usual two, creating a small, round bean that roasts more evenly and concentrates flavor. Ours come from smallholder farms on the southern slopes of Mount Kilimanjaro, where Bourbon and Kent varieties grow in the shadow of Africa's tallest peak. Hand-sorted to isolate true peaberries (only 5-10% of any harvest), then washed and dried on raised beds in the cool mountain air. The cup is vivid and electric—black currant intensity, Meyer lemon brightness, and a complex, winey depth that reminds you great coffee is, after all, a fruit.",
@@ -971,6 +993,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Panama Geisha",
         slug: "panama-geisha",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "The Gesha variety was collected from Ethiopia's Gori Gesha forest in the 1930s but languished in obscurity until Hacienda La Esmeralda in Boquete, Panama entered it in competition in 2004—and shattered every price record. Our micro-lot comes from a neighboring estate in the Chiriquí highlands, where Gesha trees grow slowly at 1,800 meters in misty, cool conditions that few other varieties could tolerate. Washed with surgical precision and dried in temperature-controlled rooms, the cup is otherworldly: waves of jasmine and orange blossom, ripe papaya and lychee, and a raw acacia honey sweetness. This is coffee at its most transcendent. Certified organic.",
@@ -1004,6 +1027,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Colombia Geisha",
         slug: "colombia-geisha",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "Colombia has emerged as an unexpected champion of the Gesha variety, and our lot from Finca El Paraíso in Cauca department shows why. Farmer Hugo Carvajal planted Gesha seeds at 2,000 meters—higher than almost any farm in the country—where nighttime temperatures drop near freezing, drastically slowing cherry development and concentrating sugars over a 10-month growing cycle. Washed in controlled fermentation tanks with precise temperature monitoring, the result is a perfumed, almost ethereal cup: ripe white peach, dried lavender, and a brown sugar sweetness that builds through a long, clean finish. Limited availability each season.",
@@ -1037,6 +1061,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Costa Rica Honey Process",
         slug: "costa-rica-honey-process",
+        heading: "The Story" as string | undefined,
         processing: "Red Honey",
         description:
           "Costa Rica pioneered the honey process, and this red honey lot from the West Valley's Naranjo micro-region is a masterclass in the technique. After depulping, about 50% of the mucilage is left on the bean during drying—more than yellow honey but less than black—creating a controlled fermentation that takes 15-18 days on raised beds. Farm manager Doña María turns the beans by hand every 45 minutes during peak drying hours to prevent over-fermentation. The payoff is extraordinary: candied apricot sweetness, raw buckwheat honey depth, and a syrupy, almost liqueur-like body that clings to the palate. A process-driven coffee that tastes nothing like its washed neighbor.",
@@ -1070,6 +1095,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Guatemala Huehuetenango",
         slug: "guatemala-huehuetenango",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "Huehuetenango is Guatemala's highest coffee-growing region, and its remoteness has been both a challenge and a blessing. Hot, dry winds from Mexico's Tehuantepec plain blow through the valley, protecting these high-altitude farms from frost and allowing cultivation up to 2,000 meters—higher than almost anywhere else in Central America. Our lot comes from the Huehue cooperative's indigenous Q'anjob'al farming communities, who grow Bourbon and Caturra under traditional milpa shade systems. Fully washed in river water and sun-dried on patios, the cup is refined and delicate: crisp Fuji apple acidity, toasted almond sweetness, and an almost crystalline clean finish. Certified organic.",
@@ -1103,6 +1129,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Bolivia Caranavi",
         slug: "bolivia-caranavi",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "Bolivia produces less than 0.1% of the world's coffee, making any Bolivian lot a genuine rarity. Ours comes from the Caranavi province in the Yungas valley—a steep, lush corridor where the Andes drop into the Amazon basin. Small family plots carved into near-vertical hillsides grow Caturra and Catuai at elevations up to 1,800 meters, picking cherry by hand because the terrain makes machinery impossible. Washed in improvised micro-mills and dried on the farmers' own patios, this coffee has a delicate sweetness—milk chocolate and mandarin orange—wrapped in a silky, almost satiny body that belies its humble processing origins.",
@@ -1136,6 +1163,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Yemen Mocha",
         slug: "yemen-mocha",
+        heading: "The Story" as string | undefined,
         processing: "Natural (Dry Process)",
         description:
           "Yemen is where the global coffee trade began, and remarkably little has changed in how it's grown here. Terraced into the steep mountainsides of the Haraz region at altitudes above 2,000 meters, ancient Typica landraces—varieties found nowhere else on Earth—are tended by families who've farmed the same plots for centuries. Water scarcity means cherries are always natural-processed, dried on rooftops in the fierce Arabian sun. The result is untamed and complex: candied date and dried fig sweetness, bitter chocolate depth, cardamom and cinnamon spice, and a winey acidity that harkens back to the port of Mocha's storied past. Our most limited and expensive single origin.",
@@ -1169,6 +1197,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "India Monsooned Malabar",
         slug: "india-monsooned-malabar",
+        heading: "The Story" as string | undefined,
         processing: "Monsooned",
         description:
           "This is one of the most unusual coffees in our lineup, born from a historical accident. In the days of sailing ships, green coffee beans traveling from India to Europe would swell and change character during months of exposure to monsoon moisture in cargo holds. When steamships shortened the journey, the distinctive flavor was lost—so Malabar coast producers began deliberately recreating the process. Our beans are spread in open-sided warehouses during the June-September monsoon, absorbing humid winds off the Arabian Sea for 12-16 weeks. The transformation is dramatic: near-zero acidity, a heavy, almost chewy body, and flavors of pipe tobacco, black pepper, and loamy earth. Not for everyone, but unforgettable for those who love it.",
@@ -1202,6 +1231,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Hawaiian Kona",
         slug: "hawaiian-kona",
+        heading: "The Story" as string | undefined,
         processing: "Washed",
         description:
           "Kona coffee grows on a narrow strip of volcanic hillside on Hawaii's Big Island, where the slopes of Hualalai and Mauna Loa create a micro-climate found nowhere else—morning sun, afternoon cloud cover, and mineral-rich lava soil. Our 100% Kona (never a blend) comes from a third-generation family farm in the Holualoa district, where Typica trees descended from the original Brazilian cuttings brought to Hawaii in 1828 still produce exceptional cherry. Fully washed and sun-dried on traditional hoshidanas (wooden drying decks), the cup is refined and aromatic: brown sugar and roasted macadamia nut sweetness, medium body, and a bright, clean finish that justifies Kona's reputation as America's finest coffee.",
@@ -1237,6 +1267,7 @@ export async function seedProducts(prisma: PrismaClient) {
       product: {
         name: "Artisan Canvas Tote",
         slug: "artisan-canvas-tote",
+        heading: undefined as string | undefined,
         processing: undefined as string | undefined,
         description:
           "Heavyweight canvas tote for bean runs and local deliveries. 16oz canvas, reinforced handles, fits two 2lb bags plus extras.",
@@ -1339,6 +1370,7 @@ export async function seedProducts(prisma: PrismaClient) {
         data: {
           name: productInput.name,
           description: productInput.description,
+          heading: productInput.heading ?? null,
           origin: productInput.origin,
           tastingNotes: productInput.tastingNotes,
           variety: productInput.variety ?? null,
@@ -1364,6 +1396,7 @@ export async function seedProducts(prisma: PrismaClient) {
           name: productInput.name,
           slug: productInput.slug,
           description: productInput.description,
+          heading: productInput.heading ?? null,
           origin: productInput.origin,
           tastingNotes: productInput.tastingNotes,
           variety: productInput.variety ?? null,


### PR DESCRIPTION
## Summary
- Add `heading String?` to Product model — customizable storefront description label (e.g., "The Story", "Description")
- Add `order Int @default(0)` to ProductVariant — explicit variant sort control
- Add `processing` to coffee Zod validation schema (field already existed in DB)
- Storefront uses `product.heading` directly — null heading shows no label
- Variant queries ordered by `order` field ascending
- Seed data updated with heading values, DB backfilled

## Test plan
- [ ] Run `npx prisma migrate deploy` on Neon (or verify migration applied)
- [ ] Seed Neon DB: verify coffee products have heading "The Story"
- [ ] Verify storefront PDP shows heading above description for coffee products
- [ ] Verify storefront PDP shows no heading when product.heading is null
- [ ] `npm run precheck` passes
- [ ] `npm run test:ci` passes (730 tests)