### PR TITLE
feat: add GA4, Search Console, and Speed Insights

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,17 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 # NEXT_PUBLIC_DEMO_MODE="true"
 
 # ==============================================
+# ANALYTICS & SEO (Optional)
+# ==============================================
+# Google Analytics 4 - Measurement ID from: https://analytics.google.com/
+# NEXT_PUBLIC_GA4_ID="G-XXXXXXXXXX"
+
+# Google Search Console - HTML tag verification code
+# Get from: https://search.google.com/search-console → Add Property → HTML tag
+# Copy only the "content" value from the meta tag
+# NEXT_PUBLIC_GSC_VERIFICATION="your_verification_code"
+
+# ==============================================
 # BUILD CONFIGURATION (Optional)
 # ==============================================
 # Set to "true" to automatically seed the database with minimal data during build

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,9 @@ import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import { SessionProvider } from "@/components/providers/SessionProvider";
 import { Toaster } from "@/components/ui/toaster";
 import { Analytics } from "@vercel/analytics/react";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import { EnvironmentIndicator } from "@/components/shared/EnvironmentIndicator";
+import { GoogleAnalytics } from "@/components/shared/GoogleAnalytics";
 import { getSiteMetadata } from "@/lib/site-metadata";
 
 // Setup the Inter font with a CSS variable
@@ -69,6 +71,9 @@ export async function generateMetadata(): Promise<Metadata> {
       title: storeName,
       description: storeTagline,
       images: [storeLogoUrl],
+    },
+    verification: {
+      google: process.env.NEXT_PUBLIC_GSC_VERIFICATION || undefined,
     },
     robots: {
       index: true,
@@ -135,6 +140,8 @@ export default async function RootLayout({
         </SessionProvider>
         <EnvironmentIndicator />
         <Analytics />
+        <SpeedInsights />
+        <GoogleAnalytics />
       </body>
     </html>
   );

--- a/components/shared/GoogleAnalytics.tsx
+++ b/components/shared/GoogleAnalytics.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import Script from "next/script";
+
+const GA_ID = process.env.NEXT_PUBLIC_GA4_ID;
+
+export function GoogleAnalytics() {
+  if (!GA_ID) return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_ID}');
+        `}
+      </Script>
+    </>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.87.15",
+  "version": "0.88.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.87.15",
+      "version": "0.88.4",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",
@@ -49,6 +49,7 @@
         "@types/ws": "^8.18.1",
         "@vapi-ai/web": "^2.5.1",
         "@vercel/analytics": "^1.5.0",
+        "@vercel/speed-insights": "^1.3.1",
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -6900,6 +6901,40 @@
         "@remix-run/react": {
           "optional": true
         },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.3.1.tgz",
+      "integrity": "sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
         "@sveltejs/kit": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@types/ws": "^8.18.1",
     "@vapi-ai/web": "^2.5.1",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.3.1",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- Add Google Analytics 4 tracking via `GoogleAnalytics` client component (env-gated)
- Add Google Search Console HTML meta tag verification (env-gated)
- Install `@vercel/speed-insights` for Core Web Vitals monitoring
- All three are instance-specific — only active when env vars are configured

## Activation (for artisanroast.app)
Set these in Vercel env vars:
- `NEXT_PUBLIC_GA4_ID` — GA4 Measurement ID (`G-XXXXXXXXXX`)
- `NEXT_PUBLIC_GSC_VERIFICATION` — Search Console verification code
- Speed Insights works automatically on Vercel

## Test plan
- [ ] No analytics scripts load without env vars set (check Network tab)
- [ ] GA4 script loads when `NEXT_PUBLIC_GA4_ID` is set
- [ ] GSC meta tag renders when `NEXT_PUBLIC_GSC_VERIFICATION` is set
- [ ] Speed Insights loads on Vercel deployment
- [ ] No impact on self-hosted instances without env vars