### PR TITLE
feat: responsive admin orders/subs with shared card component

### DIFF
--- a/app/(site)/account/tabs/SubscriptionsTab.tsx
+++ b/app/(site)/account/tabs/SubscriptionsTab.tsx
@@ -30,7 +30,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { useEditAddress } from "@/app/(site)/_hooks/useEditAddress";
 import { EditAddressDialog } from "@/app/(site)/_components/account/EditAddressDialog";
-import { MobileRecordCard } from "@/app/(site)/_components/account/MobileRecordCard";
+import { MobileRecordCard } from "@/components/shared/MobileRecordCard";
 
 type SubscriptionStatus = "ACTIVE" | "PAUSED" | "CANCELED" | "PAST_DUE";
 

--- a/app/(site)/orders/OrdersPageClient.tsx
+++ b/app/(site)/orders/OrdersPageClient.tsx
@@ -8,11 +8,11 @@ import { format } from "date-fns";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Loader2, MoreHorizontal } from "lucide-react";
-import { MobileRecordCard } from "@/app/(site)/_components/account/MobileRecordCard";
+import { MobileRecordCard } from "@/components/shared/MobileRecordCard";
 import {
   getStatusColor as sharedGetStatusColor,
   getStatusLabel as sharedGetStatusLabel,
-} from "@/app/(site)/_components/account/record-utils";
+} from "@/components/shared/record-utils";
 import {
   Select,
   SelectContent,
@@ -310,7 +310,7 @@ export default function OrdersPageClient({
               Completed ({getOrderCount("completed")})
             </SelectItem>
             <SelectItem value="failed">
-              Failed ({getOrderCount("failed")})
+              Unfulfilled ({getOrderCount("failed")})
             </SelectItem>
             <SelectItem value="cancelled">
               Canceled ({getOrderCount("cancelled")})
@@ -350,144 +350,144 @@ export default function OrdersPageClient({
               </div>
             </div>
           </div>
-          <div className="p-0">
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 xl:grid-cols-none xl:space-y-0 xl:divide-y xl:divide-border">
-              {filteredOrders.map((order) => (
-                <div key={order.id}>
-                  {/* Mobile/Tablet Card Layout */}
-                  <Card className="py-0 gap-0 xl:hidden">
-                    <MobileRecordCard
-                      type="order"
-                      status={order.status}
-                      date={order.createdAt}
-                      displayId={`#${order.id.slice(-8)}`}
-                      detailHref={`/orders/${order.id}`}
-                      items={order.items.map((item) => ({
-                        id: item.id,
-                        name: item.purchaseOption.variant.product.name,
-                        variant: item.purchaseOption.variant.name,
-                        purchaseType:
-                          item.purchaseOption.type === "SUBSCRIPTION"
-                            ? "Subscription"
-                            : "One-time",
-                        quantity: item.quantity,
-                      }))}
-                      shipping={
-                        order.shippingStreet
-                          ? {
-                              recipientName: order.recipientName,
-                              street: order.shippingStreet,
-                              city: order.shippingCity,
-                              state: order.shippingState,
-                              postalCode: order.shippingPostalCode,
-                            }
-                          : undefined
-                      }
-                      deliveryMethod={order.deliveryMethod}
-                      actions={
-                        hasActions(order)
-                          ? [
-                              ...(canEditAddress(order)
-                                ? [
-                                    {
-                                      label: "Edit Address",
-                                      onClick: () => editAddress.openDialog(order),
-                                    },
-                                  ]
-                                : []),
-                              ...(canCancelOrder(order)
-                                ? [
-                                    {
-                                      label: "Cancel Order",
-                                      onClick: () => openCancelDialog(order),
-                                      variant: "destructive" as const,
-                                    },
-                                  ]
-                                : []),
-                            ]
-                          : undefined
-                      }
-                      actionsLoading={cancellingOrderId === order.id}
-                    />
-                  </Card>
+          {/* Mobile/Tablet Card Grid */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 xl:hidden">
+            {filteredOrders.map((order) => (
+              <Card key={order.id} className="py-0 gap-0">
+                <MobileRecordCard
+                  type="order"
+                  status={order.status}
+                  date={order.createdAt}
+                  displayId={`#${order.id.slice(-8)}`}
+                  detailHref={`/orders/${order.id}`}
+                  items={order.items.map((item) => ({
+                    id: item.id,
+                    name: item.purchaseOption.variant.product.name,
+                    variant: item.purchaseOption.variant.name,
+                    purchaseType:
+                      item.purchaseOption.type === "SUBSCRIPTION"
+                        ? "Subscription"
+                        : "One-time",
+                    quantity: item.quantity,
+                  }))}
+                  shipping={
+                    order.shippingStreet
+                      ? {
+                          recipientName: order.recipientName,
+                          street: order.shippingStreet,
+                          city: order.shippingCity,
+                          state: order.shippingState,
+                          postalCode: order.shippingPostalCode,
+                        }
+                      : undefined
+                  }
+                  deliveryMethod={order.deliveryMethod}
+                  actions={
+                    hasActions(order)
+                      ? [
+                          ...(canEditAddress(order)
+                            ? [
+                                {
+                                  label: "Edit Address",
+                                  onClick: () => editAddress.openDialog(order),
+                                },
+                              ]
+                            : []),
+                          ...(canCancelOrder(order)
+                            ? [
+                                {
+                                  label: "Cancel Order",
+                                  onClick: () => openCancelDialog(order),
+                                  variant: "destructive" as const,
+                                },
+                              ]
+                            : []),
+                        ]
+                      : undefined
+                  }
+                  actionsLoading={cancellingOrderId === order.id}
+                />
+              </Card>
+            ))}
+          </div>
 
-                  {/* Desktop Table Row - only on lg screens */}
-                  <div className="hidden xl:grid grid-cols-7 gap-x-[6em] p-4 hover:bg-muted/50 transition-colors items-center">
-                    {/* Order */}
-                    <div>
-                      <Button variant="outline" size="sm" asChild>
-                        <Link href={`/orders/${order.id}`}>
-                          #{order.id.slice(-8)}
-                        </Link>
-                      </Button>
-                    </div>
-
-                    {/* Date */}
-                    <div className="text-sm text-text-muted">
-                      {format(new Date(order.createdAt), "MMM d, yyyy")}
-                    </div>
-
-                    {/* Items */}
-                    <div>
-                      <OrderItemsList items={order.items} />
-                    </div>
-
-                    {/* Ship To */}
-                    <div>
-                      <ShipToInfo order={order} />
-                    </div>
-
-                    {/* Total */}
-                    <div className="text-right font-semibold">
-                      {formatPrice(order.totalInCents)}
-                    </div>
-
-                    {/* Status */}
-                    <div className="text-center">
-                      <StatusBadge status={order.status} />
-                    </div>
-
-                    {/* Actions */}
-                    <div className="flex justify-end">
-                      {hasActions(order) && (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              disabled={cancellingOrderId === order.id}
-                            >
-                              {cancellingOrderId === order.id ? (
-                                <Loader2 className="h-4 w-4 animate-spin" />
-                              ) : (
-                                <MoreHorizontal className="h-4 w-4" />
-                              )}
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            {canEditAddress(order) && (
-                              <DropdownMenuItem
-                                onClick={() => editAddress.openDialog(order)}
-                              >
-                                Edit Address
-                              </DropdownMenuItem>
-                            )}
-                            {canCancelOrder(order) && (
-                              <DropdownMenuItem
-                                onClick={() => openCancelDialog(order)}
-                                className="text-red-600"
-                              >
-                                Cancel Order
-                              </DropdownMenuItem>
-                            )}
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      )}
-                    </div>
-                  </div>
+          {/* Desktop Table Rows */}
+          <div className="hidden xl:block xl:divide-y xl:divide-border">
+            {filteredOrders.map((order) => (
+              <div key={order.id} className="grid grid-cols-7 gap-x-[6em] p-4 hover:bg-muted/50 transition-colors items-center">
+                {/* Order */}
+                <div>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href={`/orders/${order.id}`}>
+                      #{order.id.slice(-8)}
+                    </Link>
+                  </Button>
                 </div>
-              ))}
-            </div>
+
+                {/* Date */}
+                <div className="text-sm text-text-muted">
+                  {format(new Date(order.createdAt), "MMM d, yyyy")}
+                </div>
+
+                {/* Items */}
+                <div>
+                  <OrderItemsList items={order.items} />
+                </div>
+
+                {/* Ship To */}
+                <div>
+                  <ShipToInfo order={order} />
+                </div>
+
+                {/* Total */}
+                <div className="text-right font-semibold">
+                  {formatPrice(order.totalInCents)}
+                </div>
+
+                {/* Status */}
+                <div className="text-center">
+                  <StatusBadge status={order.status} />
+                </div>
+
+                {/* Actions */}
+                <div className="flex justify-end">
+                  {hasActions(order) && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={cancellingOrderId === order.id}
+                        >
+                          {cancellingOrderId === order.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <MoreHorizontal className="h-4 w-4" />
+                          )}
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        {canEditAddress(order) && (
+                          <DropdownMenuItem
+                            onClick={() => editAddress.openDialog(order)}
+                          >
+                            Edit Address
+                          </DropdownMenuItem>
+                        )}
+                        {canCancelOrder(order) && (
+                          <DropdownMenuItem
+                            onClick={() => openCancelDialog(order)}
+                            className="text-red-600"
+                          >
+                            Cancel Order
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </div>
+              </div>
+            ))}
           </div>
         </div>
       )}

--- a/app/admin/_components/dashboard/AdminTopNav.tsx
+++ b/app/admin/_components/dashboard/AdminTopNav.tsx
@@ -73,7 +73,7 @@ function NavDropdown({ item }: { item: NavItem }) {
   const Icon = item.icon;
 
   return (
-    <NavigationMenuPrimitive.Item className="relative">
+    <NavigationMenuPrimitive.Item value={item.label} className="relative">
       <NavigationMenuPrimitive.Trigger
         className={cn(
           "group inline-flex h-auto items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors",
@@ -151,6 +151,19 @@ export function AdminTopNav({ user, storeName, storeLogoUrl }: AdminTopNavProps)
     []
   );
 
+  // Debounce nav close to prevent click-to-close racing with hover-to-reopen.
+  // Same fix as SiteHeader — ignore close events within 300ms of open.
+  const [navValue, setNavValue] = React.useState("");
+  const navOpenedAt = React.useRef(0);
+  const handleNavValueChange = React.useCallback((val: string) => {
+    if (val) {
+      setNavValue(val);
+      navOpenedAt.current = Date.now();
+    } else if (Date.now() - navOpenedAt.current > 300) {
+      setNavValue(val);
+    }
+  }, []);
+
   const initials =
     user.name
       ?.split(" ")
@@ -195,7 +208,7 @@ export function AdminTopNav({ user, storeName, storeLogoUrl }: AdminTopNavProps)
           </div>
 
           {/* Center: Navigation menu - desktop only */}
-          <NavigationMenuPrimitive.Root className="hidden lg:flex">
+          <NavigationMenuPrimitive.Root className="hidden lg:flex" value={navValue} onValueChange={handleNavValueChange} delayDuration={200}>
             <NavigationMenuPrimitive.List className="flex items-center gap-2">
               {visibleNavItems.map((item) => (
                 <NavDropdown key={item.label} item={item} />

--- a/app/admin/subscriptions/SubscriptionManagementClient.tsx
+++ b/app/admin/subscriptions/SubscriptionManagementClient.tsx
@@ -22,6 +22,7 @@ import {
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
 import { MoreHorizontal } from "lucide-react";
+import { MobileRecordCard } from "@/components/shared/MobileRecordCard";
 import {
   cancelSubscription,
   skipBillingPeriod,
@@ -264,6 +265,22 @@ export default function SubscriptionManagementClient({
     return subscription.status === "PAUSED";
   }
 
+  function getSubscriptionActions(subscription: Subscription) {
+    const actions: import("@/components/shared/MobileRecordCard").RecordAction[] = [];
+
+    if (canSkip(subscription)) {
+      actions.push({ label: "Skip Next Billing", onClick: () => openSkipDialog(subscription) });
+    }
+    if (canResume(subscription)) {
+      actions.push({ label: "Resume Subscription", onClick: () => openResumeDialog(subscription), className: "text-green-600" });
+    }
+    if (canCancel(subscription)) {
+      actions.push({ label: "Cancel Subscription", onClick: () => openCancelDialog(subscription), variant: "destructive" });
+    }
+
+    return actions;
+  }
+
   function formatShippingAddress(subscription: Subscription) {
     if (!subscription.shippingStreet) {
       return <span className="text-muted-foreground italic">No address</span>;
@@ -299,7 +316,7 @@ export default function SubscriptionManagementClient({
         </TabsList>
       </Tabs>
 
-      {/* Subscriptions Table */}
+      {/* Subscriptions */}
       {filteredSubscriptions.length === 0 ? (
         <Card>
           <CardContent className="pt-6">
@@ -309,140 +326,123 @@ export default function SubscriptionManagementClient({
           </CardContent>
         </Card>
       ) : (
-        <div className="border rounded-md">
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead>
-                <tr className="border-b bg-muted/50">
-                  <th className="text-left py-3 px-4 font-semibold text-sm">
-                    Order #
-                  </th>
-                  <th className="text-left py-3 px-4 font-semibold text-sm">
-                    Schedule
-                  </th>
-                  <th className="text-left py-3 px-4 font-semibold text-sm">
-                    Next / Resumes
-                  </th>
-                  <th className="text-left py-3 px-4 font-semibold text-sm">
-                    Customer
-                  </th>
-                  <th className="text-left py-3 px-4 font-semibold text-sm">
-                    Items
-                  </th>
-                  <th className="text-left py-3 px-4 font-semibold text-sm">
-                    Ship To
-                  </th>
-                  <th className="text-right py-3 px-4 font-semibold text-sm">
-                    Total
-                  </th>
-                  <th className="text-center py-3 px-4 font-semibold text-sm">
-                    Status
-                  </th>
-                  <th className="text-center py-3 px-4 font-semibold text-sm">
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y">
-                {filteredSubscriptions.map((subscription) => (
-                  <tr key={subscription.id} className="hover:bg-muted/30">
-                    <td className="py-4 px-4">
-                      <div className="font-medium">
-                        {subscription.id.slice(-8)}
-                      </div>
-                    </td>
-                    <td className="py-4 px-4 text-sm">
-                      {subscription.deliverySchedule || "—"}
-                    </td>
-                    <td className="py-4 px-4 text-sm">
-                      {getNextDateDisplay(subscription)}
-                    </td>
-                    <td className="py-4 px-4">
-                      <div className="text-sm font-medium">
-                        {subscription.user?.name ||
-                          subscription.recipientName ||
-                          "—"}
-                      </div>
-                      <div className="text-xs text-muted-foreground">
-                        {subscription.user?.email || "—"}
-                      </div>
-                    </td>
-                    <td className="py-4 px-4">
-                      <div className="text-sm">
-                        {subscription.productNames.length > 0
-                          ? subscription.productNames.join(", ")
-                          : "—"}
-                      </div>
-                    </td>
-                    <td className="py-4 px-4 max-w-xs">
-                      {formatShippingAddress(subscription)}
-                    </td>
-                    <td className="py-4 px-4 text-right font-semibold">
-                      ${(subscription.priceInCents / 100).toFixed(2)}
-                    </td>
-                    <td className="py-4 px-4 text-center">
-                      {getStatusBadge(
-                        subscription.status,
-                        subscription.cancelAtPeriodEnd
-                      )}
-                    </td>
-                    <td className="py-4 px-4 text-center">
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            disabled={
-                              subscription.status === "CANCELED" ||
-                              subscription.cancelAtPeriodEnd
-                            }
-                          >
-                            <MoreHorizontal className="h-4 w-4" />
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem
-                            onClick={() => openSkipDialog(subscription)}
-                            disabled={!canSkip(subscription)}
-                            className={
-                              !canSkip(subscription)
-                                ? "text-muted-foreground"
-                                : ""
-                            }
-                          >
-                            Skip Next Billing
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            onClick={() => openResumeDialog(subscription)}
-                            disabled={!canResume(subscription)}
-                            className={
-                              canResume(subscription)
-                                ? "text-green-600"
-                                : "text-muted-foreground"
-                            }
-                          >
-                            Resume Subscription
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            onClick={() => openCancelDialog(subscription)}
-                            disabled={!canCancel(subscription)}
-                            className={
-                              canCancel(subscription)
-                                ? "text-red-600"
-                                : "text-muted-foreground"
-                            }
-                          >
-                            Cancel Subscription
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+        <>
+          {/* Mobile/Tablet Card Grid */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 xl:hidden">
+            {filteredSubscriptions.map((subscription) => (
+              <Card key={subscription.id} className="py-0 gap-0">
+                <MobileRecordCard
+                  type="subscription"
+                  status={subscription.status}
+                  statusLabel={
+                    subscription.cancelAtPeriodEnd
+                      ? "Canceling"
+                      : undefined
+                  }
+                  date={new Date(subscription.createdAt)}
+                  displayId={`#${subscription.id.slice(-8)}`}
+                  customer={{ name: subscription.user?.name || subscription.recipientName, email: subscription.user?.email }}
+                  price={`$${(subscription.priceInCents / 100).toFixed(2)}`}
+                  detailsSectionHeader="Total"
+                  currentPeriod={
+                    subscription.status !== "CANCELED"
+                      ? subscription.status === "PAUSED" && subscription.pausedUntil
+                        ? `Resumes ${format(new Date(subscription.pausedUntil), "MMM d, yyyy")}`
+                        : subscription.status !== "PAUSED"
+                          ? `Next: ${format(new Date(subscription.currentPeriodEnd), "MMM d, yyyy")}`
+                          : undefined
+                      : undefined
+                  }
+                  items={subscription.productNames.map((name, idx) => ({
+                    id: String(idx),
+                    name,
+                    variant: subscription.deliverySchedule || "",
+                    purchaseType: "",
+                    quantity: 1,
+                  }))}
+                  shipping={
+                    subscription.shippingStreet
+                      ? {
+                          recipientName: subscription.recipientName,
+                          street: subscription.shippingStreet,
+                          city: subscription.shippingCity,
+                          state: subscription.shippingState,
+                          postalCode: subscription.shippingPostalCode,
+                        }
+                      : undefined
+                  }
+                  actions={getSubscriptionActions(subscription)}
+                />
+              </Card>
+            ))}
           </div>
-        </div>
+
+          {/* Desktop Table */}
+          <div className="hidden xl:block border rounded-md">
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b bg-muted/50">
+                    <th className="text-left py-3 px-4 font-semibold text-sm">Order #</th>
+                    <th className="text-left py-3 px-4 font-semibold text-sm">Schedule</th>
+                    <th className="text-left py-3 px-4 font-semibold text-sm">Next / Resumes</th>
+                    <th className="text-left py-3 px-4 font-semibold text-sm">Customer</th>
+                    <th className="text-left py-3 px-4 font-semibold text-sm">Items</th>
+                    <th className="text-left py-3 px-4 font-semibold text-sm">Ship To</th>
+                    <th className="text-right py-3 px-4 font-semibold text-sm">Total</th>
+                    <th className="text-center py-3 px-4 font-semibold text-sm">Status</th>
+                    <th className="text-center py-3 px-4 font-semibold text-sm"></th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {filteredSubscriptions.map((subscription) => (
+                    <tr key={subscription.id} className="hover:bg-muted/30">
+                      <td className="py-4 px-4">
+                        <div className="font-medium">{subscription.id.slice(-8)}</div>
+                      </td>
+                      <td className="py-4 px-4 text-sm">{subscription.deliverySchedule || "—"}</td>
+                      <td className="py-4 px-4 text-sm">{getNextDateDisplay(subscription)}</td>
+                      <td className="py-4 px-4">
+                        <div className="text-sm font-medium">{subscription.user?.name || subscription.recipientName || "—"}</div>
+                        <div className="text-xs text-muted-foreground">{subscription.user?.email || "—"}</div>
+                      </td>
+                      <td className="py-4 px-4">
+                        <div className="text-sm">
+                          {subscription.productNames.length > 0 ? subscription.productNames.join(", ") : "—"}
+                        </div>
+                      </td>
+                      <td className="py-4 px-4 max-w-xs">{formatShippingAddress(subscription)}</td>
+                      <td className="py-4 px-4 text-right font-semibold">${(subscription.priceInCents / 100).toFixed(2)}</td>
+                      <td className="py-4 px-4 text-center">{getStatusBadge(subscription.status, subscription.cancelAtPeriodEnd)}</td>
+                      <td className="py-4 px-4 text-center">
+                        {getSubscriptionActions(subscription).length > 0 && (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button variant="ghost" size="sm">
+                                <MoreHorizontal className="h-4 w-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              {getSubscriptionActions(subscription).map((action) => (
+                                <DropdownMenuItem
+                                  key={action.label}
+                                  onClick={action.onClick}
+                                  className={action.className || (action.variant === "destructive" ? "text-red-600" : "")}
+                                >
+                                  {action.label}
+                                </DropdownMenuItem>
+                              ))}
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
       )}
 
       {/* Cancel Subscription Dialog */}

--- a/components/shared/MobileRecordCard.tsx
+++ b/components/shared/MobileRecordCard.tsx
@@ -34,11 +34,13 @@ export interface RecordAction {
   variant?: "default" | "destructive";
   icon?: React.ReactNode;
   disabled?: boolean;
+  className?: string;
 }
 
 interface MobileRecordCardProps {
   type: "order" | "subscription";
   status: string;
+  statusLabel?: string;
   date: Date;
   displayId: string;
   detailHref?: string;
@@ -50,6 +52,8 @@ interface MobileRecordCardProps {
   price?: string;
   currentPeriod?: string;
   detailsSectionHeader?: string;
+  customer?: { name?: string | null; email?: string | null };
+  badge?: React.ReactNode;
 }
 
 function SectionHeader({ children }: { children: React.ReactNode }) {
@@ -63,6 +67,7 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
 export function MobileRecordCard({
   type,
   status,
+  statusLabel,
   date,
   displayId,
   detailHref,
@@ -74,15 +79,18 @@ export function MobileRecordCard({
   price,
   currentPeriod,
   detailsSectionHeader,
+  customer,
+  badge,
 }: MobileRecordCardProps) {
   return (
     <div className="flex flex-col gap-5 px-4 py-4">
-      {/* Status + actions row */}
-      <div className="flex items-center justify-end gap-3">
+      {/* Status + badge + actions row */}
+      <div className="flex items-center justify-end gap-2">
+        {badge}
         <span
           className={`inline-block px-2 py-1 text-xs font-medium rounded-full ${getStatusColor(status)}`}
         >
-          {getStatusLabel(status)}
+          {statusLabel || getStatusLabel(status)}
         </span>
         {actions && actions.length > 0 && (
           <DropdownMenu>
@@ -101,7 +109,7 @@ export function MobileRecordCard({
                   key={action.label}
                   onClick={action.onClick}
                   disabled={action.disabled}
-                  className={action.variant === "destructive" ? "text-red-600" : ""}
+                  className={action.className || (action.variant === "destructive" ? "text-red-600" : "")}
                 >
                   {action.icon}
                   {action.label}
@@ -130,6 +138,17 @@ export function MobileRecordCard({
           <p className="text-sm font-medium mt-0.5">{displayId}</p>
         )}
       </div>
+
+      {/* Customer section (admin) */}
+      {customer && (
+        <div>
+          <SectionHeader>Customer</SectionHeader>
+          <p className="text-sm font-medium mt-0.5">{customer.name || "Guest"}</p>
+          {customer.email && (
+            <p className="text-xs text-muted-foreground">{customer.email}</p>
+          )}
+        </div>
+      )}
 
       {/* SCHEDULE section */}
       {price && (

--- a/components/shared/record-utils.ts
+++ b/components/shared/record-utils.ts
@@ -29,7 +29,7 @@ export function getStatusLabel(status: string) {
     case "PAST_DUE":
       return "Past Due";
     case "FAILED":
-      return "Failed";
+      return "Unfulfilled";
     default:
       return status.charAt(0) + status.slice(1).toLowerCase();
   }


### PR DESCRIPTION
## Summary
- Move `MobileRecordCard` and `record-utils` to `components/shared/` for reuse across site and admin
- Add responsive card grid layout (xs–lg) to admin orders and subscriptions pages, with table view at xl+
- Replace inline action buttons with three-dot dropdown menus in both card and table views
- Replace admin orders Select filter with Tabs component (consistent with subscriptions page)
- Show variant info in admin order items for fulfillment purposes
- Rename "Failed" status to "Unfulfilled" across all UI labels
- Fix admin top nav click/hover race condition (same debounce pattern as SiteHeader)
- Separate site orders card grid and table containers for equal-height card rows

## Test plan
- [ ] Verify admin orders page shows card grid at xs–lg, table at xl+
- [ ] Verify admin subscriptions page shows card grid at xs–lg, table at xl+
- [ ] Verify cards in same row have equal heights at lg breakpoint
- [ ] Verify three-dot menus work in both card and table views (Ship, Pickup Ready, Unfulfill, Track)
- [ ] Verify status tabs filter correctly on admin orders page
- [ ] Verify "Unfulfilled" label appears instead of "Failed" on both admin and site
- [ ] Verify admin top nav dropdowns open/close without flickering
- [ ] Verify site orders page still works correctly with updated imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)