### PR TITLE
fix: cart, breadcrumb dropdown, page editor mobile UX

### DIFF
--- a/app/(site)/_components/cart/AddOnCard.tsx
+++ b/app/(site)/_components/cart/AddOnCard.tsx
@@ -86,6 +86,7 @@ export function AddOnCard({
       // Also drive the hook's state machine with a cart item
       const purchaseOption = variant.purchaseOptions[0];
       if (purchaseOption) {
+        const effectivePrice = discountedPriceInCents || purchaseOption.priceInCents;
         const cartItem: CartItemInput = {
           productId: product.id,
           productName: product.name,
@@ -95,7 +96,10 @@ export function AddOnCard({
           variantName: variant.name,
           purchaseOptionId: purchaseOption.id,
           purchaseType: purchaseOption.type as "ONE_TIME" | "SUBSCRIPTION",
-          priceInCents: discountedPriceInCents || purchaseOption.priceInCents,
+          priceInCents: effectivePrice,
+          ...(effectivePrice < purchaseOption.priceInCents && {
+            originalPriceInCents: purchaseOption.priceInCents,
+          }),
           imageUrl:
             addOn.imageUrl ||
             getPlaceholderImage(product.name, 400, "culture"),

--- a/app/(site)/_components/cart/CartAddOnsSuggestions.tsx
+++ b/app/(site)/_components/cart/CartAddOnsSuggestions.tsx
@@ -20,6 +20,7 @@ interface CartAddOn {
     id: string;
     name: string;
     priceInCents: number;
+    originalPriceInCents: number;
     purchaseOptionId: string;
   };
 }
@@ -118,7 +119,7 @@ export function CartAddOnsSuggestions({
               purchaseOptions: [
                 {
                   id: addOn.variant.purchaseOptionId,
-                  priceInCents: addOn.variant.priceInCents,
+                  priceInCents: addOn.variant.originalPriceInCents,
                   type: "ONE_TIME",
                 },
               ],

--- a/app/(site)/_components/cart/ShoppingCart.tsx
+++ b/app/(site)/_components/cart/ShoppingCart.tsx
@@ -329,6 +329,7 @@ export function ShoppingCart() {
                   <Link
                     href={`/products/${item.productSlug}`}
                     className="shrink-0"
+                    onClick={() => setIsOpen(false)}
                   >
                     <div className="relative w-20 h-20 rounded-md overflow-hidden bg-white dark:bg-gray-800">
                       {item.imageUrl ? (
@@ -351,6 +352,7 @@ export function ShoppingCart() {
                     <Link
                       href={`/products/${item.productSlug}`}
                       className="font-medium text-text-base hover:text-primary line-clamp-2 mb-1"
+                      onClick={() => setIsOpen(false)}
                     >
                       {item.productName}
                     </Link>
@@ -441,11 +443,11 @@ export function ShoppingCart() {
                         <span>
                           {item.originalPriceInCents && (
                             <span className="text-sm text-muted-foreground line-through mr-1.5">
-                              {formatPrice(item.originalPriceInCents * item.quantity)}
+                              {formatPrice(item.originalPriceInCents)}
                             </span>
                           )}
                           <span className="font-semibold text-text-base">
-                            {formatPrice(item.priceInCents * item.quantity)}
+                            {formatPrice(item.priceInCents)}
                           </span>
                         </span>
                       </span>

--- a/app/(site)/_components/category/CategoryClientPage.tsx
+++ b/app/(site)/_components/category/CategoryClientPage.tsx
@@ -7,10 +7,10 @@ import {
   BreadcrumbItem,
   BreadcrumbLink,
   BreadcrumbList,
-  BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { ScrollReveal } from "@/components/shared/ScrollReveal";
+import { BreadcrumbCategoryDropdown } from "@/app/(site)/_components/navigation/BreadcrumbCategoryDropdown";
 import Link from "next/link";
 
 interface CategoryClientPageProps {
@@ -38,7 +38,12 @@ export default function CategoryClientPage({
           </BreadcrumbItem>
           <BreadcrumbSeparator />
           <BreadcrumbItem>
-            <BreadcrumbPage>{categoryName}</BreadcrumbPage>
+            <BreadcrumbCategoryDropdown
+              categoryName={categoryName}
+              categorySlug={categorySlug}
+              products={products.map((p) => ({ name: p.name, slug: p.slug }))}
+              isCurrentPage
+            />
           </BreadcrumbItem>
         </BreadcrumbList>
       </Breadcrumb>

--- a/app/(site)/_components/navigation/BreadcrumbCategoryDropdown.tsx
+++ b/app/(site)/_components/navigation/BreadcrumbCategoryDropdown.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export interface BreadcrumbProduct {
+  name: string;
+  slug: string;
+}
+
+interface BreadcrumbCategoryDropdownProps {
+  categoryName: string;
+  categorySlug: string;
+  products: BreadcrumbProduct[];
+  /** Whether this is the current page (non-navigable label) vs a link */
+  isCurrentPage?: boolean;
+}
+
+export function BreadcrumbCategoryDropdown({
+  categoryName,
+  categorySlug,
+  products,
+  isCurrentPage = false,
+}: BreadcrumbCategoryDropdownProps) {
+  const [open, setOpen] = useState(false);
+
+  if (products.length === 0) {
+    if (isCurrentPage) {
+      return (
+        <span className="font-normal text-foreground" aria-current="page">
+          {categoryName}
+        </span>
+      );
+    }
+    return (
+      <Link
+        href={`/${categorySlug}`}
+        className="transition-colors hover:text-foreground"
+      >
+        {categoryName}
+      </Link>
+    );
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger className="inline-flex items-center gap-1.5 transition-colors hover:text-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 rounded-sm">
+        {isCurrentPage ? (
+          <span className="font-normal text-foreground">{categoryName}</span>
+        ) : (
+          <span>{categoryName}</span>
+        )}
+        <ChevronRight
+          className={cn(
+            "h-3.5 w-3.5 transition-[rotate] duration-200",
+            open && "rotate-90"
+          )}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="max-h-72 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[data-slot=dropdown-menu-item]]:cursor-pointer">
+        <DropdownMenuItem asChild>
+          <Link href={`/${categorySlug}`} className="font-semibold">
+            {categoryName}
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {products.map((product) => (
+          <DropdownMenuItem key={product.slug} asChild>
+            <Link href={`/products/${product.slug}?from=${categorySlug}`}>
+              {product.name}
+            </Link>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/app/(site)/products/[slug]/ProductClientPage.tsx
+++ b/app/(site)/products/[slug]/ProductClientPage.tsx
@@ -35,11 +35,16 @@ import { CoffeeDetails } from "@/app/(site)/_components/product/CoffeeDetails";
 import { ProductSelectionsSection } from "@/app/(site)/_components/product/ProductSelectionsSection";
 import { FloatingAddToCartButton } from "@/app/(site)/_components/product/FloatingAddToCartButton";
 import { RoastLevelBar } from "@/app/(site)/_components/product/RoastLevelBar";
+import {
+  BreadcrumbCategoryDropdown,
+  type BreadcrumbProduct,
+} from "@/app/(site)/_components/navigation/BreadcrumbCategoryDropdown";
 
 interface ProductClientPageProps {
   product: Product;
   relatedProducts: RelatedProduct[];
   category: Pick<Category, "name" | "slug">;
+  categoryProducts?: BreadcrumbProduct[];
   addOns: AddOnItem[];
 }
 
@@ -115,6 +120,7 @@ export default function ProductClientPage({
   product,
   relatedProducts,
   category,
+  categoryProducts = [],
   addOns,
 }: ProductClientPageProps) {
   const { settings } = useSiteSettings();
@@ -359,11 +365,12 @@ export default function ProductClientPage({
           </BreadcrumbItem>
           <BreadcrumbSeparator />
           <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link href={`/${category.slug}`}>{category.name}</Link>
-            </BreadcrumbLink>
+            <BreadcrumbCategoryDropdown
+              categoryName={category.name}
+              categorySlug={category.slug}
+              products={categoryProducts}
+            />
           </BreadcrumbItem>
-          <BreadcrumbSeparator />
           <BreadcrumbItem>
             <BreadcrumbPage>{product.name}</BreadcrumbPage>
           </BreadcrumbItem>

--- a/app/(site)/products/[slug]/page.tsx
+++ b/app/(site)/products/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getProductBySlug, getRelatedProducts } from "@/lib/data";
+import { getProductBySlug, getRelatedProducts, getProductsByCategorySlug } from "@/lib/data";
 import { prisma } from "@/lib/prisma";
 import ProductClientPage from "./ProductClientPage";
 import { getProductAddOns } from "./actions";
@@ -97,11 +97,18 @@ export default async function ProductPage({
   // Fetch add-ons for this product
   const addOns = await getProductAddOns(product.id);
 
+  // Fetch sibling products in the same category (for breadcrumb dropdown)
+  const categoryProducts = await getProductsByCategorySlug(displayCategory.slug);
+  const siblingProducts = categoryProducts
+    .filter((p) => p.id !== product.id)
+    .map((p) => ({ name: p.name, slug: p.slug }));
+
   return (
     <ProductClientPage
       product={product}
       relatedProducts={relatedProducts}
       category={displayCategory}
+      categoryProducts={siblingProducts}
       addOns={addOns}
     />
   );

--- a/app/admin/_components/cms/editors/PageEditor.tsx
+++ b/app/admin/_components/cms/editors/PageEditor.tsx
@@ -28,7 +28,13 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { Eye, Settings, X, Sparkles } from "lucide-react";
+import { Eye, Settings, X, Sparkles, MoreHorizontal } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { IconPicker } from "@/app/admin/_components/cms/fields/IconPicker";
 import { AiAssistClient } from "@/components/ai-assist/AiAssistClient";
 import { WizardAnswers } from "@/lib/api-schemas/generate-about";
@@ -395,10 +401,12 @@ export function PageEditor({
     <>
       {/* Toolbar */}
       <div className="w-full sticky -top-50 z-10 flex items-center justify-between gap-4">
-        <div className="flex items-center gap-2">
-          <h2 className="text-lg font-semibold">
-            {pageType.charAt(0).toUpperCase() + pageType.slice(1)} Page Editor
-          </h2>
+        <h2 className="text-lg font-semibold min-w-0 truncate">
+          {pageType.charAt(0).toUpperCase() + pageType.slice(1)} Page Editor
+        </h2>
+
+        {/* Desktop: inline buttons */}
+        <div className="hidden sm:flex items-center gap-2 shrink-0">
           <Button
             variant="outline"
             size="sm"
@@ -408,9 +416,6 @@ export function PageEditor({
             <Eye className="h-4 w-4 mr-2" />
             {savedPublished ? "Live Preview" : "Preview"}
           </Button>
-        </div>
-
-        <div className="flex items-center gap-2">
           {onMetadataUpdate && (
             <Button
               variant="outline"
@@ -422,7 +427,6 @@ export function PageEditor({
               Settings
             </Button>
           )}
-
           <Button
             variant="default"
             size="sm"
@@ -433,6 +437,40 @@ export function PageEditor({
             AI Assist
           </Button>
         </div>
+
+        {/* Mobile: 3-dot dropdown */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon-sm" className="sm:hidden">
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onClick={handleViewLive}
+              disabled={isEditingMetadata}
+            >
+              <Eye className="h-4 w-4 mr-2" />
+              {savedPublished ? "Live Preview" : "Preview"}
+            </DropdownMenuItem>
+            {onMetadataUpdate && (
+              <DropdownMenuItem
+                onClick={() => setIsEditingMetadata(!isEditingMetadata)}
+                disabled={isEditingMetadata}
+              >
+                <Settings className="h-4 w-4 mr-2" />
+                Settings
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem
+              onClick={() => setAiDialogOpen(true)}
+              disabled={isEditingMetadata}
+            >
+              <Sparkles className="h-4 w-4 mr-2" />
+              AI Assist
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
       <AiAssistClient
@@ -457,7 +495,7 @@ export function PageEditor({
 
       {/* SEO Metadata Panel */}
       {isEditingMetadata && onMetadataUpdate && (
-        <div className="container pt-6">
+        <div className="w-full pt-6">
           <Card className="relative">
             <Button
               variant="ghost"
@@ -655,7 +693,7 @@ export function PageEditor({
       )}
 
       {/* Blocks Container - WYSIWYG Layout */}
-      <div className="container pt-6">
+      <div className="w-full pt-6">
         {blocks.length === 0 ? (
           <div className="text-center py-12 text-muted-foreground">
             <p className="text-lg mb-2">No blocks yet</p>

--- a/app/api/cart/addons/route.ts
+++ b/app/api/cart/addons/route.ts
@@ -112,6 +112,7 @@ export async function POST(request: Request) {
           id: string;
           name: string;
           priceInCents: number;
+          originalPriceInCents: number;
           purchaseOptionId: string;
         };
       }
@@ -154,6 +155,7 @@ export async function POST(request: Request) {
               id: variant.id,
               name: variant.name,
               priceInCents: effectivePrice,
+              originalPriceInCents: po.priceInCents,
               purchaseOptionId: po.id,
             },
           });
@@ -194,6 +196,7 @@ export async function POST(request: Request) {
             id: addOn.addOnVariant.id,
             name: addOn.addOnVariant.name,
             priceInCents: effectivePrice,
+            originalPriceInCents: po.priceInCents,
             purchaseOptionId: po.id,
           },
         });

--- a/hooks/useAddToCartWithFeedback.ts
+++ b/hooks/useAddToCartWithFeedback.ts
@@ -148,8 +148,13 @@ export function useAddToCartWithFeedback(
 
           // If cart was empty before (total now equals what we just added),
           // this is a first-time buyer - show "Buy Now"
+          // But never offer Buy Now for subscriptions (requires cart review)
           // Otherwise, show "Checkout Now"
-          if (totalBefore === 0 && totalAfter === quantity) {
+          if (
+            totalBefore === 0 &&
+            totalAfter === quantity &&
+            item.purchaseType !== "SUBSCRIPTION"
+          ) {
             setButtonState("buy-now");
           } else {
             setButtonState("checkout-now");


### PR DESCRIPTION
## Summary
- **Cart drawer**: Close when navigating to a product page, show unit prices instead of quantity totals
- **Subscription buy-now**: Skip "Buy Now" prompt for subscription items (only show "View Cart")
- **Add-on discount**: Display original price with strikethrough for discounted add-ons in cart
- **Breadcrumb dropdown**: Category breadcrumb segments show a dropdown with sibling product links
- **Page editor mobile**: Collapse toolbar buttons into a 3-dot dropdown menu on mobile, fix container width

## Test plan
- [ ] Cart drawer closes when clicking product image/name links
- [ ] Cart shows unit prices per line item (not quantity × price)
- [ ] Adding a subscription shows "View Cart" not "Buy Now"
- [ ] Discounted add-ons show strikethrough original price in cart
- [ ] Category pages show breadcrumb dropdown with product list
- [ ] Product pages show breadcrumb dropdown for category with sibling products
- [ ] Page editor toolbar collapses to 3-dot menu on mobile
- [ ] Page editor content sections use full width consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)