### PR TITLE
fix: cafe page carousel, location layout, and content bar polish

### DIFF
--- a/app/(site)/_components/content/HoursCard.tsx
+++ b/app/(site)/_components/content/HoursCard.tsx
@@ -1,4 +1,3 @@
-import { Clock } from "lucide-react";
 import { ReactNode } from "react";
 
 interface ScheduleEntry {
@@ -49,7 +48,6 @@ export function HoursCard({
       onClick={onClick}
     >
       <div className="flex items-center gap-2 pb-2">
-        <Clock className="h-4 w-4 text-muted-foreground" />
         <h3 className="font-semibold">{title}</h3>
       </div>
       <div className="space-y-1">

--- a/app/admin/_components/cms/blocks/CarouselBlock.tsx
+++ b/app/admin/_components/cms/blocks/CarouselBlock.tsx
@@ -11,13 +11,14 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { FormHeading } from "@/components/ui/forms/FormHeading";
 import { Switch } from "@/components/ui/switch";
-import { Plus, ArrowRight } from "lucide-react";
+import { Plus, ArrowDown } from "lucide-react";
 import Image from "next/image";
 import { ImageField } from "@/app/admin/_components/cms/fields/ImageField";
 import { ImageCard } from "../fields/ImageCard";
 import { ScrollCarousel } from "@/components/shared/media/ScrollCarousel";
 import { useMultiImageUpload } from "@/app/admin/_hooks/useImageUpload";
 import { useValidation } from "@/hooks/useFormDialog";
+import { useResponsiveValue } from "@/hooks/useResponsiveValue";
 
 type CarouselBlockType = ImageCarouselBlock | LocationCarouselBlock;
 
@@ -100,6 +101,10 @@ export function CarouselBlock({
  */
 function CarouselDisplay({ block }: { block: CarouselBlockType }) {
   const { slides, autoScroll, intervalSeconds } = block.content;
+  const slidesPerView = useResponsiveValue(
+    { 640: 1.5, 768: 2.2 },
+    1.2
+  );
 
   const handleSlideClick = (slide: {
     locationBlockId?: string;
@@ -133,10 +138,12 @@ function CarouselDisplay({ block }: { block: CarouselBlockType }) {
 
   return (
     <ScrollCarousel
-      slidesPerView={2.5}
+      slidesPerView={slidesPerView}
       autoplay={autoScroll}
       autoplayDelay={intervalSeconds * 1000}
       noBorder={true}
+      padEdges={block.type === "locationCarousel"}
+      showDots={false}
     >
       {slides.map(
         (
@@ -149,7 +156,10 @@ function CarouselDisplay({ block }: { block: CarouselBlockType }) {
           },
           index: number
         ) => (
-          <div key={index} className="relative group">
+          <div
+            key={index}
+            className="relative group"
+          >
             {/* Image */}
             <div className="relative aspect-4/3 rounded-lg overflow-hidden">
               <Image
@@ -168,10 +178,10 @@ function CarouselDisplay({ block }: { block: CarouselBlockType }) {
                     handleSlideClick(slide);
                   }}
                   onPointerDown={(e) => e.stopPropagation()}
-                  className="absolute bottom-4 right-4 flex items-center gap-1.5 bg-white/90 hover:bg-white text-foreground px-4 py-2 rounded-md text-sm font-medium transition-colors shadow-sm z-10"
+                  className="absolute bottom-4 right-4 flex items-center gap-1.5 bg-black/60 backdrop-blur-sm hover:bg-black/70 text-white px-3 py-2 rounded-md text-sm font-medium transition-colors shadow-sm z-10"
                 >
-                  Hours & Location
-                  <ArrowRight className="w-4 h-4" />
+                  <span className="hidden md:inline">Hours & Location</span>
+                  <ArrowDown className="w-4 h-4" />
                 </button>
               )}
             </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -233,6 +233,30 @@ We define CSS variables for each theme.
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
   }
+
+  /* Scrollbar always present (no layout shift), thumb visible on hover — md+ only */
+  @media (min-width: 768px) {
+    .scroll-on-hover {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    .scroll-on-hover:hover {
+      scrollbar-color: oklch(0.5 0 0 / 0.3) transparent;
+    }
+    .scroll-on-hover::-webkit-scrollbar {
+      width: 6px;
+    }
+    .scroll-on-hover::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    .scroll-on-hover::-webkit-scrollbar-thumb {
+      background: transparent;
+      border-radius: 3px;
+    }
+    .scroll-on-hover:hover::-webkit-scrollbar-thumb {
+      background: oklch(0.5 0 0 / 0.3);
+    }
+  }
 }
 
 /* Highlight animation for newly added items */

--- a/components/shared/media/ScrollCarousel.tsx
+++ b/components/shared/media/ScrollCarousel.tsx
@@ -19,6 +19,8 @@ interface ScrollCarouselProps {
   wheelGestures?: boolean;
   /** When provided, overrides inline slide sizing with responsive Tailwind classes */
   slideClassName?: string;
+  /** Add horizontal padding to viewport so first/last slides are inset from edges */
+  padEdges?: boolean;
 }
 
 export function ScrollCarousel({
@@ -32,6 +34,7 @@ export function ScrollCarousel({
   autoplayDelay = 4000,
   wheelGestures = true,
   slideClassName,
+  padEdges = false,
 }: ScrollCarouselProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -45,7 +48,7 @@ export function ScrollCarousel({
     },
     [
       ...(autoplay
-        ? [Autoplay({ delay: autoplayDelay, stopOnInteraction: true })]
+        ? [Autoplay({ delay: autoplayDelay, stopOnInteraction: true, stopOnMouseEnter: true })]
         : []),
       ...(wheelGestures ? [WheelGesturesPlugin({ forceWheelAxis: "x" })] : []),
     ]
@@ -97,7 +100,7 @@ export function ScrollCarousel({
         !noBorder && "border border-border rounded-lg overflow-hidden"
       )}
     >
-      <div className="overflow-hidden touch-pan-y" ref={emblaRef}>
+      <div className={cn("overflow-hidden touch-pan-y", padEdges && "px-4")} ref={emblaRef}>
         <div
           ref={containerRef}
           className={cn("flex", gap)}

--- a/lib/page-layouts/location-info.tsx
+++ b/lib/page-layouts/location-info.tsx
@@ -111,15 +111,16 @@ export const renderLocationInfoLayout: LayoutRenderer = (blocks, handlers) => {
           {renderBlock(carousel, handlers)}
         </div>
       )}
-      <div className="container mx-auto px-8 pt-12 max-w-5xl space-y-16">
-        {/* Slot: Rich Text Content */}
-        {content.length > 0 && (
-          <div className="space-y-8 border-l-5 pl-8">
+      {/* Slot: Rich Text Content - border hugs left edge, content stays contained */}
+      {content.length > 0 && (
+        <div className="border-l-[10px] border-foreground mt-12">
+          <div className="container mx-auto px-8 max-w-5xl space-y-8 py-8">
             {content.map((block) => renderBlock(block, handlers))}
           </div>
-        )}
-        {/* Slot: Location Sections & Content - Contained */}
+        </div>
+      )}
 
+      <div className="container mx-auto px-8 pt-12 max-w-5xl">
         {/* Slot: Location Sections (60/40 split) */}
         {locations.length > 0 && (
           <div className="space-y-20 pb-16">


### PR DESCRIPTION
## Summary
- **Carousel**: dark mode friendly button (`bg-black/60`), responsive slides per breakpoint via `useResponsiveValue`, edge padding with `padEdges` prop, hide dot navigation, pause autoplay on hover, arrow down instead of right
- **Location block**: remove MapPinned/Phone/Clock icons, address renders with line breaks (`whitespace-pre-line`), info panel absolutely positioned to match image height with scroll-on-hover scrollbar (transparent by default, visible on hover, `overscroll-contain` only when overflow detected)
- **Content bar**: 10px `border-foreground` bar hugs left browser edge, content stays in `container` with `max-w-5xl`
- **New CSS utility**: `.scroll-on-hover` — scrollbar always present (no layout shift), thumb fades in on hover, scoped to md+ via media query

## Test plan
- [ ] Carousel: verify responsive slide counts (1.2 xs, 1.5 sm, 2.2 md+), edge padding, dark mode button, autoplay pauses on hover
- [ ] Location: info panel scrolls when content exceeds image height, scrollbar appears on hover, no layout shift
- [ ] Location: overscroll-contain only on instances with overflow, page scrolls normally on short-content locations
- [ ] Content bar: foreground-colored 10px bar from left edge, content centered in container
- [ ] Mobile: location stacks vertically, no scroll constraint, no clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)