### PR TITLE
fix: mobile help popover and cart badge positioning

### DIFF
--- a/app/(site)/_components/cart/ShoppingCart.tsx
+++ b/app/(site)/_components/cart/ShoppingCart.tsx
@@ -284,7 +284,7 @@ export function ShoppingCart() {
         >
           <ShoppingCartIcon className="w-6 h-6" />
           {displayCount > 0 && (
-            <span className="absolute -top-1.5 -right-1.5 sm:-top-2 sm:-right-2 bg-red-600 text-white text-[10px] sm:text-xs w-4 h-4 sm:w-5 sm:h-5 rounded-full flex items-center justify-center font-semibold">
+            <span className="absolute top-0 -right-1.5 md:-top-2 md:-right-2 bg-red-600 text-white text-[10px] md:text-xs w-4 h-4 md:w-5 md:h-5 rounded-full flex items-center justify-center font-semibold">
               {displayCount}
             </span>
           )}


### PR DESCRIPTION
## Summary
- Replace Dialog with Popover + PopoverAnchor for mobile help in action bar overflow menu — same primitive as desktop, anchored to the "..." button
- Add debounce guard (300ms) to prevent dropdown cleanup from dismissing the popover on subsequent opens
- Fix cart item count badge origin at xs–md: `top-0` so badge top aligns with button top instead of overflowing above the header

## Test plan
- [ ] Mobile: tap "..." overflow → Help — popover opens anchored to button, stays open
- [ ] Repeat help open/close multiple times — stays open consistently
- [ ] Mobile: cart badge top edge aligns with cart button top edge
- [ ] Desktop (md+): cart badge uses larger size with `-top-2` offset as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)