### PR TITLE
perf: optimize PageSpeed mobile score (61 → 75+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.88.9 - 2026-02-15
+
+### Changed
+
+- **Skeleton loading for featured products**: Replace "Loading coffees..." text with skeleton cards matching carousel dimensions to eliminate CLS
+- **Lazy-load AI components**: Defer ChatBarista and VoiceBarista with `next/dynamic` to reduce initial JS by ~84 KiB
+- **Unify motion imports**: Consolidate `framer-motion` → `motion/react` to deduplicate bundle
+- **Add browserslist config**: Target modern browsers only, eliminating ~24 KiB of legacy polyfills
+- **GA4 scripts deferred to idle**: Switch from `afterInteractive` to `lazyOnload` to reduce TBT
+- **Accurate image sizes attributes**: Context-specific `sizes` prop on ProductCard for carousel and grid layouts, reducing downloaded image sizes by ~30-40%
+
 ## 0.88.7 - 2026-02-14
 
 ### Added

--- a/app/(site)/_components/category/CategoryClientPage.tsx
+++ b/app/(site)/_components/category/CategoryClientPage.tsx
@@ -63,6 +63,7 @@ export default function CategoryClientPage({
                 product={product}
                 showPurchaseOptions={showPurchaseOptions}
                 categorySlug={categorySlug}
+                sizes="(max-width: 768px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 2rem), 400px"
               />
             </motion.div>
           ))}

--- a/app/(site)/_components/content/animated-sections.tsx
+++ b/app/(site)/_components/content/animated-sections.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type ReactNode, useEffect, useState } from "react";
-import { motion } from "framer-motion";
+import { motion } from "motion/react";
 
 export function ScrollReveal({
   children,

--- a/app/(site)/_components/product/FeaturedProducts.tsx
+++ b/app/(site)/_components/product/FeaturedProducts.tsx
@@ -44,7 +44,24 @@ export default function FeaturedProducts() {
         </h2>
 
         {isLoading ? (
-          <div className="text-center text-text-muted">Loading coffees...</div>
+          <div className="[--slide-size:66.67%] md:[--slide-size:40%] lg:[--slide-size:28.57%]">
+            <div className="flex gap-4 overflow-hidden">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="shrink-0"
+                  style={{ minWidth: "var(--slide-size)" }}
+                >
+                  <div className="aspect-square bg-muted animate-pulse rounded-t-lg" />
+                  <div className="border-x border-b rounded-b-lg p-4 space-y-3">
+                    <div className="h-5 bg-muted animate-pulse rounded w-3/4" />
+                    <div className="h-3 bg-muted animate-pulse rounded w-1/2" />
+                    <div className="h-3 bg-muted animate-pulse rounded w-2/3" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
         ) : (
           <div className="[--slide-size:66.67%] md:[--slide-size:40%] lg:[--slide-size:28.57%]">
           <ScrollCarousel
@@ -66,6 +83,7 @@ export default function FeaturedProducts() {
                   hoverRevealFooter={true}
                   compact={true}
                   priority={index < 4}
+                  sizes="(max-width: 768px) 67vw, (max-width: 1200px) 40vw, 29vw"
                 />
               </motion.div>
             ))}

--- a/app/(site)/_components/product/ProductCard.tsx
+++ b/app/(site)/_components/product/ProductCard.tsx
@@ -32,6 +32,7 @@ export default function ProductCard({
   hidePriceOnMobile = false,
   hoverRevealFooter = false,
   compact = false,
+  sizes = "(max-width: 768px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 2rem), 400px",
 }: Omit<ProductCardProps, "onAddToCart"> & {
   categorySlug?: string;
   priority?: boolean;
@@ -42,6 +43,8 @@ export default function ProductCard({
   hoverRevealFooter?: boolean;
   /** Smaller title and notes for carousel contexts */
   compact?: boolean;
+  /** Custom sizes attribute for responsive image loading */
+  sizes?: string;
 }) {
   const { buttonState, isCheckingOut, handleAddToCart, handleActionClick } =
     useAddToCartWithFeedback();
@@ -115,7 +118,7 @@ export default function ProductCard({
             alt={altText}
             fill
             className="object-cover"
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            sizes={sizes}
             priority={priority || product.isFeatured}
           />
         </CardHeader>

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,11 +1,19 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useSession } from "next-auth/react";
 import { motion } from "motion/react";
 import FeaturedProducts from "@/app/(site)/_components/product/FeaturedProducts";
 import RecommendationsSection from "@/app/(site)/_components/product/RecommendationsSection";
-import ChatBarista from "@/app/(site)/_components/ai/ChatBarista";
-import VoiceBarista from "@/app/(site)/_components/ai/VoiceBarista";
+
+const ChatBarista = dynamic(
+  () => import("@/app/(site)/_components/ai/ChatBarista"),
+  { ssr: false }
+);
+const VoiceBarista = dynamic(
+  () => import("@/app/(site)/_components/ai/VoiceBarista"),
+  { ssr: false }
+);
 
 const fadeInUp = {
   initial: { opacity: 0, y: 24 },

--- a/components/shared/GoogleAnalytics.tsx
+++ b/components/shared/GoogleAnalytics.tsx
@@ -11,9 +11,9 @@ export function GoogleAnalytics() {
     <>
       <Script
         src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
-        strategy="afterInteractive"
+        strategy="lazyOnload"
       />
-      <Script id="google-analytics" strategy="afterInteractive">
+      <Script id="google-analytics" strategy="lazyOnload">
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}

--- a/components/shared/media/CarouselDots.tsx
+++ b/components/shared/media/CarouselDots.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { motion } from "framer-motion";
+import { motion } from "motion/react";
 
 interface CarouselDotsProps {
   total: number;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.88.8",
+  "version": "0.88.9",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -131,6 +131,9 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
   },
+  "browserslist": [
+    "defaults and fully supports es6-module"
+  ],
   "engines": {
     "node": ">=24.0.0",
     "npm": ">=10.0.0"


### PR DESCRIPTION
## Summary
- **Skeleton loading** for FeaturedProducts carousel — eliminates CLS from "Loading coffees..." text swap
- **Lazy-load ChatBarista/VoiceBarista** via `next/dynamic` — defers ~84 KiB from initial bundle
- **Unify motion imports** — `framer-motion` → `motion/react` to deduplicate bundle entry points
- **Add browserslist** — targets modern browsers, eliminating ~24 KiB legacy polyfills
- **GA4 → lazyOnload** — defers analytics scripts until browser idle, reducing TBT
- **Accurate image `sizes`** — context-specific sizes for carousel (67vw/40vw/29vw) and grid layouts, serving ~30-40% smaller images

## Test plan
- [x] `npm run precheck` — TypeScript + ESLint clean
- [x] `npm run test:ci` — 756/756 tests passing
- [ ] Deploy to Vercel preview → re-run PageSpeed Insights on mobile
- [ ] Confirm GA4 still fires (check Real-Time in GA4 dashboard)
- [ ] Target: mobile score 73-83 (from 61)