### PR TITLE
chore: bump version to 0.86.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.86.1",
+  "version": "0.86.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Sync package.json version to 0.86.2 to match git tag v0.86.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)