### PR TITLE
fix: suppress lint warnings for useReactTable and scratchpad

### DIFF
--- a/app/admin/_components/data-table/hooks/useDataTable.ts
+++ b/app/admin/_components/data-table/hooks/useDataTable.ts
@@ -48,6 +48,7 @@ export function useDataTable<TData>({
     [activeFilter, filterToColumnFilters]
   );
 
+  // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table returns unstable refs by design
   const table = useReactTable({
     data,
     columns,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,7 @@ const eslintConfig = defineConfig([
       // Temporary scratchpad and screenshot scripts
       ".scratchpad/**",
       ".screenshots/**",
+      "scratchpad/**",
     ],
   },
   ...nextVitals,


### PR DESCRIPTION
## Summary
- Add `eslint-disable` for `react-hooks/incompatible-library` on `useReactTable()` call (known TanStack Table limitation)
- Add `scratchpad/` to ESLint ignores (already in `.gitignore` and `tsconfig.json` exclude)

## Test plan
- [x] `npm run precheck` returns 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)