### PR TITLE
feat: add dynamic OG images for social sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.88.6 - 2026-02-14
+
+### Added
+
+- **Dynamic OG Images**: Auto-generated 1200x630 social sharing images for root, features, and about pages using Next.js ImageResponse
+- Dark coffee-themed gradient with adapted logo, title/subtitle text, and domain footer
+
+### Changed
+
+- Twitter card type updated from `summary` to `summary_large_image` for richer social previews
+- Removed hardcoded 512x512 logo from OG/Twitter metadata in favor of dynamic route-based images
+
 ## 0.88.0 - 2026-02-13
 
 ### Added
@@ -29,6 +41,7 @@
 
 - Old monolithic ProductFormClient and its section components
 - Product-level image model (replaced by VariantImage)
+
 ## 0.87.13 - 2026-02-12
 
 ### Fixed

--- a/app/(site)/about/opengraph-image.tsx
+++ b/app/(site)/about/opengraph-image.tsx
@@ -1,0 +1,21 @@
+import { ImageResponse } from "next/og";
+
+import { getSiteMetadata } from "@/lib/site-metadata";
+
+import { OG_SIZE, renderOgLayout } from "../../_og/og-layout";
+
+export const size = OG_SIZE;
+export const contentType = "image/png";
+export const alt = "About Artisan Roast";
+
+export default async function Image() {
+  const { storeName } = await getSiteMetadata();
+
+  return new ImageResponse(
+    await renderOgLayout({
+      title: `About ${storeName}`,
+      subtitle: "Full-stack e-commerce for specialty coffee",
+    }),
+    { ...size }
+  );
+}

--- a/app/(site)/features/opengraph-image.tsx
+++ b/app/(site)/features/opengraph-image.tsx
@@ -1,0 +1,17 @@
+import { ImageResponse } from "next/og";
+
+import { OG_SIZE, renderOgLayout } from "../../_og/og-layout";
+
+export const size = OG_SIZE;
+export const contentType = "image/png";
+export const alt = "Artisan Roast Features — Built for Specialty Coffee";
+
+export default async function Image() {
+  return new ImageResponse(
+    await renderOgLayout({
+      title: "Built for Specialty Coffee.",
+      subtitle: "Powered by Modern Tech.",
+    }),
+    { ...size }
+  );
+}

--- a/app/_og/og-layout.tsx
+++ b/app/_og/og-layout.tsx
@@ -1,0 +1,78 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+interface OgLayoutProps {
+  title: string;
+  subtitle: string;
+}
+
+export const OG_SIZE = { width: 1200, height: 630 };
+
+export async function renderOgLayout({ title, subtitle }: OgLayoutProps) {
+  let logoSvg = await readFile(
+    join(process.cwd(), "public", "logo.svg"),
+    "utf-8"
+  );
+
+  // Adapt logo colors for dark background
+  logoSvg = logoSvg.replace(/#c7f1ff/g, "#3d2a1a"); // blue bg → dark brown
+  logoSvg = logoSvg.replace(/#000000/g, "#e8d5c0"); // black strokes → light tan
+
+  const logoSrc = `data:image/svg+xml;base64,${Buffer.from(logoSvg).toString("base64")}`;
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        background:
+          "linear-gradient(135deg, #1c0f06 0%, #2d1810 40%, #3d2317 100%)",
+        padding: "60px 80px",
+      }}
+    >
+      {/* Logo */}
+      <div style={{ display: "flex" }}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={logoSrc} width={72} height={72} alt="" />
+      </div>
+
+      {/* Content */}
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        <div
+          style={{
+            color: "#ffffff",
+            fontSize: 60,
+            fontWeight: 700,
+            lineHeight: 1.15,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            color: "#c89b6e",
+            fontSize: 28,
+            marginTop: 20,
+          }}
+        >
+          {subtitle}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          color: "#7a6148",
+          fontSize: 22,
+        }}
+      >
+        artisanroast.app
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ const inter = Inter({
 
 // Generate metadata dynamically from database
 export async function generateMetadata(): Promise<Metadata> {
-  const { storeName, storeTagline, storeDescription, storeLogoUrl, storeFaviconUrl } =
+  const { storeName, storeTagline, storeDescription, storeFaviconUrl } =
     await getSiteMetadata();
 
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://artisanroast.app";
@@ -57,20 +57,11 @@ export async function generateMetadata(): Promise<Metadata> {
       siteName: storeName,
       title: storeName,
       description: storeTagline,
-      images: [
-        {
-          url: storeLogoUrl,
-          width: 512,
-          height: 512,
-          alt: storeName,
-        },
-      ],
     },
     twitter: {
-      card: "summary",
+      card: "summary_large_image",
       title: storeName,
       description: storeTagline,
-      images: [storeLogoUrl],
     },
     verification: {
       google: process.env.NEXT_PUBLIC_GSC_VERIFICATION || undefined,

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,18 @@
+import { ImageResponse } from "next/og";
+
+import { getSiteMetadata } from "@/lib/site-metadata";
+
+import { OG_SIZE, renderOgLayout } from "./_og/og-layout";
+
+export const size = OG_SIZE;
+export const contentType = "image/png";
+export const alt = "Artisan Roast — Specialty Coffee E-Commerce";
+
+export default async function Image() {
+  const { storeName, storeTagline } = await getSiteMetadata();
+
+  return new ImageResponse(
+    await renderOgLayout({ title: storeName, subtitle: storeTagline }),
+    { ...size }
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.88.5",
+  "version": "0.88.6",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Add auto-generated 1200×630 OG images for root, features, and about pages using Next.js `ImageResponse`
- Dark coffee-themed gradient layout with adapted logo, title/subtitle, and domain footer
- Replace hardcoded 512×512 logo in OG/Twitter metadata with dynamic route-based images, update twitter card to `summary_large_image`

## Test plan
- [ ] Visit `/opengraph-image` — renders root OG image with store name + tagline
- [ ] Visit `/features/opengraph-image` — renders features OG image
- [ ] Visit `/about/opengraph-image` — renders about OG image
- [ ] Check `<meta property="og:image">` tags in page source for each page
- [ ] Test sharing URL on https://www.opengraph.xyz/ after deploy