### PR TITLE
chore: bump version to 0.89.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.89.2",
+  "version": "0.89.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Sync package.json version to match git tag v0.89.3 for Vercel build.