### PR TITLE
fix: set isVisible=true on category labels in seed

### DIFF
--- a/prisma/seed/menu.ts
+++ b/prisma/seed/menu.ts
@@ -272,8 +272,8 @@ export async function seedMenu(prisma: PrismaClient) {
     const { name, icon } = LABEL_DEFS[i];
     const label = await prisma.categoryLabel.upsert({
       where: { name },
-      update: { order: i + 1, icon },
-      create: { name, order: i + 1, icon },
+      update: { order: i + 1, icon, isVisible: true },
+      create: { name, order: i + 1, icon, isVisible: true },
     });
     labels.set(name, label.id);
   }


### PR DESCRIPTION
## Summary
- Category label upsert in seed was missing `isVisible: true`, causing the Merch label to be hidden in the shop dropdown after reseeding
- Also sets it in the `update` block so existing labels get fixed on re-seed

## Test plan
- [ ] Run `npm run seed` and verify all 6 labels show `isVisible: true`
- [ ] Check shop dropdown shows Merch section

🤖 Generated with [Claude Code](https://claude.com/claude-code)