### PR TITLE
feat: table scroll min-widths and nav selected text on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.87.8 - 2026-02-11
+
+### Changed
+
+- Menu builder nav shows selected item text on mobile, icon-only for unselected
+- All menu builder table views set table-level min-width to prevent column overlap before scroll
+
 ## 0.87.7 - 2026-02-11
 
 ### Added

--- a/app/admin/product-menu/menu-builder/components/NavItem.tsx
+++ b/app/admin/product-menu/menu-builder/components/NavItem.tsx
@@ -24,7 +24,8 @@ interface NavItemProps {
  *
  * Displays icon + text with optional dropdown.
  * Shows selected state with primary background.
- * Responsive: icon-only on mobile, icon + text on md+
+ * Responsive: selected item shows icon + text at all breakpoints,
+ * unselected items show icon-only on mobile, icon + text on md+.
  */
 export function NavItem({
   icon,
@@ -45,7 +46,7 @@ export function NavItem({
       onClick={!hasDropdown ? onClick : undefined}
     >
       {icon && <DynamicIcon name={icon} className="w-4 h-4" size={16} />}
-      <span className="hidden md:inline">{text}</span>
+      <span className={cn(!isSelected && "hidden md:inline")}>{text}</span>
       {hasDropdown && <ChevronDown className="w-4 h-4 ml-1" />}
     </Button>
   );

--- a/app/admin/product-menu/menu-builder/components/table-views/AllCategoriesTableView.tsx
+++ b/app/admin/product-menu/menu-builder/components/table-views/AllCategoriesTableView.tsx
@@ -452,7 +452,7 @@ export function AllCategoriesTableView() {
 
   return (
     <>
-      <TableViewWrapper>
+      <TableViewWrapper className="min-w-[692px]">
         <TableHeader
           columns={ALL_CATEGORIES_HEADER_COLUMNS}
           preset={allCategoriesConfig.widthPreset}

--- a/app/admin/product-menu/menu-builder/components/table-views/AllLabelsTableView.tsx
+++ b/app/admin/product-menu/menu-builder/components/table-views/AllLabelsTableView.tsx
@@ -481,7 +481,7 @@ export function AllLabelsTableView() {
 
   return (
     <>
-      <TableViewWrapper>
+      <TableViewWrapper className="min-w-[676px]">
         <TableHeader
           columns={ALL_LABELS_HEADER_COLUMNS}
           preset={allLabelsWidthPreset}

--- a/app/admin/product-menu/menu-builder/components/table-views/CategoryTableView.tsx
+++ b/app/admin/product-menu/menu-builder/components/table-views/CategoryTableView.tsx
@@ -554,7 +554,7 @@ export function CategoryTableView() {
 
   return (
     <>
-      <TableViewWrapper>
+      <TableViewWrapper className="min-w-[628px]">
         <TableHeader
           columns={CATEGORY_VIEW_HEADER_COLUMNS}
           preset={categoryViewWidthPreset}

--- a/app/admin/product-menu/menu-builder/components/table-views/LabelTableView.tsx
+++ b/app/admin/product-menu/menu-builder/components/table-views/LabelTableView.tsx
@@ -500,7 +500,7 @@ export function LabelTableView() {
 
   return (
     <>
-      <TableViewWrapper>
+      <TableViewWrapper className="min-w-[724px]">
         <TableHeader
           columns={LABEL_VIEW_HEADER_COLUMNS}
           preset={labelViewWidthPreset}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.87.7",
+  "version": "0.87.8",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- **Table scroll min-widths**: All 4 remaining menu builder table views (AllCategories, AllLabels, CategoryView, LabelView) now set table-level min-width to prevent column overlap before horizontal scroll kicks in
- **Nav selected text on mobile**: Selected nav item shows icon + text at all breakpoints; unselected items stay icon-only on mobile, full text at md+

## Test plan
- [ ] All Categories view: table scrolls horizontally before columns overlap on narrow viewports
- [ ] All Labels view: same scroll behavior
- [ ] Category detail view: same scroll behavior
- [ ] Label detail view: same scroll behavior
- [ ] Menu builder nav bar: selected item shows text on mobile, others show icon-only
- [ ] Nav bar: switching views updates which item shows text

🤖 Generated with [Claude Code](https://claude.com/claude-code)