### PR TITLE
chore: add process loop enforcement hooks for agentic workflow

### DIFF
--- a/.claude/hooks/session-start-loop-node.js
+++ b/.claude/hooks/session-start-loop-node.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// .claude/hooks/session-start-loop-node.js
+//
+// Claude Code SessionStart hook — injects workflow state context when a
+// session begins on a branch tracked in verification-status.json.
+//
+// Exit 0 = no context (main branch or untracked branch).
+// Exit 2 = inject context message via stderr.
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const fs = require("fs");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require("path");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { execSync } = require("child_process");
+
+function inject(message) {
+  process.stderr.write(message);
+  process.exit(2);
+}
+
+function main() {
+  const hookDir = __dirname;
+  const projectDir = path.resolve(hookDir, "..", "..");
+  const statusFile = path.join(hookDir, "..", "verification-status.json");
+
+  // Get current branch
+  let branch = "";
+  try {
+    branch = execSync("git branch --show-current", {
+      cwd: projectDir,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    process.exit(0);
+  }
+
+  // Skip on main or detached HEAD
+  if (!branch || branch === "main" || branch === "master") {
+    process.exit(0);
+  }
+
+  // No status file — no workflow tracking
+  if (!fs.existsSync(statusFile)) {
+    process.exit(0);
+  }
+
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(statusFile, "utf8"));
+  } catch {
+    process.exit(0);
+  }
+
+  const entry = data.branches && data.branches[branch];
+  if (!entry) {
+    process.exit(0);
+  }
+
+  const status = entry.status || "pending";
+  const passed = entry.acs_passed || 0;
+  const total = entry.acs_total || 0;
+
+  switch (status) {
+    case "planned":
+      inject(
+        `WORKFLOW ACTIVE: Branch '${branch}' has an approved plan with ${total} ACs. ` +
+          `Begin implementation per the plan and commit schedule. ` +
+          `Status: PLANNED — next step is IMPLEMENT.`
+      );
+      break;
+
+    case "implementing":
+      inject(
+        `WORKFLOW ACTIVE: Branch '${branch}' is mid-implementation (${total} ACs defined). ` +
+          `Continue implementing per the commit schedule. ` +
+          `When done, update status to "pending" and run /verify-workflow to verify all ACs. ` +
+          `Status: IMPLEMENTING.`
+      );
+      break;
+
+    case "pending":
+      inject(
+        `WORKFLOW ACTIVE: Branch '${branch}' has ${total} ACs awaiting verification. ` +
+          `Run /verify-workflow or /ac-verify before declaring done. ` +
+          `Status: PENDING VERIFICATION.`
+      );
+      break;
+
+    case "partial":
+      inject(
+        `WORKFLOW ACTIVE: Branch '${branch}' has ${passed}/${total} ACs verified. ` +
+          `Complete verification for remaining ACs before declaring done. ` +
+          `Status: PARTIAL.`
+      );
+      break;
+
+    case "verified":
+      inject(
+        `WORKFLOW COMPLETE: Branch '${branch}' is fully verified (${passed}/${total} ACs). ` +
+          `Ready for commit, PR, and release.`
+      );
+      break;
+
+    default:
+      process.exit(0);
+  }
+}
+
+main();

--- a/.claude/hooks/verify-before-stop-node.js
+++ b/.claude/hooks/verify-before-stop-node.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// .claude/hooks/verify-before-stop-node.js
+//
+// Claude Code Stop hook — blocks Claude from finishing a response when
+// the current branch has "pending" or "partial" verification status.
+//
+// This prevents the agent from declaring "done" without running verification.
+//
+// Exit 0 = allow stop.
+// Exit 2 = block stop (reason on stderr), Claude must continue.
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const fs = require("fs");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require("path");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { execSync } = require("child_process");
+
+function block(reason) {
+  process.stderr.write(reason);
+  process.exit(2);
+}
+
+const SOURCE_EXTS = [".ts", ".tsx", ".js", ".jsx", ".css", ".prisma"];
+
+function hasSourceChanges(projectDir) {
+  let status = "";
+  try {
+    status = execSync("git status --porcelain", {
+      cwd: projectDir,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return false;
+  }
+
+  if (!status) return false;
+
+  return status.split("\n").some((line) => {
+    // git status --porcelain lines: XY filename
+    const file = line.slice(3).trim();
+    return SOURCE_EXTS.some((ext) => file.endsWith(ext));
+  });
+}
+
+function main(input) {
+  // Parse stdin — Stop hooks receive JSON with stop_hook_active flag
+  let parsed;
+  try {
+    parsed = JSON.parse(input);
+  } catch {
+    // No valid JSON — allow
+    process.exit(0);
+  }
+
+  // Prevent infinite loop: if stop hook already fired this cycle, allow
+  if (parsed.stop_hook_active === true) {
+    process.exit(0);
+  }
+
+  const hookDir = __dirname;
+  const projectDir = path.resolve(hookDir, "..", "..");
+  const statusFile = path.join(hookDir, "..", "verification-status.json");
+
+  // Get current branch
+  let branch = "";
+  try {
+    branch = execSync("git branch --show-current", {
+      cwd: projectDir,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    process.exit(0);
+  }
+
+  // Skip on main or detached HEAD
+  if (!branch || branch === "main" || branch === "master") {
+    process.exit(0);
+  }
+
+  // No source changes — nothing to enforce
+  if (!hasSourceChanges(projectDir)) {
+    process.exit(0);
+  }
+
+  // No status file — soft reminder
+  if (!fs.existsSync(statusFile)) {
+    block(
+      `REMINDER: Branch '${branch}' has uncommitted source changes but no ` +
+        `verification-status.json file. If this is an AC-driven feature, ` +
+        `create a verification-status entry and run /verify-workflow before finishing.`
+    );
+  }
+
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(statusFile, "utf8"));
+  } catch {
+    process.exit(0);
+  }
+
+  const entry = data.branches && data.branches[branch];
+
+  // No entry for this branch — soft reminder
+  if (!entry) {
+    block(
+      `REMINDER: Branch '${branch}' has uncommitted source changes but no ` +
+        `workflow entry in verification-status.json. If this is an AC-driven ` +
+        `feature, register the branch and run /verify-workflow before finishing.`
+    );
+  }
+
+  const status = entry.status || "pending";
+  const passed = entry.acs_passed || 0;
+  const total = entry.acs_total || 0;
+
+  switch (status) {
+    case "verified":
+    case "planned":
+    case "implementing":
+      // Allow stop during these states
+      process.exit(0);
+      break;
+
+    case "pending":
+      block(
+        `BLOCKED: Implementation appears complete on '${branch}' but ` +
+          `verification has not been done (${total} ACs pending). ` +
+          `Run /verify-workflow or /ac-verify. ` +
+          `Do NOT present results to the user without verification.`
+      );
+      break;
+
+    case "partial":
+      block(
+        `BLOCKED: Verification incomplete on '${branch}' ` +
+          `(${passed}/${total} ACs passed). ` +
+          `Complete all AC verification before declaring done.`
+      );
+      break;
+
+    default:
+      block(
+        `BLOCKED: Branch '${branch}' has unknown status "${status}". ` +
+          `Update verification-status.json to a valid state before finishing.`
+      );
+      break;
+  }
+}
+
+// Read stdin
+let input = "";
+process.stdin.on("data", (chunk) => (input += chunk));
+process.stdin.on("end", () => main(input));

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/session-start-loop-node.js",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
@@ -7,6 +18,17 @@
           {
             "type": "command",
             "command": "node .claude/hooks/verify-before-commit-node.js",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/verify-before-stop-node.js",
             "timeout": 10
           }
         ]

--- a/.claude/skills/verify-workflow/SKILL.md
+++ b/.claude/skills/verify-workflow/SKILL.md
@@ -54,9 +54,35 @@ Drive a complete **implement -> verify -> iterate -> review** loop using sub-age
 
 ## Step-by-Step
 
+### Step 0: Register & Branch
+
+Before implementation, set up the workflow tracking:
+
+1. **Create feature branch:** `git checkout -b feat/{feature-name}`
+2. **Commit the approved plan** to the branch: `git commit -m "docs: add plan for {feature}"`
+3. **Register in verification-status.json:**
+
+   ```jsonc
+   // .claude/verification-status.json → branches["{branch}"]
+   {
+     "status": "planned",
+     "acs_passed": 0,
+     "acs_total": {count from plan},
+     "tasks": [],
+     "notes": "Plan approved and committed."
+   }
+   ```
+
+4. **When coding begins**, update status to `"implementing"`
+5. **When all code is written + precheck passes**, update status to `"pending"`
+
+This activates the enforcement hooks: SessionStart will inject workflow context, Stop will block premature completion, and the commit gate will allow intermediate commits.
+
 ### Step 1: Implement
 
 Execute the approved plan. Track progress with TaskCreate/TaskUpdate.
+
+Follow the **commit schedule** defined in the plan — commit logical chunks as you go (status must be `"planned"` or `"implementing"` for intermediate commits).
 
 **After implementation, run precheck:**
 
@@ -64,7 +90,7 @@ Execute the approved plan. Track progress with TaskCreate/TaskUpdate.
 npm run precheck
 ```
 
-Fix any TS/ESLint errors before proceeding to verification.
+Fix any TS/ESLint errors, then update verification-status to `"pending"` before proceeding to verification.
 
 ### Step 2: Verify (sub-agent delegation)
 

--- a/claude.md
+++ b/claude.md
@@ -348,6 +348,29 @@ npm run release:minor -- -y --push --sync-package --github-release
 /release minor --github-release
 ```
 
+### 6. Verification Enforcement (Process Loop)
+
+The agentic workflow is enforced by hooks that track the process loop state machine:
+
+**State machine:** `planned` → `implementing` → `pending` → [verify] → `verified`
+
+**SessionStart hook** (`session-start-loop-node.js`): On session start, reads `verification-status.json` for the current branch and injects workflow state context. Tells Claude where it is in the loop and what to do next.
+
+**Stop hook** (`verify-before-stop-node.js`): Blocks Claude from finishing a response when status is `pending` or `partial`. Only fires when source files have uncommitted changes. Allows stop during `planned`, `implementing`, and `verified`.
+
+**Commit gate** (`verify-before-commit-node.js`): Blocks `git commit` during `pending`/`partial` states. Allows intermediate commits during `planned`/`implementing` and final commits when `verified`.
+
+**State transitions** (managed by the main thread):
+
+| Transition | When |
+|-----------|------|
+| (none) → `planned` | After plan approved + committed to branch |
+| `planned` → `implementing` | When coding begins |
+| `implementing` → `pending` | After all code written + precheck passes |
+| `pending`/`partial` → `verified` | After all ACs pass verification |
+
+**Plan phase requirement:** After plan approval, commit the plan to the feature branch and register a `"planned"` entry in `verification-status.json` with `acs_total` set to the AC count. This activates the entire enforcement chain.
+
 ---
 
 ## Common Development Patterns


### PR DESCRIPTION
## Summary
- Add SessionStart hook (`session-start-loop-node.js`) that injects workflow state context at session start
- Add Stop hook (`verify-before-stop-node.js`) that blocks Claude from declaring "done" during `pending`/`partial` verification states
- Update commit gate to allow intermediate commits during `planned`/`implementing` states
- Register all three hooks in `.claude/settings.json`
- Add Step 0 (branch creation, plan commit, status registration) to verify-workflow skill
- Document process loop state machine, enforcement hooks, and commit schedule convention

## Test plan
- [ ] Start a new session on a branch with `"planned"` status — SessionStart hook should inject context
- [ ] Implement a feature, set status to `"pending"` — Stop hook should block completion
- [ ] Set status to `"verified"` — Stop hook and commit gate should allow
- [ ] Intermediate commits should work during `"implementing"` state

🤖 Generated with [Claude Code](https://claude.com/claude-code)