### PR TITLE
perf: server-side data fetching for homepage LCP

### DIFF
--- a/app/(site)/_components/ai/HomeAiSection.tsx
+++ b/app/(site)/_components/ai/HomeAiSection.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { motion } from "motion/react";
+
+const ChatBarista = dynamic(
+  () => import("@/app/(site)/_components/ai/ChatBarista"),
+  { ssr: false }
+);
+const VoiceBarista = dynamic(
+  () => import("@/app/(site)/_components/ai/VoiceBarista"),
+  { ssr: false }
+);
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 24 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, margin: "-60px" },
+  transition: { duration: 0.5, ease: "easeOut" as const },
+};
+
+interface HomeAiSectionProps {
+  showVoiceBarista: boolean;
+  userEmail?: string;
+  userName?: string;
+  isAuthenticated: boolean;
+}
+
+export default function HomeAiSection({
+  showVoiceBarista,
+  userEmail,
+  userName,
+  isAuthenticated,
+}: HomeAiSectionProps) {
+  return (
+    <motion.div {...fadeInUp}>
+      {showVoiceBarista ? (
+        <VoiceBarista userEmail={userEmail} />
+      ) : (
+        <ChatBarista userName={userName} isAuthenticated={isAuthenticated} />
+      )}
+    </motion.div>
+  );
+}

--- a/app/(site)/_components/product/FeaturedProducts.tsx
+++ b/app/(site)/_components/product/FeaturedProducts.tsx
@@ -1,69 +1,28 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { motion } from "motion/react";
 import { FeaturedProduct } from "@/lib/types";
 import ProductCard from "@/app/(site)/_components/product/ProductCard";
 import { ScrollCarousel } from "@/components/shared/media/ScrollCarousel";
-import { useSiteSettings } from "@/hooks/useSiteSettings";
 
-// This component is now self-contained. It fetches its own data.
-// Changed from arrow function to function declaration
-export default function FeaturedProducts() {
-  const { settings } = useSiteSettings();
-  const [products, setProducts] = useState<FeaturedProduct[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+interface FeaturedProductsProps {
+  products: FeaturedProduct[];
+  heading: string;
+}
 
-  // Fetch data from our API on component mount
-  useEffect(() => {
-    const fetchProducts = async () => {
-      try {
-        setIsLoading(true);
-        const response = await fetch("/api/products/featured");
-        if (!response.ok) {
-          throw new Error("Failed to fetch products");
-        }
-        const data: FeaturedProduct[] = await response.json();
-        setProducts(data);
-      } catch (error) {
-        console.error(error);
-        // You could set an error state here
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchProducts();
-  }, []); // Empty dependency array means this runs once on mount
-
+export default function FeaturedProducts({
+  products,
+  heading,
+}: FeaturedProductsProps) {
   return (
     <section className="py-16">
       <div className="mx-auto max-w-screen-2xl px-4 md:px-8">
         <h2 className="text-3xl font-bold text-center text-text-base mb-12">
-          {settings.homepageFeaturedHeading}
+          {heading}
         </h2>
 
-        {isLoading ? (
-          <div className="[--slide-size:66.67%] md:[--slide-size:40%] lg:[--slide-size:28.57%]">
-            <div className="flex gap-4 overflow-hidden">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="shrink-0"
-                  style={{ minWidth: "var(--slide-size)" }}
-                >
-                  <div className="aspect-square bg-muted animate-pulse rounded-t-lg" />
-                  <div className="border-x border-b rounded-b-lg p-4 space-y-3">
-                    <div className="h-5 bg-muted animate-pulse rounded w-3/4" />
-                    <div className="h-3 bg-muted animate-pulse rounded w-1/2" />
-                    <div className="h-3 bg-muted animate-pulse rounded w-2/3" />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        ) : (
-          <div className="[--slide-size:66.67%] md:[--slide-size:40%] lg:[--slide-size:28.57%]">
+        <div className="[--slide-size:66.67%] md:[--slide-size:40%] lg:[--slide-size:28.57%]">
           <ScrollCarousel
             showDots={true}
             noBorder={true}
@@ -75,7 +34,11 @@ export default function FeaturedProducts() {
                 initial={{ opacity: 0, y: 20 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.3 }}
-                transition={{ duration: 0.4, ease: "easeOut", delay: index * 0.08 }}
+                transition={{
+                  duration: 0.4,
+                  ease: "easeOut",
+                  delay: index * 0.08,
+                }}
               >
                 <ProductCard
                   product={product}
@@ -88,8 +51,7 @@ export default function FeaturedProducts() {
               </motion.div>
             ))}
           </ScrollCarousel>
-          </div>
-        )}
+        </div>
       </div>
     </section>
   );

--- a/app/api/recommendations/route.ts
+++ b/app/api/recommendations/route.ts
@@ -1,18 +1,6 @@
 import { NextResponse } from "next/server";
-import { ProductType } from "@prisma/client";
 import { auth } from "@/auth";
-import { getUserRecommendationContext, getTrendingProducts } from "@/lib/data";
-import { prisma } from "@/lib/prisma";
-
-// RecommendationProduct interface matches the type returned from Prisma queries
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-interface RecommendationProduct {
-  id: string;
-  name: string;
-  slug: string;
-  tastingNotes: string[];
-  reasoning?: string;
-}
+import { getHomeRecommendations } from "@/lib/data";
 
 /**
  * API endpoint for personalized product recommendations.
@@ -22,178 +10,30 @@ export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const limit = parseInt(searchParams.get("limit") || "6");
-    const excludeId = searchParams.get("exclude"); // Optional product ID to exclude
+    const excludeId = searchParams.get("exclude") || undefined;
 
-    // Check for authenticated user
     const session = await auth();
     const userId = session?.user?.id;
 
-    if (!userId) {
-      // Anonymous user - return trending products
-      const trending = await getTrendingProducts(limit + 1, 7);
-      const filtered = trending.filter((p) => !excludeId || p!.id !== excludeId).slice(0, limit);
-      return NextResponse.json({
-        products: filtered.map((p) => ({
-          id: p!.id,
-          name: p!.name,
-          slug: p!.slug,
-          type: p!.type,
-          roastLevel: p!.roastLevel,
-          isFeatured: p!.isFeatured,
-          tastingNotes: p!.tastingNotes,
-          variants: p!.variants,
-          categories: p!.categories,
-        })),
-        isPersonalized: false,
-        source: "trending",
-      });
-    }
-
-    // Authenticated user - try to get personalized recommendations
-    // Fall back to trending if personalization fails
-    let userContext;
-    try {
-      userContext = await getUserRecommendationContext(userId);
-    } catch (contextError) {
-      console.warn("Failed to get user context, falling back to trending:", contextError);
-      const trending = await getTrendingProducts(limit + 1, 7);
-      const filtered = trending.filter((p) => !excludeId || p!.id !== excludeId).slice(0, limit);
-      return NextResponse.json({
-        products: filtered.map((p) => ({
-          id: p!.id,
-          name: p!.name,
-          slug: p!.slug,
-          type: p!.type,
-          roastLevel: p!.roastLevel,
-          isFeatured: p!.isFeatured,
-          tastingNotes: p!.tastingNotes,
-          variants: p!.variants,
-          categories: p!.categories,
-        })),
-        isPersonalized: false,
-        source: "trending",
-      });
-    }
-
-    // Check if user has enough history for personalization
-    const hasHistory =
-      userContext.purchaseHistory.totalOrders > 0 ||
-      userContext.recentViews.length > 0;
-
-    if (!hasHistory) {
-      // New user - return trending products
-      const trending = await getTrendingProducts(limit + 1, 7);
-      const filtered = trending.filter((p) => !excludeId || p!.id !== excludeId).slice(0, limit);
-      return NextResponse.json({
-        products: filtered.map((p) => ({
-          id: p!.id,
-          name: p!.name,
-          slug: p!.slug,
-          type: p!.type,
-          roastLevel: p!.roastLevel,
-          isFeatured: p!.isFeatured,
-          tastingNotes: p!.tastingNotes,
-          variants: p!.variants,
-          categories: p!.categories,
-        })),
-        isPersonalized: false,
-        source: "trending",
-      });
-    }
-
-    // Get products they haven't ordered recently
-    const purchasedProductIds = userContext.purchaseHistory.products.map(
-      (p: { name: string }) => p.name
-    );
-    const recentlyViewedIds = userContext.recentViews.map((v) => v.name);
-
-    // Fetch all products (excluding the specified product if provided)
-    const allProducts = await prisma.product.findMany({
-      where: {
-        type: ProductType.COFFEE,
-        isDisabled: false,
-        ...(excludeId && { id: { not: excludeId } }),
-      },
-      include: {
-        variants: {
-          orderBy: { order: "asc" },
-          include: {
-            images: {
-              orderBy: { order: "asc" },
-              take: 1,
-            },
-            purchaseOptions: {
-              where: { type: "ONE_TIME" },
-              take: 1,
-            },
-          },
-        },
-        categories: {
-          where: { isPrimary: true },
-          include: {
-            category: {
-              select: {
-                slug: true,
-              },
-            },
-          },
-        },
-      },
-    });
-
-    // Score products based on user preferences
-    const scoredProducts = allProducts.map((product) => {
-      let score = 0;
-
-      // Match tasting notes with user's top preferences
-      const matchingNotes = product.tastingNotes.filter((note) =>
-        userContext.purchaseHistory.topTastingNotes.includes(note)
-      );
-      score += matchingNotes.length * 5;
-
-      // Slightly prefer products they've viewed but not purchased
-      if (
-        recentlyViewedIds.includes(product.name) &&
-        !purchasedProductIds.includes(product.name)
-      ) {
-        score += 3;
-      }
-
-      // Penalize recently purchased products (avoid repetition)
-      if (purchasedProductIds.slice(0, 3).includes(product.name)) {
-        score -= 20;
-      }
-
-      return { product, score };
-    });
-
-    // Sort by score and take top recommendations
-    const recommendations = scoredProducts
-      .sort((a, b) => b.score - a.score)
-      .slice(0, limit)
-      .map(({ product }) => ({
-        id: product.id,
-        name: product.name,
-        slug: product.slug,
-        type: product.type,
-        roastLevel: product.roastLevel,
-        isFeatured: product.isFeatured,
-        tastingNotes: product.tastingNotes,
-        variants: product.variants,
-        categories: product.categories,
-      }));
+    const result = await getHomeRecommendations(userId, limit, excludeId);
 
     return NextResponse.json({
-      products: recommendations,
-      isPersonalized: true,
-      source: "behavioral",
-      userPreferences: {
-        preferredRoastLevel: userContext.purchaseHistory.preferredRoastLevel,
-        topTastingNotes: userContext.purchaseHistory.topTastingNotes.slice(
-          0,
-          3
-        ),
-      },
+      products: result.products.map((p) => ({
+        id: p.id,
+        name: p.name,
+        slug: p.slug,
+        type: p.type,
+        roastLevel: p.roastLevel,
+        isFeatured: p.isFeatured,
+        tastingNotes: p.tastingNotes,
+        variants: p.variants,
+        categories: p.categories,
+      })),
+      isPersonalized: result.isPersonalized,
+      source: result.source,
+      ...(result.userPreferences && {
+        userPreferences: result.userPreferences,
+      }),
     });
   } catch (error) {
     console.error("Recommendations API Error:", error);

--- a/hooks/useSiteSettings.ts
+++ b/hooks/useSiteSettings.ts
@@ -1,48 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import {
+  type SiteSettings,
+  defaultSettings,
+  mapSettingsRecord,
+} from "@/lib/site-settings";
 
-export interface SiteSettings {
-  storeName: string;
-  storeTagline: string;
-  storeDescription: string;
-  storeLogoUrl: string;
-  contactEmail: string;
-  // Marketing Content
-  homepageFeaturedHeading: string;
-  homepageRecommendationsTrendingHeading: string;
-  homepageRecommendationsTrendingDescription: string;
-  homepageRecommendationsPersonalizedHeading: string;
-  homepageRecommendationsExploreAllText: string;
-  footerCategoriesHeading: string;
-  footerQuickLinksHeading: string;
-  productRelatedHeading: string;
-  // Add-ons Section Titles
-  productAddOnsSectionTitle: string;
-  cartAddOnsSectionTitle: string;
-}
-
-const defaultSettings: SiteSettings = {
-  storeName: "Artisan Roast",
-  storeTagline: "Specialty coffee sourced from the world's finest origins.",
-  storeDescription:
-    "Premium specialty coffee, carefully roasted to perfection. From single-origin beans to signature blends, discover exceptional coffee delivered to your door.",
-  storeLogoUrl: "/logo.svg",
-  contactEmail: "hello@artisan-roast.com",
-  // Marketing Content defaults
-  homepageFeaturedHeading: "Our Small Batch Collection",
-  homepageRecommendationsTrendingHeading: "Trending Now",
-  homepageRecommendationsTrendingDescription:
-    "Discover what other coffee lovers are enjoying",
-  homepageRecommendationsPersonalizedHeading: "Recommended For You",
-  homepageRecommendationsExploreAllText: "Explore All Coffees",
-  footerCategoriesHeading: "Coffee Selection",
-  footerQuickLinksHeading: "Quick Links",
-  productRelatedHeading: "You Might Also Like",
-  // Add-ons defaults
-  productAddOnsSectionTitle: "Save on a Bundle",
-  cartAddOnsSectionTitle: "You May Also Like",
-};
+// Re-export for consumers that import from this module
+export type { SiteSettings };
+export { defaultSettings };
 
 // Cache for settings to avoid repeated fetches
 let cachedSettings: SiteSettings | null = null;
@@ -62,45 +29,7 @@ async function fetchSettings(): Promise<SiteSettings> {
       return res.json();
     })
     .then((data) => {
-      cachedSettings = {
-        storeName: data.store_name || defaultSettings.storeName,
-        storeTagline: data.store_tagline || defaultSettings.storeTagline,
-        storeDescription:
-          data.store_description || defaultSettings.storeDescription,
-        storeLogoUrl: data.store_logo_url || defaultSettings.storeLogoUrl,
-        contactEmail: data.contactEmail || defaultSettings.contactEmail,
-        // Marketing Content
-        homepageFeaturedHeading:
-          data.homepage_featured_heading ||
-          defaultSettings.homepageFeaturedHeading,
-        homepageRecommendationsTrendingHeading:
-          data.homepage_recommendations_trending_heading ||
-          defaultSettings.homepageRecommendationsTrendingHeading,
-        homepageRecommendationsTrendingDescription:
-          data.homepage_recommendations_trending_description ||
-          defaultSettings.homepageRecommendationsTrendingDescription,
-        homepageRecommendationsPersonalizedHeading:
-          data.homepage_recommendations_personalized_heading ||
-          defaultSettings.homepageRecommendationsPersonalizedHeading,
-        homepageRecommendationsExploreAllText:
-          data.homepage_recommendations_explore_all_text ||
-          defaultSettings.homepageRecommendationsExploreAllText,
-        footerCategoriesHeading:
-          data.footer_categories_heading ||
-          defaultSettings.footerCategoriesHeading,
-        footerQuickLinksHeading:
-          data.footer_quick_links_heading ||
-          defaultSettings.footerQuickLinksHeading,
-        productRelatedHeading:
-          data.product_related_heading || defaultSettings.productRelatedHeading,
-        // Add-ons Section Titles
-        productAddOnsSectionTitle:
-          data.product_addons_section_title ||
-          defaultSettings.productAddOnsSectionTitle,
-        cartAddOnsSectionTitle:
-          data.cart_addons_section_title ||
-          defaultSettings.cartAddOnsSectionTitle,
-      };
+      cachedSettings = mapSettingsRecord(data);
       fetchPromise = null; // Clear promise after successful fetch
       return cachedSettings;
     })

--- a/lib/site-settings.ts
+++ b/lib/site-settings.ts
@@ -1,0 +1,84 @@
+export interface SiteSettings {
+  storeName: string;
+  storeTagline: string;
+  storeDescription: string;
+  storeLogoUrl: string;
+  contactEmail: string;
+  // Marketing Content
+  homepageFeaturedHeading: string;
+  homepageRecommendationsTrendingHeading: string;
+  homepageRecommendationsTrendingDescription: string;
+  homepageRecommendationsPersonalizedHeading: string;
+  homepageRecommendationsExploreAllText: string;
+  footerCategoriesHeading: string;
+  footerQuickLinksHeading: string;
+  productRelatedHeading: string;
+  // Add-ons Section Titles
+  productAddOnsSectionTitle: string;
+  cartAddOnsSectionTitle: string;
+}
+
+export const defaultSettings: SiteSettings = {
+  storeName: "Artisan Roast",
+  storeTagline: "Specialty coffee sourced from the world's finest origins.",
+  storeDescription:
+    "Premium specialty coffee, carefully roasted to perfection. From single-origin beans to signature blends, discover exceptional coffee delivered to your door.",
+  storeLogoUrl: "/logo.svg",
+  contactEmail: "hello@artisan-roast.com",
+  // Marketing Content defaults
+  homepageFeaturedHeading: "Our Small Batch Collection",
+  homepageRecommendationsTrendingHeading: "Trending Now",
+  homepageRecommendationsTrendingDescription:
+    "Discover what other coffee lovers are enjoying",
+  homepageRecommendationsPersonalizedHeading: "Recommended For You",
+  homepageRecommendationsExploreAllText: "Explore All Coffees",
+  footerCategoriesHeading: "Coffee Selection",
+  footerQuickLinksHeading: "Quick Links",
+  productRelatedHeading: "You Might Also Like",
+  // Add-ons defaults
+  productAddOnsSectionTitle: "Save on a Bundle",
+  cartAddOnsSectionTitle: "You May Also Like",
+};
+
+/** Maps a DB key-value record to a SiteSettings object with defaults */
+export function mapSettingsRecord(
+  record: Record<string, string>
+): SiteSettings {
+  return {
+    storeName: record.store_name || defaultSettings.storeName,
+    storeTagline: record.store_tagline || defaultSettings.storeTagline,
+    storeDescription:
+      record.store_description || defaultSettings.storeDescription,
+    storeLogoUrl: record.store_logo_url || defaultSettings.storeLogoUrl,
+    contactEmail: record.contactEmail || defaultSettings.contactEmail,
+    homepageFeaturedHeading:
+      record.homepage_featured_heading ||
+      defaultSettings.homepageFeaturedHeading,
+    homepageRecommendationsTrendingHeading:
+      record.homepage_recommendations_trending_heading ||
+      defaultSettings.homepageRecommendationsTrendingHeading,
+    homepageRecommendationsTrendingDescription:
+      record.homepage_recommendations_trending_description ||
+      defaultSettings.homepageRecommendationsTrendingDescription,
+    homepageRecommendationsPersonalizedHeading:
+      record.homepage_recommendations_personalized_heading ||
+      defaultSettings.homepageRecommendationsPersonalizedHeading,
+    homepageRecommendationsExploreAllText:
+      record.homepage_recommendations_explore_all_text ||
+      defaultSettings.homepageRecommendationsExploreAllText,
+    footerCategoriesHeading:
+      record.footer_categories_heading ||
+      defaultSettings.footerCategoriesHeading,
+    footerQuickLinksHeading:
+      record.footer_quick_links_heading ||
+      defaultSettings.footerQuickLinksHeading,
+    productRelatedHeading:
+      record.product_related_heading || defaultSettings.productRelatedHeading,
+    productAddOnsSectionTitle:
+      record.product_addons_section_title ||
+      defaultSettings.productAddOnsSectionTitle,
+    cartAddOnsSectionTitle:
+      record.cart_addons_section_title ||
+      defaultSettings.cartAddOnsSectionTitle,
+  };
+}


### PR DESCRIPTION
## Summary
- Convert homepage from client-side `useEffect` fetch waterfall to server-side data fetching via `Promise.all`
- Extract `getPublicSiteSettings()` and `getHomeRecommendations()` into `lib/data.ts` for direct DB access
- Product image URLs now ship in initial HTML, eliminating ~1,800ms LCP resource load delay

## Test plan
- [x] `npm run precheck` — TypeScript + ESLint clean
- [x] `npm run test:ci` — 756/756 tests pass
- [ ] Visually confirm homepage renders correctly (recommendations + featured products)
- [ ] Deploy to Vercel preview → re-run PageSpeed Insights on mobile