### PR TITLE
feat: SEO repositioning for platform launch

### DIFF
--- a/app/(site)/[category]/page.tsx
+++ b/app/(site)/[category]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import {
   getCategoryBySlug,
@@ -13,6 +14,19 @@ export const revalidate = 3600;
 interface CategoryPageProps {
   // We allow params to be a Promise to satisfy the Next.js runtime warning
   params: { category: string } | Promise<{ category: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: CategoryPageProps): Promise<Metadata> {
+  const { category: categorySlug } = await params;
+  const category = await getCategoryBySlug(categorySlug);
+  if (!category) return {};
+
+  const title = category.name;
+  const description = `Browse our ${category.name.toLowerCase()} collection — specialty coffee curated for quality.`;
+
+  return { title, description, openGraph: { title, description } };
 }
 
 export default async function CategoryPage({ params }: CategoryPageProps) {

--- a/app/(site)/products/[slug]/page.tsx
+++ b/app/(site)/products/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getProductBySlug, getRelatedProducts } from "@/lib/data";
 import { prisma } from "@/lib/prisma";
@@ -9,6 +10,30 @@ export const revalidate = 3600; // Re-fetch this page in the background, at most
 interface ProductPageProps {
   params: { slug: string } | Promise<{ slug: string }>;
   searchParams: Promise<{ from?: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: ProductPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const product = await getProductBySlug(slug);
+  if (!product) return {};
+
+  const title = product.name;
+  const description =
+    product.description ||
+    `Shop ${product.name} — specialty coffee from ${product.origin?.length ? product.origin.join(", ") : "select origins"}.`;
+  const image = product.variants[0]?.images[0]?.url;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      ...(image && { images: [{ url: image, alt: product.name }] }),
+    },
+  };
 }
 
 /**

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,7 +32,16 @@ export async function generateMetadata(): Promise<Metadata> {
       template: `%s | ${storeName}`,
     },
     description: storeDescription,
-    keywords: ["coffee", "specialty coffee", "coffee roaster", "coffee shop", "online coffee store", "coffee subscriptions"],
+    keywords: [
+      "open source ecommerce",
+      "nextjs ecommerce",
+      "specialty coffee ecommerce",
+      "ecommerce platform",
+      "stripe ecommerce",
+      "react ecommerce",
+      "coffee shop website",
+      "ecommerce template",
+    ],
     authors: [{ name: storeName }],
     creator: storeName,
     icons: {
@@ -80,14 +89,38 @@ export async function generateMetadata(): Promise<Metadata> {
  * It provides global wrappers (theme, session, analytics) for all routes.
  * Individual route groups like (site) and admin have their own layouts.
  */
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const { storeName, storeDescription } = await getSiteMetadata();
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://ecomm-ai-app.vercel.app";
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    name: storeName,
+    description: storeDescription,
+    url: appUrl,
+    applicationCategory: "BusinessApplication",
+    operatingSystem: "Any",
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+  };
+
   return (
     // We add 'suppressHydrationWarning' as required by next-themes
     <html lang="en" className={`${inter.variable}`} suppressHydrationWarning>
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
       <body className="min-h-screen bg-background font-sans antialiased">
         <SessionProvider>
           <ThemeProvider

--- a/lib/site-metadata.ts
+++ b/lib/site-metadata.ts
@@ -27,10 +27,10 @@ export async function getSiteMetadata() {
     storeName: settingsMap.store_name || "Artisan Roast",
     storeTagline:
       settingsMap.store_tagline ||
-      "Specialty coffee sourced from the world's finest origins.",
+      "Open-source specialty coffee e-commerce platform",
     storeDescription:
       settingsMap.store_description ||
-      "Premium specialty coffee, carefully roasted to perfection. From single-origin beans to signature blends, discover exceptional coffee delivered to your door.",
+      "A modern, open-source e-commerce platform built with Next.js, Stripe, and Prisma. Launch your specialty coffee business with subscriptions, AI recommendations, and a beautiful storefront.",
     storeLogoUrl: settingsMap.store_logo_url || "/logo.svg",
     storeFaviconUrl: settingsMap.store_favicon_url || "/favicon.ico",
   };

--- a/scripts/backup-database.ts
+++ b/scripts/backup-database.ts
@@ -153,7 +153,7 @@ async function backupDatabase() {
 
 // Run the backup
 backupDatabase()
-  .then((backupPath) => {
+  .then((_backupPath) => {
     console.log("✅ Backup process completed");
     process.exit(0);
   })


### PR DESCRIPTION
## Summary
- Update default tagline and description in `lib/site-metadata.ts` from coffee-shop copy to platform-oriented copy
- Replace coffee-shop keywords with platform-discovery keywords in root layout
- Add JSON-LD `WebApplication` structured data for search engine rich results
- Add `generateMetadata` to product pages (unique title, description, OG image)
- Add `generateMetadata` to category pages (unique title, description)
- Fix unused variable lint warnings in `scripts/backup-database.ts` and delete `scratchpad/`

## Test plan
- [x] `npm run precheck` — 0 errors, 0 warnings
- [ ] `npm run build` — verify `generateMetadata` works at build time
- [ ] View source on `/`, `/products/<slug>`, and `/<category>` to confirm metadata renders