### PR TITLE
feat: per-card fade-in-up animations

### DIFF
--- a/app/(site)/_components/category/CategoryClientPage.tsx
+++ b/app/(site)/_components/category/CategoryClientPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { motion } from "motion/react";
 import { CategoryProduct } from "@/lib/types";
 import ProductCard from "@/app/(site)/_components/product/ProductCard";
 import {
@@ -50,13 +51,20 @@ export default function CategoryClientPage({
         <p className="text-text-muted">No products found in this category.</p>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {products.map((product) => (
-            <ProductCard
+          {products.map((product, index) => (
+            <motion.div
               key={product.id}
-              product={product}
-              showPurchaseOptions={showPurchaseOptions}
-              categorySlug={categorySlug}
-            />
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.3 }}
+              transition={{ duration: 0.4, ease: "easeOut", delay: index * 0.08 }}
+            >
+              <ProductCard
+                product={product}
+                showPurchaseOptions={showPurchaseOptions}
+                categorySlug={categorySlug}
+              />
+            </motion.div>
           ))}
         </div>
       )}

--- a/app/(site)/_components/product/FeaturedProducts.tsx
+++ b/app/(site)/_components/product/FeaturedProducts.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { motion } from "motion/react";
 import { FeaturedProduct } from "@/lib/types";
 import ProductCard from "@/app/(site)/_components/product/ProductCard";
 import { ScrollCarousel } from "@/components/shared/media/ScrollCarousel";
@@ -52,15 +53,22 @@ export default function FeaturedProducts() {
             minWidth="var(--slide-size)"
           >
             {products.map((product, index) => (
-              <ProductCard
+              <motion.div
                 key={product.id}
-                product={product}
-                showPurchaseOptions={true}
-                hoverRevealFooter={true}
-                compactFooter={true}
-                compact={true}
-                priority={index < 4}
-              />
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.3 }}
+                transition={{ duration: 0.4, ease: "easeOut", delay: index * 0.08 }}
+              >
+                <ProductCard
+                  product={product}
+                  showPurchaseOptions={true}
+                  hoverRevealFooter={true}
+                  compactFooter={true}
+                  compact={true}
+                  priority={index < 4}
+                />
+              </motion.div>
             ))}
           </ScrollCarousel>
           </div>

--- a/app/(site)/_components/product/RecommendationsSection.tsx
+++ b/app/(site)/_components/product/RecommendationsSection.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
+import { motion } from "motion/react";
 import ProductCard from "@/app/(site)/_components/product/ProductCard";
 import { Sparkles, TrendingUp } from "lucide-react";
 import { useSiteSettings } from "@/hooks/useSiteSettings";
@@ -163,14 +164,21 @@ export default function RecommendationsSection() {
         {/* Product Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {products.map((product, index) => (
-            <ProductCard
+            <motion.div
               key={product.id}
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              product={product as any}
-              showPurchaseOptions={true}
-              hoverRevealFooter={true}
-              priority={index === 0} // Load first image eagerly as it's likely LCP
-            />
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.3 }}
+              transition={{ duration: 0.4, ease: "easeOut", delay: index * 0.08 }}
+            >
+              <ProductCard
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                product={product as any}
+                showPurchaseOptions={true}
+                hoverRevealFooter={true}
+                priority={index === 0} // Load first image eagerly as it's likely LCP
+              />
+            </motion.div>
           ))}
         </div>
 

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -40,14 +40,10 @@ export default function Home() {
       </motion.div>
 
       {/* Personalized Recommendations Section */}
-      <motion.div {...fadeInUp}>
-        <RecommendationsSection />
-      </motion.div>
+      <RecommendationsSection />
 
       {/* Product Grid Section */}
-      <motion.div {...fadeInUp}>
-        <FeaturedProducts />
-      </motion.div>
+      <FeaturedProducts />
     </>
   );
 }

--- a/app/(site)/products/[slug]/ProductClientPage.tsx
+++ b/app/(site)/products/[slug]/ProductClientPage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, startTransition, useRef } from "react";
 import Link from "next/link";
+import { motion } from "motion/react";
 import { ProductType, PurchaseType } from "@prisma/client";
 import {
   Product,
@@ -367,14 +368,19 @@ export default function ProductClientPage({
       </Breadcrumb>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-y-4 md:gap-x-10 md:gap-y-5 lg:gap-x-14 lg:gap-y-8">
-        <div className="w-full min-w-0 md:sticky md:top-6 md:self-start">
+        <motion.div
+          className="w-full min-w-0 md:sticky md:top-6 md:self-start"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, ease: "easeOut" }}
+        >
           <ImageCarousel
             images={galleryImages}
             aspectRatio="square"
             showThumbnails={showThumbs}
             showDots={true}
           />
-        </div>
+        </motion.div>
 
         <div className="w-full min-w-0 flex flex-col gap-4">
           {/* ---- Coffee header: origin, name, roast bar, tasting notes ---- */}


### PR DESCRIPTION
## Summary
- Add per-card staggered fade-in-up animations to homepage (Recommendations + Featured), category page, and product page image
- Move animation ownership from page-level wrappers into individual components for granular per-card control
- Hero/barista section keeps its section-level animation (single element)

## Test plan
- [ ] Homepage: each recommendation card fades in individually with stagger as it scrolls into view
- [ ] Homepage: each featured product card fades in individually with stagger
- [ ] Category page: each product card fades in with stagger
- [ ] Product page: image fades in on mount
- [ ] All animations play once only (no re-trigger on scroll back)
- [ ] No impact on page load performance (animations are CSS transforms, not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)