### PR TITLE
fix: mobile action menu matches desktop with delete option

### DIFF
--- a/app/admin/products/hooks/useProductsTable.tsx
+++ b/app/admin/products/hooks/useProductsTable.tsx
@@ -12,8 +12,7 @@ import type {
   ColumnFiltersState,
   FilterFn,
 } from "@tanstack/react-table";
-import { Button } from "@/components/ui/button";
-import { MoreHorizontal, Pencil, Settings, Trash } from "lucide-react";
+import { Pencil, Settings, Trash } from "lucide-react";
 import { useCallback, useMemo } from "react";
 
 import { VariantCell } from "../_components/VariantCell";
@@ -292,15 +291,26 @@ export function useProductsTable({
         enableSorting: false,
         enableResizing: false,
         meta: { responsive: "mobile" } satisfies DataTableColumnMeta,
-        cell: ({ row }) => (
-          <Button
-            variant="outline"
-            size="icon-sm"
-            onClick={() => onEditVariants(row.original)}
-          >
-            <MoreHorizontal className="h-4 w-4" />
-          </Button>
-        ),
+        cell: ({ row }) => {
+          const product = row.original;
+          const items: RowActionItem[] = [
+            {
+              type: "item",
+              label: "Edit Variants",
+              icon: Pencil,
+              onClick: () => onEditVariants(product),
+            },
+            { type: "separator" },
+            {
+              type: "item",
+              label: "Delete",
+              icon: Trash,
+              variant: "destructive",
+              onClick: () => onDeleteProduct(product),
+            },
+          ];
+          return <RowActionMenu items={items} />;
+        },
       },
       // Row action column (desktop only)
       {


### PR DESCRIPTION
## Summary
- Replace simple button with RowActionMenu dropdown on mobile actions column
- Includes Edit Variants and Delete options (omits Show/Hide Columns since it's not relevant on mobile)

## Test plan
- [ ] Mobile (xs) action menu shows Edit Variants + Delete in dropdown
- [ ] Desktop action menu unchanged (Edit Variants + Show/Hide Columns + Delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)