### PR TITLE
fix: UX tweaks for hero orbs, card animations, mobile nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.88.7 - 2026-02-14
+
+### Added
+
+- **Contact link in mobile menu**: Mail icon shortcut alongside Home, Search, Orders, Account
+
+### Changed
+
+- **Hero orbs toned down**: Reduced opacity and brightness so floating light orbs sit behind text
+- **Hero titles forced black**: Titles on features and about pages stay black in both light and dark modes
+- **Per-card scroll animation**: Feature and about cards now reveal individually on scroll (stacking feel) instead of all at once
+- **Mobile navbar always visible**: Header no longer auto-hides on scroll at small breakpoints
+
 ## 0.88.6 - 2026-02-14
 
 ### Added

--- a/app/(site)/_components/content/animated-sections.tsx
+++ b/app/(site)/_components/content/animated-sections.tsx
@@ -114,8 +114,8 @@ export function AnimatedGradient({
             hsl(${hue3}, 80%, 85%) 100%)`,
         }}
       />
-      {/* Floating light orbs */}
-      <div className="absolute inset-0 z-[1] overflow-hidden">
+      {/* Floating light orbs — no z-index so they sit between gradient and text */}
+      <div className="absolute inset-0 overflow-hidden">
         <motion.div
           className="absolute h-96 w-96 rounded-full blur-2xl"
           animate={{
@@ -124,9 +124,9 @@ export function AnimatedGradient({
           }}
           transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }}
           style={{
-            opacity: 0.7,
+            opacity: 0.35,
             background:
-              "radial-gradient(circle, rgba(255,255,255,0.9), transparent 70%)",
+              "radial-gradient(circle, rgba(255,255,255,0.6), transparent 70%)",
             top: "10%",
             left: "10%",
           }}
@@ -139,9 +139,9 @@ export function AnimatedGradient({
           }}
           transition={{ duration: 10, repeat: Infinity, ease: "easeInOut" }}
           style={{
-            opacity: 0.6,
+            opacity: 0.3,
             background:
-              "radial-gradient(circle, rgba(255,255,255,0.9), transparent 70%)",
+              "radial-gradient(circle, rgba(255,255,255,0.6), transparent 70%)",
             bottom: "10%",
             right: "15%",
           }}
@@ -154,9 +154,9 @@ export function AnimatedGradient({
           }}
           transition={{ duration: 12, repeat: Infinity, ease: "easeInOut" }}
           style={{
-            opacity: 0.5,
+            opacity: 0.25,
             background:
-              "radial-gradient(circle, rgba(255,255,255,0.9), transparent 70%)",
+              "radial-gradient(circle, rgba(255,255,255,0.6), transparent 70%)",
             top: "40%",
             left: "50%",
           }}

--- a/app/(site)/_components/layout/SiteHeader.tsx
+++ b/app/(site)/_components/layout/SiteHeader.tsx
@@ -40,7 +40,7 @@ import {
 import { useNavOverflow } from "@/hooks/useNavOverflow";
 import { useSiteSettings } from "@/hooks/useSiteSettings";
 import { cn } from "@/lib/utils";
-import { ChevronDown, FileText, Home, LogOut, Menu, MoreHorizontal, PackageSearch, Search, User } from "lucide-react";
+import { ChevronDown, FileText, Home, LogOut, Mail, Menu, MoreHorizontal, PackageSearch, Search, User } from "lucide-react";
 import { signOut } from "next-auth/react";
 import Image from "next/image";
 import Link from "next/link";
@@ -159,6 +159,9 @@ export default function SiteHeader({
   }, []);
 
   const handleScroll = useCallback(() => {
+    // Keep navbar always visible on mobile (< md breakpoint)
+    if (window.innerWidth < 768) return;
+
     const currentScrollY = window.scrollY;
     const threshold = 10;
 
@@ -295,6 +298,17 @@ export default function SiteHeader({
                           <User className="w-5 h-5" />
                           <span className="text-[10px] uppercase tracking-wide font-medium">
                             Account
+                          </span>
+                        </Link>
+                      </SheetClose>
+                      <SheetClose asChild>
+                        <Link
+                          href="/contact"
+                          className="inline-flex flex-1 flex-col items-center justify-center gap-1 py-2 rounded-md text-foreground hover:text-primary hover:bg-accent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                        >
+                          <Mail className="w-5 h-5" />
+                          <span className="text-[10px] uppercase tracking-wide font-medium">
+                            Contact
                           </span>
                         </Link>
                       </SheetClose>

--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -27,8 +27,6 @@ import { getSiteMetadata } from "@/lib/site-metadata";
 import type { Metadata } from "next";
 import {
   ScrollReveal,
-  StaggerContainer,
-  StaggerItem,
   AnimatedGradient,
 } from "@/app/(site)/_components/content/animated-sections";
 
@@ -48,7 +46,7 @@ export default async function AboutPage() {
         <div className="relative container mx-auto px-4 py-16 md:py-24">
           <ScrollReveal>
             <div className="mx-auto max-w-3xl text-center">
-              <h1 className="mb-4 text-3xl font-bold tracking-tight md:text-5xl">
+              <h1 className="mb-4 text-3xl font-bold tracking-tight text-black md:text-5xl">
                 About{" "}
 {storeName}
               </h1>
@@ -66,8 +64,8 @@ export default async function AboutPage() {
       <div className="bg-gradient-to-b from-stone-100/70 via-stone-100/40 to-stone-100/20 pb-24 dark:from-stone-800/20 dark:via-stone-800/10 dark:to-stone-800/5" />
       <div className="container mx-auto px-4 -mt-32 relative z-10 pb-16">
         <div className="mx-auto max-w-5xl">
-          <StaggerContainer className="grid gap-6 md:grid-cols-2" staggerDelay={0.2}>
-            <StaggerItem>
+          <div className="grid gap-6 md:grid-cols-2">
+            <ScrollReveal>
               <Card className="h-full transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -140,9 +138,9 @@ export default async function AboutPage() {
                   </div>
                 </CardContent>
               </Card>
-            </StaggerItem>
+            </ScrollReveal>
 
-            <StaggerItem>
+            <ScrollReveal delay={0.1}>
               <Card className="h-full transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -194,9 +192,9 @@ export default async function AboutPage() {
                   </div>
                 </CardContent>
               </Card>
-            </StaggerItem>
+            </ScrollReveal>
 
-            <StaggerItem className="md:col-span-2">
+            <ScrollReveal delay={0.15} className="md:col-span-2">
               <Card className="transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -281,8 +279,8 @@ export default async function AboutPage() {
                   </div>
                 </CardContent>
               </Card>
-            </StaggerItem>
-          </StaggerContainer>
+            </ScrollReveal>
+          </div>
         </div>
       </div>
 

--- a/app/(site)/features/page.tsx
+++ b/app/(site)/features/page.tsx
@@ -24,8 +24,6 @@ import {
 import type { Metadata } from "next";
 import {
   ScrollReveal,
-  StaggerContainer,
-  StaggerItem,
   AnimatedGradient,
 } from "@/app/(site)/_components/content/animated-sections";
 
@@ -230,7 +228,7 @@ export default function FeaturesPage() {
         <div className="relative container mx-auto px-4 py-16 md:py-24">
           <ScrollReveal>
             <div className="mx-auto max-w-3xl text-center">
-              <h1 className="mb-4 text-3xl font-bold tracking-tight md:text-5xl">
+              <h1 className="mb-4 text-3xl font-bold tracking-tight text-black md:text-5xl">
                 Built for Specialty Coffee.
                 <br />
                 Powered by Modern Tech.
@@ -263,12 +261,9 @@ export default function FeaturesPage() {
       <div className="bg-gradient-to-b from-muted/60 via-muted/40 to-muted/20 pb-24 dark:from-muted/30 dark:via-muted/15 dark:to-muted/10" />
       <div className="container mx-auto px-4 -mt-32 relative z-10 pb-16">
         <div className="mx-auto max-w-5xl">
-          <StaggerContainer
-            className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4"
-            staggerDelay={0.15}
-          >
-            {features.map(({ icon: Icon, title, description, accent }) => (
-              <StaggerItem key={title}>
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {features.map(({ icon: Icon, title, description, accent }, index) => (
+              <ScrollReveal key={title} delay={index * 0.08}>
                 <div className="group flex h-full flex-col rounded-lg border border-border bg-card p-6 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
                   <div
                     className={`mb-4 flex h-12 w-12 items-center justify-center rounded-lg ${accent}`}
@@ -280,9 +275,9 @@ export default function FeaturesPage() {
                     {description}
                   </p>
                 </div>
-              </StaggerItem>
+              </ScrollReveal>
             ))}
-          </StaggerContainer>
+          </div>
         </div>
       </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.88.6",
+  "version": "0.88.7",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Tone down hero floating orbs (halved opacity, reduced white alpha) and layer them behind foreground text
- Force hero titles to black in both light/dark modes on features and about pages
- Replace container-level `StaggerContainer` with per-card `ScrollReveal` for stacking scroll animation (matches home/category pattern)
- Add Contact (Mail icon) link to mobile menu icon bar
- Disable auto-hide navbar on scroll for xs-sm breakpoints (< md)

## Test plan
- [ ] Features/about hero orbs are subtle and don't obscure text
- [ ] Hero titles stay black in dark mode
- [ ] Feature cards animate individually as they scroll into view
- [ ] About cards animate with staggered stacking effect
- [ ] Mobile menu shows Contact icon alongside Home, Search, Orders, Account
- [ ] Mobile navbar stays visible when scrolling down
- [ ] Desktop navbar still auto-hides on scroll down