### PR TITLE
feat: mobile responsive polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.87.7 - 2026-02-11
+
+### Added
+
+- **Action Bar Mobile Dropdown**: Menu builder action bar collapses into overflow dropdown below md breakpoint with icons, labels, and keyboard shortcuts matching context menu pattern
+
+### Changed
+
+- Order history cards display in 2-column grid at lg breakpoint, stacked below
+- Cart item count badge smaller at xs-sm breakpoints
+- Menu view name column uses fixed width (w-72) with table-level min-width for horizontal scroll
+- Remove TouchTarget wrappers from inline checkbox/chevron in menu view (fixes inflated hit areas at sm)
+- Checkbox-to-chevron spacing tightened (mr-4 → mr-3) for better alignment
+
 ## 0.87.6 - 2026-02-11
 
 ### Added

--- a/app/(site)/_components/cart/ShoppingCart.tsx
+++ b/app/(site)/_components/cart/ShoppingCart.tsx
@@ -284,7 +284,7 @@ export function ShoppingCart() {
         >
           <ShoppingCartIcon className="w-6 h-6" />
           {displayCount > 0 && (
-            <span className="absolute -top-2 -right-2 bg-red-600 text-white text-xs w-5 h-5 rounded-full flex items-center justify-center font-semibold">
+            <span className="absolute -top-1.5 -right-1.5 sm:-top-2 sm:-right-2 bg-red-600 text-white text-[10px] sm:text-xs w-4 h-4 sm:w-5 sm:h-5 rounded-full flex items-center justify-center font-semibold">
               {displayCount}
             </span>
           )}

--- a/app/(site)/orders/OrdersPageClient.tsx
+++ b/app/(site)/orders/OrdersPageClient.tsx
@@ -335,9 +335,9 @@ export default function OrdersPageClient({
           </CardContent>
         </Card>
       ) : (
-        <div className="lg:border lg:border-border lg:rounded-lg lg:bg-card">
-          {/* Desktop Table Header - only on lg screens */}
-          <div className="hidden lg:block">
+        <div className="xl:border xl:border-border xl:rounded-lg xl:bg-card">
+          {/* Desktop Table Header - only on xl screens */}
+          <div className="hidden xl:block">
             <div className="bg-muted/50 rounded-t-lg px-4 py-3 border-b border-border">
               <div className="grid grid-cols-7 gap-x-[6em] font-semibold text-sm text-text-muted">
                 <div>Order</div>
@@ -351,11 +351,11 @@ export default function OrdersPageClient({
             </div>
           </div>
           <div className="p-0">
-            <div className="space-y-4 lg:space-y-0 lg:divide-y lg:divide-border">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 xl:grid-cols-none xl:space-y-0 xl:divide-y xl:divide-border">
               {filteredOrders.map((order) => (
                 <div key={order.id}>
                   {/* Mobile/Tablet Card Layout */}
-                  <Card className="py-0 gap-0 lg:hidden">
+                  <Card className="py-0 gap-0 xl:hidden">
                     <MobileRecordCard
                       type="order"
                       status={order.status}
@@ -412,7 +412,7 @@ export default function OrdersPageClient({
                   </Card>
 
                   {/* Desktop Table Row - only on lg screens */}
-                  <div className="hidden lg:grid grid-cols-7 gap-x-[6em] p-4 hover:bg-muted/50 transition-colors items-center">
+                  <div className="hidden xl:grid grid-cols-7 gap-x-[6em] p-4 hover:bg-muted/50 transition-colors items-center">
                     {/* Order */}
                     <div>
                       <Button variant="outline" size="sm" asChild>

--- a/app/admin/product-menu/menu-builder/components/table-views/MenuTableView.tsx
+++ b/app/admin/product-menu/menu-builder/components/table-views/MenuTableView.tsx
@@ -31,7 +31,6 @@ import { useInlineEditHandlers } from "../../../hooks/useInlineEditHandlers";
 import { useMenuBuilder } from "../../MenuBuilderProvider";
 import { CheckboxCell } from "./shared/cells/CheckboxCell";
 import { ChevronToggleCell } from "./shared/cells/ChevronToggleCell";
-import { TouchTarget } from "./shared/cells/TouchTarget";
 import { InlineIconCell } from "./shared/cells/InlineIconCell";
 import { InlineNameEditor } from "./shared/cells/InlineNameEditor";
 import { RowContextMenu } from "./shared/cells/RowContextMenu";
@@ -573,7 +572,6 @@ export function MenuTableView() {
         <TableCell config={menuViewWidthPreset.name}>
           <HierarchyNameCell depth={0}>
             <HierarchyCheckbox>
-              <TouchTarget>
                 <CheckboxCell
                   id={row.id}
                   checked={isSelected}
@@ -585,10 +583,8 @@ export function MenuTableView() {
                   anchorKey={anchorKey}
                   onRangeSelect={anchorKey && anchorKey !== labelKey ? () => rangeSelect(labelKey) : undefined}
                 />
-              </TouchTarget>
             </HierarchyCheckbox>
             <HierarchyChevron>
-              <TouchTarget>
                 <ChevronToggleCell
                   isExpanded={row.isExpanded}
                   isExpandable={row.isExpandable}
@@ -597,7 +593,6 @@ export function MenuTableView() {
                   disabled={dragState.isDraggingLabel}
                   showDisabledWhenEmpty
                 />
-              </TouchTarget>
             </HierarchyChevron>
             {/* Icon + Name as visual unit with tighter spacing */}
             <div className="flex items-center gap-1">
@@ -745,7 +740,6 @@ export function MenuTableView() {
         <TableCell config={menuViewWidthPreset.name}>
           <HierarchyNameCell depth={1}>
             <HierarchyCheckbox>
-              <TouchTarget>
                 <CheckboxCell
                   id={compositeId}
                   checked={isSelected}
@@ -756,7 +750,6 @@ export function MenuTableView() {
                   anchorKey={anchorKey}
                   onRangeSelect={anchorKey && anchorKey !== categoryKey ? () => rangeSelect(categoryKey) : undefined}
                 />
-              </TouchTarget>
             </HierarchyCheckbox>
             <HierarchyName>
               <span className="truncate">{row.name}</span>
@@ -858,7 +851,7 @@ export function MenuTableView() {
 
   return (
     <>
-      <TableViewWrapper>
+      <TableViewWrapper className="min-w-[672px]">
         <TableHeader
           columns={MENU_VIEW_HEADER_COLUMNS}
           preset={menuViewWidthPreset}

--- a/app/admin/product-menu/menu-builder/components/table-views/shared/cells/HierarchyNameCell.tsx
+++ b/app/admin/product-menu/menu-builder/components/table-views/shared/cells/HierarchyNameCell.tsx
@@ -78,7 +78,7 @@ export function HierarchyCheckbox({ children, className }: SlotProps) {
     <div
       data-slot="hierarchy-checkbox"
       data-row-click-ignore
-      className={cn("flex-shrink-0 mr-4", className)}
+      className={cn("flex-shrink-0 mr-3", className)}
     >
       {children}
     </div>

--- a/app/admin/product-menu/menu-builder/components/table-views/shared/table/columnWidthPresets.ts
+++ b/app/admin/product-menu/menu-builder/components/table-views/shared/table/columnWidthPresets.ts
@@ -137,11 +137,11 @@ export const categoryViewWidthPreset: ColumnWidthPreset = extendWidthPreset(
 export const menuViewWidthPreset: ColumnWidthPreset = extendWidthPreset(
   baseMenuBuilderWidthPreset,
   {
-    // Name column: takes remaining space (no fixed width)
+    // Name column: fixed width, never shrinks — table scrolls horizontally instead
     // Contains inline checkbox + hierarchical content with depth-based indentation
     name: {
-      head: "pl-2.5 pr-6",
-      cell: "pl-2.5 pr-6 min-w-48",
+      head: "pl-2.5 pr-6 w-72 min-w-72",
+      cell: "pl-2.5 pr-6 w-72 min-w-72",
     },
     // Categories count column: shown only for labels, centered
     categories: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.87.6",
+  "version": "0.87.7",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- **Action bar mobile dropdown**: Menu builder action bar collapses into overflow dropdown (MoreHorizontal) below md, keeping New/Add visible; dropdown items show icon + label + kbd shortcut matching context menu pattern
- **Order history 2-col grid**: Cards display in 2-column grid at lg, stacked below; desktop table pushed to xl
- **Cart badge sizing**: Smaller badge (w-4 h-4, text-[10px]) at xs-sm breakpoints
- **Menu view table scroll**: Fixed name column width (w-72) with table-level min-width (672px) for horizontal scroll instead of column compression
- **TouchTarget fix**: Removed TouchTarget wrappers from inline checkbox/chevron in menu view — they inflated hit areas to 44px at sm, breaking layout
- **Checkbox spacing**: mr-4 → mr-3 on HierarchyCheckbox for tighter chevron alignment

## Test plan
- [ ] Menu builder action bar: verify New/Add visible at all sizes, remaining actions in dropdown below md
- [ ] Order history: 2-col cards at lg, stacked xs-md, desktop table at xl
- [ ] Cart badge: smaller at xs-sm, normal at md+
- [ ] Menu view: horizontal scroll at narrow widths, no column overlap
- [ ] Menu view: checkbox and chevron properly sized at all breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)