### PR TITLE
fix: pinned column bg, z-index, and variants min-width

### DIFF
--- a/app/admin/_components/data-table/DataTable.tsx
+++ b/app/admin/_components/data-table/DataTable.tsx
@@ -13,7 +13,7 @@ interface DataTableProps<TData> {
   emptyMessage?: string;
 }
 
-const PIN_LEFT_CLASS = "sticky left-0 z-10 bg-admin-bg after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-border";
+const PIN_LEFT_CLASS = "sticky left-0 z-30 bg-background after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-border";
 
 const RESPONSIVE_CLASSES: Record<string, string> = {
   desktop: "hidden sm:table-cell",

--- a/app/admin/_components/data-table/DataTableHeaderCell.tsx
+++ b/app/admin/_components/data-table/DataTableHeaderCell.tsx
@@ -48,7 +48,7 @@ export function DataTableHeaderCell<TData>({
           ? "border-b-foreground"
           : "border-b-border",
         meta?.pin === "left" &&
-          "sticky left-0 z-10 bg-admin-bg after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-border",
+          "sticky left-0 z-30 bg-background after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-border",
         className
       )}
       style={{ width: header.getSize() }}

--- a/app/admin/products/hooks/useProductsTable.tsx
+++ b/app/admin/products/hooks/useProductsTable.tsx
@@ -207,6 +207,8 @@ export function useProductsTable({
       {
         id: "variants",
         header: "Variants",
+        size: 320,
+        minSize: 280,
         enableSorting: false,
         enableResizing: true,
         meta: { responsive: "desktop" } satisfies DataTableColumnMeta,


### PR DESCRIPTION
## Summary
- Pinned column uses `bg-background` (solid white) with `z-30` to render above resize handle borders (`z-20`)
- Right border restored on pinned column as visual scroll indicator
- Variants column `size: 320`, `minSize: 280` prevents overlap with actions column at smaller breakpoints

## Test plan
- [ ] Scroll table right — pinned Name column covers content, no borders bleeding through
- [ ] Right border visible on pinned column edge
- [ ] Variants column has adequate width at sm/md breakpoints, no overlap with actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)