### PR TITLE
chore: bump version to 0.88.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.88.16",
+  "version": "0.88.18",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Sync package.json version with git tag v0.88.18 for Vercel build compatibility.