### PR TITLE
chore: bump version to 0.89.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.89.8",
+  "version": "0.89.9",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Sync package.json version with git tag v0.89.9 for Vercel build compatibility.