### PR TITLE
perf: replace motion animations with CSS-only scroll reveal

### DIFF
--- a/app/(site)/_components/category/CategoryClientPage.tsx
+++ b/app/(site)/_components/category/CategoryClientPage.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { motion } from "motion/react";
 import { CategoryProduct } from "@/lib/types";
 import ProductCard from "@/app/(site)/_components/product/ProductCard";
 import {
@@ -11,6 +10,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import { ScrollReveal } from "@/components/shared/ScrollReveal";
 import Link from "next/link";
 
 interface CategoryClientPageProps {
@@ -52,20 +52,14 @@ export default function CategoryClientPage({
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
           {products.map((product, index) => (
-            <motion.div
-              key={product.id}
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.3 }}
-              transition={{ duration: 0.4, ease: "easeOut", delay: index * 0.08 }}
-            >
+            <ScrollReveal key={product.id} delay={index * 0.08}>
               <ProductCard
                 product={product}
                 showPurchaseOptions={showPurchaseOptions}
                 categorySlug={categorySlug}
                 sizes="(max-width: 768px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 2rem), 400px"
               />
-            </motion.div>
+            </ScrollReveal>
           ))}
         </div>
       )}

--- a/app/(site)/_components/product/FeaturedProducts.tsx
+++ b/app/(site)/_components/product/FeaturedProducts.tsx
@@ -3,6 +3,7 @@
 import { FeaturedProduct } from "@/lib/types";
 import ProductCard from "@/app/(site)/_components/product/ProductCard";
 import { ScrollCarousel } from "@/components/shared/media/ScrollCarousel";
+import { ScrollReveal } from "@/components/shared/ScrollReveal";
 
 interface FeaturedProductsProps {
   products: FeaturedProduct[];
@@ -27,7 +28,7 @@ export default function FeaturedProducts({
             minWidth="var(--slide-size)"
           >
             {products.map((product, index) => (
-              <div key={product.id}>
+              <ScrollReveal key={product.id} delay={index * 0.08}>
                 <ProductCard
                   product={product}
                   showPurchaseOptions={true}
@@ -36,7 +37,7 @@ export default function FeaturedProducts({
                   priority={index === 0}
                   sizes="(max-width: 768px) 67vw, (max-width: 1200px) 40vw, 29vw"
                 />
-              </div>
+              </ScrollReveal>
             ))}
           </ScrollCarousel>
         </div>

--- a/app/(site)/_components/product/RecommendationsSection.tsx
+++ b/app/(site)/_components/product/RecommendationsSection.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import ProductCard from "@/app/(site)/_components/product/ProductCard";
+import { ScrollReveal } from "@/components/shared/ScrollReveal";
 import { FeaturedProduct } from "@/lib/types";
 import { Sparkles, TrendingUp } from "lucide-react";
 
@@ -74,14 +75,14 @@ export default function RecommendationsSection({
         {/* Product Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {products.map((product, index) => (
-            <div key={product.id}>
+            <ScrollReveal key={product.id} delay={index * 0.08}>
               <ProductCard
                 product={product}
                 showPurchaseOptions={true}
                 hoverRevealFooter={true}
                 priority={index === 0}
               />
-            </div>
+            </ScrollReveal>
           ))}
         </div>
 

--- a/app/(site)/products/[slug]/ProductClientPage.tsx
+++ b/app/(site)/products/[slug]/ProductClientPage.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState, startTransition, useRef } from "react";
 import Link from "next/link";
-import { motion } from "motion/react";
 import { ProductType, PurchaseType } from "@prisma/client";
 import {
   Product,
@@ -370,19 +369,14 @@ export default function ProductClientPage({
       </Breadcrumb>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-y-4 md:gap-x-10 md:gap-y-5 lg:gap-x-14 lg:gap-y-8">
-        <motion.div
-          className="w-full min-w-0 md:sticky md:top-6 md:self-start"
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, ease: "easeOut" }}
-        >
+        <div className="w-full min-w-0 md:sticky md:top-6 md:self-start animate-fade-in-up">
           <ImageCarousel
             images={galleryImages}
             aspectRatio="square"
             showThumbnails={showThumbs}
             showDots={true}
           />
-        </motion.div>
+        </div>
 
         <div className="w-full min-w-0 flex flex-col gap-4">
           {/* ---- Coffee header: origin, name, roast bar, tasting notes ---- */}

--- a/app/globals.css
+++ b/app/globals.css
@@ -310,3 +310,19 @@ We define CSS variables for each theme.
   animation: drop-target-flash 0.6s ease-in-out;
 }
 
+/* Fade-in-up animation for page elements (mount animation) */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(1.25rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 0.4s ease-out both;
+}
+

--- a/components/shared/ScrollReveal.tsx
+++ b/components/shared/ScrollReveal.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface ScrollRevealProps {
+  children: React.ReactNode;
+  delay?: number;
+  className?: string;
+}
+
+export function ScrollReveal({
+  children,
+  delay = 0,
+  className,
+}: ScrollRevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.3 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className={`transition-[opacity,transform] duration-[400ms] ease-out ${className ?? ""}`}
+      style={{
+        opacity: visible ? 1 : 0,
+        transform: visible ? "translateY(0)" : "translateY(1.25rem)",
+        transitionDelay: `${delay}s`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace `motion/react` animations with lightweight CSS-only alternatives on product detail, category, homepage recommendations, and featured products pages
- Product detail page: CSS `@keyframes fade-in-up` animation (mount animation, no JS)
- Category + recommendations grids: `ScrollReveal` component using `IntersectionObserver` + CSS transitions with stagger delay
- Featured products carousel: per-slide `ScrollReveal` fade-in as slides enter viewport
- Extract shared `ScrollReveal` component (~40 lines) to `components/shared/`

## Why
Motion's `initial: { opacity: 0, y: 20 }` was applied via JS after hydration, causing CLS (0.61 on /products/[slug] mobile). CSS-based animations bake the initial state into the stylesheet — no layout shift, no 60KB library dependency for the animation.

## Test plan
- [ ] Homepage: recommendations cards fade-in-up with stagger on scroll
- [ ] Homepage: featured carousel slides fade-in-up individually on scroll
- [ ] Category page: product grid cards fade-in-up with stagger on scroll
- [ ] Product detail page: image carousel fades in on mount
- [ ] All animations play once only (no re-trigger on scroll back)
- [ ] `npm run precheck` passes
- [ ] `npm run test:ci` passes (756 tests)