### PR TITLE
fix: close verification workflow optional loopholes

### DIFF
--- a/.claude/hooks/verify-before-stop-node.js
+++ b/.claude/hooks/verify-before-stop-node.js
@@ -90,7 +90,8 @@ function main(input) {
     block(
       `REMINDER: Branch '${branch}' has uncommitted source changes but no ` +
         `verification-status.json file. If this is an AC-driven feature, ` +
-        `create a verification-status entry and run /verify-workflow before finishing.`
+        `create a verification-status entry and run /verify-workflow before finishing.\n\n` +
+        `NOTE: For patch/hotfix branches without ACs, this reminder can be ignored.`
     );
   }
 
@@ -108,7 +109,8 @@ function main(input) {
     block(
       `REMINDER: Branch '${branch}' has uncommitted source changes but no ` +
         `workflow entry in verification-status.json. If this is an AC-driven ` +
-        `feature, register the branch and run /verify-workflow before finishing.`
+        `feature, register the branch and run /verify-workflow before finishing.\n\n` +
+        `NOTE: For patch/hotfix branches without ACs, this reminder can be ignored.`
     );
   }
 

--- a/.claude/skills/verify-workflow/SKILL.md
+++ b/.claude/skills/verify-workflow/SKILL.md
@@ -7,6 +7,8 @@ description: Full verification workflow automation - precheck, tests, UI verific
 
 Orchestrates the full autonomous feature development loop — from implementation through verification — with sub-agent delegation and human-in-the-loop review gates.
 
+**IMPORTANT:** Verification is NOT optional for AC-driven features. Once implementation is complete and status is `pending`, you MUST run the verification loop. Do not ask the user "should I verify?" — just proceed with verification.
+
 See `docs/AGENTIC-WORKFLOW.md` for the complete architecture document.
 
 ## Purpose

--- a/docs/AGENTIC-WORKFLOW.md
+++ b/docs/AGENTIC-WORKFLOW.md
@@ -283,11 +283,18 @@ Main thread reads both reports when complete                           ─┘
 - Same flow, but AC-UI section is empty
 - Sub-agent only runs code review + tests
 
-# Urgent fix (skip formal verification)
-- Implement fix
-- Manually set verification-status to "verified" with notes explaining why
-- Commit → PR → merge → /release
 ```
+
+## Emergency Override (Human Authorization Required)
+
+For critical hotfixes where the full verification loop would cause unacceptable delay:
+
+1. **Get explicit human approval** to skip verification
+2. Implement the fix
+3. Manually set verification-status to `"verified"` with notes: `"EMERGENCY: {reason}, authorized by {human}"`
+4. Commit → PR → merge → /release
+
+This is a last-resort escape hatch, NOT a convenience shortcut. If Claude suggests this path, the human must explicitly authorize it.
 
 ## Process Loop & State Machine
 


### PR DESCRIPTION
## Summary
- Remove "optional" language from MEMORY.md verification triggering section — now says MANDATORY
- Move "urgent fix" shortcut from Quick Reference into separate **Emergency Override** section with human authorization requirement
- Add clarifying NOTE to stop hook reminders so non-AC branches know to ignore
- Add mandate language to verify-workflow SKILL.md — Claude must not ask "should I verify?"

## Test plan
- [ ] Read updated MEMORY.md — no "optional" in verification context
- [ ] Read AGENTIC-WORKFLOW.md — urgent fix in separate Emergency Override section
- [ ] Read verify-before-stop-node.js — both reminders have clarifying NOTE
- [ ] Read verify-workflow SKILL.md — mandate paragraph present
- [ ] New session on AC-driven branch — Claude proceeds with verification without asking

🤖 Generated with [Claude Code](https://claude.com/claude-code)