### PR TITLE
fix: correct table min-widths for views with flex columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.87.9 - 2026-02-11
+
+### Fixed
+
+- Correct table min-widths for AllCategories, CategoryView, and LabelView (fixed columns exceeded previous min-width, hiding flex columns)
+
 ## 0.87.8 - 2026-02-11
 
 ### Changed

--- a/app/admin/product-menu/menu-builder/components/table-views/AllCategoriesTableView.tsx
+++ b/app/admin/product-menu/menu-builder/components/table-views/AllCategoriesTableView.tsx
@@ -452,7 +452,7 @@ export function AllCategoriesTableView() {
 
   return (
     <>
-      <TableViewWrapper className="min-w-[692px]">
+      <TableViewWrapper className="min-w-[940px]">
         <TableHeader
           columns={ALL_CATEGORIES_HEADER_COLUMNS}
           preset={allCategoriesConfig.widthPreset}

--- a/app/admin/product-menu/menu-builder/components/table-views/CategoryTableView.tsx
+++ b/app/admin/product-menu/menu-builder/components/table-views/CategoryTableView.tsx
@@ -554,7 +554,7 @@ export function CategoryTableView() {
 
   return (
     <>
-      <TableViewWrapper className="min-w-[628px]">
+      <TableViewWrapper className="min-w-[860px]">
         <TableHeader
           columns={CATEGORY_VIEW_HEADER_COLUMNS}
           preset={categoryViewWidthPreset}

--- a/app/admin/product-menu/menu-builder/components/table-views/LabelTableView.tsx
+++ b/app/admin/product-menu/menu-builder/components/table-views/LabelTableView.tsx
@@ -500,7 +500,7 @@ export function LabelTableView() {
 
   return (
     <>
-      <TableViewWrapper className="min-w-[724px]">
+      <TableViewWrapper className="min-w-[748px]">
         <TableHeader
           columns={LABEL_VIEW_HEADER_COLUMNS}
           preset={labelViewWidthPreset}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.87.8",
+  "version": "0.87.9",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Fix table min-widths that were smaller than the sum of fixed column widths, causing flex columns (labels, categories, products) to be completely hidden
- AllCategories: 692px → 940px
- CategoryView: 628px → 860px
- LabelView: 724px → 748px

## Test plan
- [ ] AllCategories: labels column visible and scrollable
- [ ] CategoryView: categories column visible and scrollable
- [ ] LabelView: products column visible and scrollable

🤖 Generated with [Claude Code](https://claude.com/claude-code)