### PR TITLE
fix: cart trash icon, qty multiplier, line totals

### DIFF
--- a/app/(site)/_components/cart/ShoppingCart.tsx
+++ b/app/(site)/_components/cart/ShoppingCart.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import {
   ShoppingCart as ShoppingCartIcon,
-  X,
+  Trash2,
   Plus,
   Minus,
   Loader2,
@@ -390,7 +390,7 @@ export function ShoppingCart() {
                             }
                           >
                             {item.quantity <= 1 ? (
-                              <X className="h-3 w-3" />
+                              <Trash2 className="h-3 w-3" />
                             ) : (
                               <Minus className="h-3 w-3" />
                             )}
@@ -421,7 +421,7 @@ export function ShoppingCart() {
                             onClick={() => handleRemoveItem(item)}
                             aria-label="Remove item"
                           >
-                            <X className="h-3 w-3" />
+                            <Trash2 className="h-3 w-3" />
                           </Button>
                           <input
                             type="text"
@@ -432,14 +432,21 @@ export function ShoppingCart() {
                           />
                         </ButtonGroup>
                       )}
-                      <span className="text-right">
-                        {item.originalPriceInCents && (
-                          <span className="text-sm text-muted-foreground line-through mr-1.5">
-                            {formatPrice(item.originalPriceInCents)}
+                      <span className="text-right flex items-center">
+                        {item.quantity > 1 && (
+                          <span className="text-sm font-medium text-muted-foreground pr-4">
+                            ×{item.quantity}
                           </span>
                         )}
-                        <span className="font-semibold text-text-base">
-                          {formatPrice(item.priceInCents)}
+                        <span>
+                          {item.originalPriceInCents && (
+                            <span className="text-sm text-muted-foreground line-through mr-1.5">
+                              {formatPrice(item.originalPriceInCents * item.quantity)}
+                            </span>
+                          )}
+                          <span className="font-semibold text-text-base">
+                            {formatPrice(item.priceInCents * item.quantity)}
+                          </span>
                         </span>
                       </span>
                     </div>


### PR DESCRIPTION
## Summary
- Replace X icon with Trash2 for item removal (qty=1 and subscriptions)
- Show "×{qty}" multiplier inline before price when quantity > 1
- Display line totals (unit price × quantity) instead of unit price
- Strikethrough original price also shows line total for correct comparison

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [ ] Cart: qty=1 shows trash icon, qty>1 shows minus
- [ ] Cart: "×2" multiplier appears with pr-4 spacing when qty > 1
- [ ] Cart: price reflects line total (e.g. $21.45 × 2 = $42.90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)