### PR TITLE
fix: add-ons undo/redo in product editor

### DIFF
--- a/app/admin/products/_hooks/useAutoSave.ts
+++ b/app/admin/products/_hooks/useAutoSave.ts
@@ -152,6 +152,15 @@ export function useAutoSave<T = unknown>({
     }
   }, [historyRedo, refreshCounts]);
 
+  /** Record an external save (e.g. add-on API call) to undo history without triggering saveFn. */
+  const markExternalSave = useCallback((newFormState?: T) => {
+    if (lastSavedStateRef.current !== undefined && historyKey) {
+      pushSnapshot(lastSavedStateRef.current);
+      refreshCounts();
+    }
+    lastSavedStateRef.current = newFormState ?? formStateRef.current;
+  }, [pushSnapshot, historyKey, refreshCounts]);
+
   return {
     status,
     saveNow,
@@ -160,5 +169,6 @@ export function useAutoSave<T = unknown>({
     canUndo: historyCounts.undo > 0,
     canRedo: historyCounts.redo > 0,
     clearHistory: clear,
+    markExternalSave,
   };
 }


### PR DESCRIPTION
## Summary
- Add-on changes (add, remove, discount edits) now participate in the product editor's undo/redo history
- Previously, AddOnsSection saved directly to API without creating history snapshots, making add-on changes irreversible
- On undo, the restored add-ons state is synced back to the API via a diff (POST new, DELETE removed, PUT selections)

## Changes
- **useAutoSave**: New `markExternalSave()` function for creating undo snapshots from external saves (not triggered by deps)
- **AddOnsSection**: New `onAddOnsChange` callback notifies parent of user-initiated mutations; new `restoreAddOns` ref method diffs and syncs restored state to API
- **CoffeeProductForm / MerchProductForm**: Track addOns in formState for snapshots, create undo points on add-on changes, restore add-ons on undo

## Test plan
- [ ] Edit a coffee product, add an add-on, then press U to undo — add-on should disappear
- [ ] Redo (Shift+U) — add-on should reappear
- [ ] Change an add-on discount, undo — discount should revert
- [ ] Remove an add-on, undo — add-on should reappear
- [ ] Existing undo/redo for product info, specs, categories still works
- [ ] Variant action tests pass (5/5)
- [ ] Precheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)