### PR TITLE
fix: add fetchPriority to LCP image and limit priority count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,17 @@
 # Changelog
 
-## 0.88.15 - 2026-02-15
+## 0.88.16 - 2026-02-16
 
 ### Changed
 
 - **Remove homepage motion animations**: Products and AI section render instantly from server HTML, eliminating 2.5s render delay (LCP) and layout shifts (CLS)
-- **Optimize image sizes**: Add 480px image size step to close the 384→640 gap, saving ~97 KiB across homepage images
-- **Tighten browserslist**: Target last 2 versions of modern browsers, eliminating ~13.7 KiB of unnecessary polyfills
+- **Optimize image sizes**: Add 480px image size step to close the 384→640 gap
+- **Limit priority images**: Only preload the first recommendation and first carousel slide (was preloading 5+ images, diluting browser priority)
 
 ### Fixed
 
 - **AI section layout shift**: Add loading skeleton to reserve space for dynamically imported ChatBarista/VoiceBarista, preventing CLS from content popping in after hydration
+- **LCP fetchpriority**: Add `fetchPriority="high"` to priority product images so the browser fetches the LCP image at high priority
 - **Carousel dot touch targets**: Increase tap area to 48px minimum for mobile accessibility while keeping dots visually small
 
 ## 0.88.13 - 2026-02-15

--- a/app/(site)/_components/product/FeaturedProducts.tsx
+++ b/app/(site)/_components/product/FeaturedProducts.tsx
@@ -33,7 +33,7 @@ export default function FeaturedProducts({
                   showPurchaseOptions={true}
                   hoverRevealFooter={true}
                   compact={true}
-                  priority={index < 4}
+                  priority={index === 0}
                   sizes="(max-width: 768px) 67vw, (max-width: 1200px) 40vw, 29vw"
                 />
               </div>

--- a/app/(site)/_components/product/ProductCard.tsx
+++ b/app/(site)/_components/product/ProductCard.tsx
@@ -119,7 +119,8 @@ export default function ProductCard({
             fill
             className="object-cover"
             sizes={sizes}
-            priority={priority || product.isFeatured}
+            priority={priority}
+            fetchPriority={priority ? "high" : undefined}
           />
         </CardHeader>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.88.15",
+  "version": "0.88.16",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -133,10 +133,7 @@
     "typescript": "^5"
   },
   "browserslist": [
-    "last 2 Chrome versions",
-    "last 2 Firefox versions",
-    "last 2 Safari versions",
-    "last 2 Edge versions"
+    "defaults and fully supports es6-module"
   ],
   "engines": {
     "node": ">=24.0.0",


### PR DESCRIPTION
## Summary
- Add `fetchPriority="high"` to priority product images — Next.js `priority` generates preload links but doesn't set `fetchpriority` on the `<img>` element itself (which Lighthouse flags)
- Remove `product.isFeatured` from ProductCard's Image priority condition — priority should be controlled by the parent, not the data model. Was causing 5+ preload links, diluting browser priority
- FeaturedProducts carousel: only preload the first slide (`index === 0`) instead of first 4 (`index < 4`)
- Revert browserslist change — the polyfills Lighthouse flags (Array.prototype.at, Object.hasOwn, etc.) are baked into Next.js's core runtime and cannot be removed via browserslist

## Test plan
- [x] `npm run precheck` passes
- [ ] `curl -s https://artisanroast.app/ | grep fetchpriority` shows `fetchPriority="high"` on the LCP image
- [ ] Lighthouse mobile: LCP should improve (fewer competing preloads + fetchpriority hint)