### PR TITLE
feat: sign-in redirect, banner ticker, and hero text fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.88.13 - 2026-02-15
+
+### Added
+
+- **Demo banner ticker animation**: CTA cycles between "Try Admin Dashboard" and "See User Account" with a slide-up ticker effect
+- **Sign-in redirect**: Mobile menu sign-in button returns users to the page they were on after authentication
+
+### Changed
+
+- **Mobile menu**: Replace "Close" button with "Sign In" link for unauthenticated users; swap Account icon to CircleUserRound; remove Contact shortcut
+
+### Fixed
+
+- **Auth callback URL handling**: NextAuth redirect callback now properly honors relative and same-origin callback URLs
+
 ## 0.88.12 - 2026-02-15
 
 ### Added

--- a/app/(site)/_components/content/DemoBanner.tsx
+++ b/app/(site)/_components/content/DemoBanner.tsx
@@ -4,15 +4,50 @@ import { cn } from "@/lib/utils";
 import { ArrowRight, X, Zap } from "lucide-react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const CTA_OPTIONS = [
+  "Try Admin Dashboard",
+  "See User Account",
+] as const;
+
+type Phase = "idle" | "exit" | "enter";
 
 /**
  * Demo banner that invites users to try the admin dashboard.
  * Only renders when NEXT_PUBLIC_DEMO_MODE env var is set to "true" and user is not logged in.
+ * CTA text cycles with a slide-up ticker animation.
  */
 export function DemoBanner() {
   const { data: session } = useSession();
   const [isDismissed, setIsDismissed] = useState(false);
+  const [ctaIndex, setCtaIndex] = useState(0);
+  const [phase, setPhase] = useState<Phase>("idle");
+  const rafRef = useRef(0);
+
+  const cycle = useCallback(() => {
+    // Phase 1: slide current text up and out
+    setPhase("exit");
+
+    setTimeout(() => {
+      // Swap text, position below
+      setCtaIndex((i) => (i + 1) % CTA_OPTIONS.length);
+      setPhase("enter");
+
+      // Next frame: slide new text up into place
+      rafRef.current = requestAnimationFrame(() => {
+        setPhase("idle");
+      });
+    }, 300);
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(cycle, 4000);
+    return () => {
+      clearInterval(interval);
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [cycle]);
 
   // Only show in demo mode when not logged in
   if (process.env.NEXT_PUBLIC_DEMO_MODE !== "true" || isDismissed || session?.user) {
@@ -30,10 +65,25 @@ export function DemoBanner() {
         <span className="hidden sm:inline text-white/80">No signup required.</span>
         <Link
           href="/auth/signin"
-          className="font-semibold underline underline-offset-2 hover:no-underline"
+          className="font-semibold underline underline-offset-2 hover:no-underline inline-flex items-center"
         >
-          Try Admin Dashboard
-          <ArrowRight className="h-4 w-4 inline-block ml-1" aria-hidden="true" />
+          <span className="relative inline-flex overflow-hidden">
+            {/* Invisible sizer — reserves width of longest option */}
+            <span className="invisible" aria-hidden="true">
+              {CTA_OPTIONS.reduce((a, b) => (a.length >= b.length ? a : b))}
+            </span>
+            <span
+              className={cn(
+                "absolute inset-0 flex items-center justify-end",
+                phase === "idle" && "translate-y-0 transition-transform duration-300 ease-out",
+                phase === "exit" && "-translate-y-full transition-transform duration-300 ease-in",
+                phase === "enter" && "translate-y-full"
+              )}
+            >
+              {CTA_OPTIONS[ctaIndex]}
+            </span>
+          </span>
+          <ArrowRight className="h-4 w-4 ml-1 shrink-0" aria-hidden="true" />
         </Link>
         <button
           onClick={() => setIsDismissed(true)}

--- a/app/(site)/_components/layout/SiteHeader.tsx
+++ b/app/(site)/_components/layout/SiteHeader.tsx
@@ -40,7 +40,7 @@ import {
 import { useNavOverflow } from "@/hooks/useNavOverflow";
 import { useSiteSettings } from "@/hooks/useSiteSettings";
 import { cn } from "@/lib/utils";
-import { ChevronDown, FileText, Home, LogOut, Mail, Menu, MoreHorizontal, PackageSearch, Search, User } from "lucide-react";
+import { ChevronDown, CircleUserRound, FileText, Home, LogIn, LogOut, Menu, MoreHorizontal, PackageSearch, Search, User } from "lucide-react";
 import { signOut } from "next-auth/react";
 import Image from "next/image";
 import Link from "next/link";
@@ -295,20 +295,9 @@ export default function SiteHeader({
                           href="/account"
                           className="inline-flex flex-1 flex-col items-center justify-center gap-1 py-2 rounded-md text-foreground hover:text-primary hover:bg-accent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                         >
-                          <User className="w-5 h-5" />
+                          <CircleUserRound className="w-5 h-5" />
                           <span className="text-[10px] uppercase tracking-wide font-medium">
                             Account
-                          </span>
-                        </Link>
-                      </SheetClose>
-                      <SheetClose asChild>
-                        <Link
-                          href="/contact"
-                          className="inline-flex flex-1 flex-col items-center justify-center gap-1 py-2 rounded-md text-foreground hover:text-primary hover:bg-accent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                        >
-                          <Mail className="w-5 h-5" />
-                          <span className="text-[10px] uppercase tracking-wide font-medium">
-                            Contact
                           </span>
                         </Link>
                       </SheetClose>
@@ -393,8 +382,11 @@ export default function SiteHeader({
                       </SheetClose>
                     ) : (
                       <SheetClose asChild>
-                        <Button className="w-full" variant="secondary">
-                          Close
+                        <Button className="w-full" variant="secondary" asChild>
+                          <Link href={`/auth/signin?callbackUrl=${encodeURIComponent(pathname)}`}>
+                            <LogIn className="w-4 h-4 mr-2" />
+                            Sign In
+                          </Link>
                         </Button>
                       </SheetClose>
                     )}
@@ -505,7 +497,7 @@ export default function SiteHeader({
         <div className="order-2 md:order-1 flex-1 md:flex-none flex justify-center md:justify-start">
           <Link
             href="/"
-            className="flex flex-col md:flex-row items-center gap-1 md:gap-2 text-primary"
+            className="flex flex-col md:flex-row items-center gap-1 md:gap-2 text-foreground"
           >
             <Image
               src={settings.storeLogoUrl}

--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -46,7 +46,7 @@ export default async function AboutPage() {
         <div className="relative container mx-auto px-4 py-16 md:py-24">
           <ScrollReveal>
             <div className="mx-auto max-w-3xl text-center">
-              <h1 className="mb-4 text-3xl font-bold tracking-tight text-black md:text-5xl">
+              <h1 className="mb-4 text-3xl font-bold tracking-tight text-foreground md:text-5xl">
                 About{" "}
 {storeName}
               </h1>

--- a/app/(site)/features/page.tsx
+++ b/app/(site)/features/page.tsx
@@ -228,7 +228,7 @@ export default function FeaturesPage() {
         <div className="relative container mx-auto px-4 py-16 md:py-24">
           <ScrollReveal>
             <div className="mx-auto max-w-3xl text-center">
-              <h1 className="mb-4 text-3xl font-bold tracking-tight text-black md:text-5xl">
+              <h1 className="mb-4 text-3xl font-bold tracking-tight text-foreground md:text-5xl">
                 Built for Specialty Coffee.
                 <br />
                 Powered by Modern Tech.

--- a/auth.ts
+++ b/auth.ts
@@ -67,6 +67,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     signIn: "/auth/signin",
   },
   callbacks: {
+    async redirect({ url, baseUrl }) {
+      // Allow relative callback URLs (e.g. "/", "/products/foo")
+      if (url.startsWith("/")) return `${baseUrl}${url}`;
+      // Allow same-origin absolute URLs
+      if (new URL(url).origin === baseUrl) return url;
+      return baseUrl;
+    },
     async jwt({ token, user }) {
       // Add user ID to JWT token on sign in
       if (user) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.88.12",
+  "version": "0.88.13",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Add `redirect` callback in auth.ts so users return to the page they were on after signing in
- Replace mobile menu "Close" button with "Sign In" link (with `callbackUrl`) for unauthenticated users
- Change account icon from `User` to `CircleUserRound`
- Add split-flap ticker animation to DemoBanner cycling between "Try Admin Dashboard" and "See User Account"
- Fix store name color in SiteHeader (`text-primary` → `text-foreground`)
- Fix hero h1 color on Features and About pages (`text-black` → `text-foreground`) for dark mode compatibility

## Test plan
- [ ] Sign in from a product page → should redirect back to that product page
- [ ] Mobile: unauthenticated → see "Sign In" link in menu drawer
- [ ] Demo banner ticker cycles between two CTAs with smooth slide-up animation
- [ ] Store name in header renders correctly in both light and dark mode
- [ ] Features and About page hero text visible in dark mode