### PR TITLE
fix: shipping page cron note and cleanup toggle

### DIFF
--- a/app/admin/settings/shipping/page.tsx
+++ b/app/admin/settings/shipping/page.tsx
@@ -18,8 +18,10 @@ export default function ShippingSettingsPage() {
         <Info className="h-4 w-4 text-blue-500 mt-0.5 shrink-0" />
         <span>
           Carrier API keys enable automatic delivery status updates.
-          Orders shipped with a configured carrier will have their tracking
-          status checked daily and customers notified on delivery.
+          Orders shipped with a configured carrier will have their status
+          checked and customers notified on delivery. This feature relies
+          on a scheduled task (cron job) configured through your hosting
+          provider.
         </span>
       </div>
 

--- a/app/api/cron/check-deliveries/route.ts
+++ b/app/api/cron/check-deliveries/route.ts
@@ -12,7 +12,7 @@ const CHUNK_SIZE = 10;
 
 /**
  * GET /api/cron/check-deliveries
- * Hourly cron job that checks SHIPPED orders for delivery status via carrier APIs.
+ * Daily cron job that checks SHIPPED orders for delivery status via carrier APIs.
  * When a package is detected as delivered, updates order to DELIVERED and sends email.
  */
 export async function GET(request: NextRequest) {


### PR DESCRIPTION
## Summary
- Update shipping settings info callout to mention cron dependency on hosting provider
- Remove delivery tracking toggle (cron is infrastructure-level, not app-level)
- Update cron route comment from "hourly" to "daily"