### PR TITLE
perf: remove homepage motion animations and optimize images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.88.14 - 2026-02-15
+
+### Changed
+
+- **Remove homepage motion animations**: Products and AI section render instantly from server HTML, eliminating 2.5s render delay (LCP) and layout shifts (CLS)
+- **Optimize image sizes**: Add 480px image size step to close the 384→640 gap, saving ~97 KiB across homepage images
+- **Tighten browserslist**: Target last 2 versions of modern browsers, eliminating ~13.7 KiB of unnecessary polyfills
+
+### Fixed
+
+- **Carousel dot touch targets**: Increase tap area to 48px minimum for mobile accessibility while keeping dots visually small
+
 ## 0.88.13 - 2026-02-15
 
 ### Added

--- a/app/(site)/_components/ai/HomeAiSection.tsx
+++ b/app/(site)/_components/ai/HomeAiSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { motion } from "motion/react";
 
 const ChatBarista = dynamic(
   () => import("@/app/(site)/_components/ai/ChatBarista"),
@@ -11,13 +10,6 @@ const VoiceBarista = dynamic(
   () => import("@/app/(site)/_components/ai/VoiceBarista"),
   { ssr: false }
 );
-
-const fadeInUp = {
-  initial: { opacity: 0, y: 24 },
-  whileInView: { opacity: 1, y: 0 },
-  viewport: { once: true, margin: "-60px" },
-  transition: { duration: 0.5, ease: "easeOut" as const },
-};
 
 interface HomeAiSectionProps {
   showVoiceBarista: boolean;
@@ -33,12 +25,12 @@ export default function HomeAiSection({
   isAuthenticated,
 }: HomeAiSectionProps) {
   return (
-    <motion.div {...fadeInUp}>
+    <>
       {showVoiceBarista ? (
         <VoiceBarista userEmail={userEmail} />
       ) : (
         <ChatBarista userName={userName} isAuthenticated={isAuthenticated} />
       )}
-    </motion.div>
+    </>
   );
 }

--- a/app/(site)/_components/product/FeaturedProducts.tsx
+++ b/app/(site)/_components/product/FeaturedProducts.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import React from "react";
-import { motion } from "motion/react";
 import { FeaturedProduct } from "@/lib/types";
 import ProductCard from "@/app/(site)/_components/product/ProductCard";
 import { ScrollCarousel } from "@/components/shared/media/ScrollCarousel";
@@ -29,17 +27,7 @@ export default function FeaturedProducts({
             minWidth="var(--slide-size)"
           >
             {products.map((product, index) => (
-              <motion.div
-                key={product.id}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, amount: 0.3 }}
-                transition={{
-                  duration: 0.4,
-                  ease: "easeOut",
-                  delay: index * 0.08,
-                }}
-              >
+              <div key={product.id}>
                 <ProductCard
                   product={product}
                   showPurchaseOptions={true}
@@ -48,7 +36,7 @@ export default function FeaturedProducts({
                   priority={index < 4}
                   sizes="(max-width: 768px) 67vw, (max-width: 1200px) 40vw, 29vw"
                 />
-              </motion.div>
+              </div>
             ))}
           </ScrollCarousel>
         </div>

--- a/app/(site)/_components/product/RecommendationsSection.tsx
+++ b/app/(site)/_components/product/RecommendationsSection.tsx
@@ -1,7 +1,4 @@
-"use client";
-
 import Link from "next/link";
-import { motion } from "motion/react";
 import ProductCard from "@/app/(site)/_components/product/ProductCard";
 import { FeaturedProduct } from "@/lib/types";
 import { Sparkles, TrendingUp } from "lucide-react";
@@ -77,20 +74,14 @@ export default function RecommendationsSection({
         {/* Product Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {products.map((product, index) => (
-            <motion.div
-              key={product.id}
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.3 }}
-              transition={{ duration: 0.4, ease: "easeOut", delay: index * 0.08 }}
-            >
+            <div key={product.id}>
               <ProductCard
                 product={product}
                 showPurchaseOptions={true}
                 hoverRevealFooter={true}
                 priority={index === 0}
               />
-            </motion.div>
+            </div>
           ))}
         </div>
 

--- a/components/shared/media/CarouselDots.tsx
+++ b/components/shared/media/CarouselDots.tsx
@@ -29,31 +29,32 @@ export function CarouselDots({
       )}
     >
       {Array.from({ length: total }).map((_, index) => (
-        <motion.button
+        <button
           key={index}
           onClick={() => onDotClick(index)}
-          animate={{
-            width: index === currentIndex ? "2rem" : "0.5rem",
-          }}
-          whileHover={{
-            opacity: 0.75,
-          }}
-          transition={{
-            duration: 0.3,
-            ease: "easeInOut",
-          }}
-          className={cn(
-            "h-2 rounded-full transition-colors",
-            noBorder
-              ? index === currentIndex
-                ? "bg-foreground"
-                : "bg-foreground/30"
-              : index === currentIndex
-                ? "bg-white"
-                : "bg-white/50"
-          )}
+          className="py-5 flex items-center"
           aria-label={`Go to slide ${index + 1}`}
-        />
+        >
+          <motion.span
+            animate={{
+              width: index === currentIndex ? "2rem" : "0.5rem",
+            }}
+            transition={{
+              duration: 0.3,
+              ease: "easeInOut",
+            }}
+            className={cn(
+              "h-2 rounded-full block transition-colors",
+              noBorder
+                ? index === currentIndex
+                  ? "bg-foreground"
+                  : "bg-foreground/30"
+                : index === currentIndex
+                  ? "bg-white"
+                  : "bg-white/50"
+            )}
+          />
+        </button>
       ))}
     </div>
   );

--- a/components/shared/media/__tests__/ScrollCarousel.test.tsx
+++ b/components/shared/media/__tests__/ScrollCarousel.test.tsx
@@ -15,6 +15,16 @@ jest.mock("framer-motion", () => ({
         </button>
       );
     }),
+    span: React.forwardRef<
+      HTMLSpanElement,
+      React.ComponentPropsWithoutRef<"span">
+    >(function MotionSpan({ children, className, ...props }, ref) {
+      return (
+        <span ref={ref} className={className} {...props}>
+          {children}
+        </span>
+      );
+    }),
   },
 }));
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -32,6 +32,7 @@ const nextConfig: NextConfig = {
   images: {
     // We must whitelist the domains we'll be using for our product images.
     // This is a security feature of Next.js Image Optimization.
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384, 480],
     dangerouslyAllowSVG: true,
     contentDispositionType: "attachment",
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.88.13",
+  "version": "0.88.14",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -133,7 +133,10 @@
     "typescript": "^5"
   },
   "browserslist": [
-    "defaults and fully supports es6-module"
+    "last 2 Chrome versions",
+    "last 2 Firefox versions",
+    "last 2 Safari versions",
+    "last 2 Edge versions"
   ],
   "engines": {
     "node": ">=24.0.0",


### PR DESCRIPTION
## Summary
- Remove `motion/react` animations from RecommendationsSection, FeaturedProducts, and HomeAiSection — products render instantly from server HTML, eliminating ~2.5s LCP render delay and CLS layout shifts
- Add 480px image size step in `next.config.ts` to close the 384→640 gap (~25% smaller per image, ~97 KiB saved)
- Tighten browserslist to last 2 versions of modern browsers, eliminating ~13.7 KiB of unnecessary polyfills
- Fix CarouselDots touch targets to meet 48px mobile minimum while keeping dots visually small

## Test plan
- [x] `npm run precheck` passes (TypeScript + ESLint)
- [x] `npm run test:ci` passes (756 tests, 63 suites)
- [ ] Visual check: homepage loads, products visible immediately, carousel works, dots are tappable
- [ ] Run Lighthouse mobile audit to confirm LCP/CLS improvements