### PR TITLE
fix: add loading skeleton to AI section to prevent CLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.88.14 - 2026-02-15
+## 0.88.15 - 2026-02-15
 
 ### Changed
 
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- **AI section layout shift**: Add loading skeleton to reserve space for dynamically imported ChatBarista/VoiceBarista, preventing CLS from content popping in after hydration
 - **Carousel dot touch targets**: Increase tap area to 48px minimum for mobile accessibility while keeping dots visually small
 
 ## 0.88.13 - 2026-02-15

--- a/app/(site)/_components/ai/HomeAiSection.tsx
+++ b/app/(site)/_components/ai/HomeAiSection.tsx
@@ -2,13 +2,34 @@
 
 import dynamic from "next/dynamic";
 
+function AiSectionSkeleton() {
+  return (
+    <div className="relative overflow-hidden border-b">
+      <div className="py-16 md:py-24">
+        <div className="mx-auto max-w-screen-2xl px-4 md:px-8">
+          <div className="max-w-3xl mx-auto text-center space-y-6">
+            <div className="h-10 md:h-12 bg-muted rounded-lg w-3/4 mx-auto animate-pulse" />
+            <div className="space-y-2">
+              <div className="h-5 bg-muted rounded w-5/6 mx-auto animate-pulse" />
+              <div className="h-5 bg-muted rounded w-2/3 mx-auto animate-pulse" />
+            </div>
+            <div className="flex justify-center">
+              <div className="h-14 w-40 bg-muted rounded-md animate-pulse" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 const ChatBarista = dynamic(
   () => import("@/app/(site)/_components/ai/ChatBarista"),
-  { ssr: false }
+  { ssr: false, loading: AiSectionSkeleton }
 );
 const VoiceBarista = dynamic(
   () => import("@/app/(site)/_components/ai/VoiceBarista"),
-  { ssr: false }
+  { ssr: false, loading: AiSectionSkeleton }
 );
 
 interface HomeAiSectionProps {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.88.14",
+  "version": "0.88.15",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- The previous PR removed motion animations that were masking layout shifts with `opacity: 0`. The `ssr: false` dynamic imports for ChatBarista/VoiceBarista render nothing on the server, then pop in ~330px of content on hydration — causing massive CLS (0.23 → 0.458)
- Add `AiSectionSkeleton` as the `loading` fallback for both dynamic imports, matching the hero section's padding (`py-16 md:py-24`) and content structure
- The skeleton renders in server HTML, reserving the correct vertical space before the dynamic import loads

## Test plan
- [x] `npm run precheck` passes
- [ ] Run Lighthouse mobile audit — CLS should drop significantly