### PR TITLE
chore: bump version to 0.88.8 for Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.88.7",
+  "version": "0.88.8",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Bump package.json version to 0.88.8 to match git tag v0.88.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)