### PR TITLE
fix: show grabbing cursor only while dragging table

### DIFF
--- a/app/admin/_components/data-table/DataTableShell.tsx
+++ b/app/admin/_components/data-table/DataTableShell.tsx
@@ -51,7 +51,7 @@ export function DataTableShell({ children, className }: DataTableShellProps) {
       ref={containerRef}
       className={cn(
         "relative w-full overflow-x-auto",
-        isDragging ? "cursor-grabbing select-none" : "cursor-grab",
+        isDragging && "select-none",
         className
       )}
       onMouseDown={handleMouseDown}
@@ -59,7 +59,10 @@ export function DataTableShell({ children, className }: DataTableShellProps) {
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
     >
-      <table className="w-full min-w-max table-fixed caption-bottom text-sm">
+      <table className={cn(
+        "w-full min-w-max table-fixed caption-bottom text-sm",
+        isDragging && "[&_td]:cursor-grabbing [&_th]:cursor-grabbing"
+      )}>
         {children}
       </table>
     </div>


### PR DESCRIPTION
## Summary
- Default pointer cursor on table cells (no grab cursor at rest)
- Show grabbing cursor on all cells only while actively dragging
- Header cells unchanged — sort/resize cues are sufficient

## Test plan
- [ ] Hover over table rows — normal pointer cursor
- [ ] Click and drag — cursor changes to grabbing hand
- [ ] Release — cursor returns to normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)