### PR TITLE
fix: action bar sticky docking and dropdown positioning

### DIFF
--- a/app/admin/_components/data-table/DataTableFilter.tsx
+++ b/app/admin/_components/data-table/DataTableFilter.tsx
@@ -68,7 +68,7 @@ function ComparisonFilterContent({
 
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <InputGroupButton size="xs" variant="secondary">
             {filter.operator || ">"}
@@ -192,7 +192,7 @@ export function DataTableFilter({
 
   const typeSelector = (
     <InputGroupAddon align="inline-end">
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <InputGroupButton size="icon-xs">
             <MoreHorizontal />

--- a/app/admin/_components/data-table/DataTablePageSizeSelector.tsx
+++ b/app/admin/_components/data-table/DataTablePageSizeSelector.tsx
@@ -2,12 +2,13 @@
 
 import { ButtonGroup, ButtonGroupText } from "@/components/ui/button-group";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ChevronDown } from "lucide-react";
 import type { Table } from "@tanstack/react-table";
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
@@ -19,29 +20,39 @@ interface DataTablePageSizeSelectorProps<TData> {
 export function DataTablePageSizeSelector<TData>({
   table,
 }: DataTablePageSizeSelectorProps<TData>) {
+  const pageSize = table.getState().pagination.pageSize;
+
   return (
-    <ButtonGroup>
+    <ButtonGroup className="hidden lg:flex">
       <ButtonGroupText className="px-2.5 text-xs text-muted-foreground">
         R/P
       </ButtonGroupText>
-      <Select
-        value={String(table.getState().pagination.pageSize)}
-        onValueChange={(value) => {
-          table.setPageSize(Number(value));
-          table.setPageIndex(0);
-        }}
-      >
-        <SelectTrigger size="sm" className="w-[72px]">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent align="end">
-          {PAGE_SIZE_OPTIONS.map((size) => (
-            <SelectItem key={size} value={String(size)}>
-              {size}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="flex h-8 items-center justify-between gap-1 rounded-md border border-input bg-transparent px-3 text-sm shadow-xs hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 w-[72px]"
+          >
+            {pageSize}
+            <ChevronDown className="size-4 opacity-50" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuRadioGroup
+            value={String(pageSize)}
+            onValueChange={(value) => {
+              table.setPageSize(Number(value));
+              table.setPageIndex(0);
+            }}
+          >
+            {PAGE_SIZE_OPTIONS.map((size) => (
+              <DropdownMenuRadioItem key={size} value={String(size)}>
+                {size}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </ButtonGroup>
   );
 }


### PR DESCRIPTION
## Summary
- Add IntersectionObserver to detect when action bar is sticky-docked; conditionally apply bg/border/padding
- Drop z-index from 51 to 50 so mobile drawer renders above action bar
- Restructure expanded slot overlay inside sticky wrapper (fixes search/filter positioning when docked)
- Replace Radix Select with DropdownMenu for page size selector (prevents scroll lock/freeze)
- Set `modal={false}` on all action bar DropdownMenus to prevent body scroll lock
- Hide R/P page size selector below lg breakpoint to save mobile space

## Test plan
- [ ] Scroll products table — action bar docks seamlessly with navbar (bg, border, rounded corners)
- [ ] When inline (not scrolled), action bar has no extra padding/bg/border
- [ ] Page size dropdown opens near trigger, no scroll freeze
- [ ] Mobile drawer renders above action bar
- [ ] Search/filter expand overlays stick to top when docked
- [ ] R/P hidden on mobile, visible on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)