### PR TITLE
fix: change delivery check cron to daily for Vercel Hobby

### DIFF
--- a/app/admin/settings/shipping/page.tsx
+++ b/app/admin/settings/shipping/page.tsx
@@ -19,7 +19,7 @@ export default function ShippingSettingsPage() {
         <span>
           Carrier API keys enable automatic delivery status updates.
           Orders shipped with a configured carrier will have their tracking
-          status checked hourly and customers notified on delivery.
+          status checked daily and customers notified on delivery.
         </span>
       </div>
 

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "/api/cron/check-deliveries",
-      "schedule": "0 * * * *"
+      "schedule": "0 0 * * *"
     }
   ],
   "redirects": [],


### PR DESCRIPTION
## Summary
- Change check-deliveries cron from hourly to daily — Vercel Hobby plan only supports once-per-day cron jobs
- Update shipping settings callout text to match ("daily" instead of "hourly")