### PR TITLE
fix: demo banner responsive text and accessibility

### DIFF
--- a/app/(site)/_components/content/DemoBanner.tsx
+++ b/app/(site)/_components/content/DemoBanner.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState } from "react";
-import { useSession } from "next-auth/react";
-import { X, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { ArrowRight, X, Zap } from "lucide-react";
+import { useSession } from "next-auth/react";
 import Link from "next/link";
+import { useState } from "react";
 
 /**
  * Demo banner that invites users to try the admin dashboard.
@@ -22,24 +22,22 @@ export function DemoBanner() {
   return (
     <div className="w-full bg-gradient-to-r from-violet-600 to-indigo-600 text-white px-4 py-2.5">
       <div className="container mx-auto flex items-center justify-center gap-2 sm:gap-4 text-sm">
-        <div className="flex items-center gap-2">
-          <Sparkles className="h-4 w-4 shrink-0" />
-          <span className="font-medium">This is a live demo.</span>
+        <div className="flex items-center gap-2 whitespace-nowrap">
+          <Zap className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span className="font-medium hidden sm:inline">This is a live demo.</span>
+          <span className="font-medium sm:hidden">Live demo.</span>
         </div>
-        <span className="hidden sm:inline text-white/80">
-          No signup required.
-        </span>
+        <span className="hidden sm:inline text-white/80">No signup required.</span>
         <Link
           href="/auth/signin"
-          className="font-semibold underline underline-offset-2 hover:no-underline whitespace-nowrap"
+          className="font-semibold underline underline-offset-2 hover:no-underline"
         >
-          Try Admin Dashboard →
+          Try Admin Dashboard
+          <ArrowRight className="h-4 w-4 inline-block ml-1" aria-hidden="true" />
         </Link>
         <button
           onClick={() => setIsDismissed(true)}
-          className={cn(
-            "p-1 rounded hover:bg-white/20 transition-colors ml-auto sm:ml-0"
-          )}
+          className={cn("p-1 rounded hover:bg-white/20 transition-colors ml-auto sm:ml-0")}
           aria-label="Dismiss banner"
         >
           <X className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Shorter banner text on mobile ("Live demo." vs "This is a live demo.")
- Swap Sparkles icon for Zap, use ArrowRight component instead of text arrow
- Add `aria-hidden` to decorative icons

## Test plan
- [ ] Banner renders correctly on mobile and desktop
- [ ] "Try Admin Dashboard" link works
- [ ] Dismiss button works