### PR TITLE
fix: remove subtotalInCents from seed order financials

### DIFF
--- a/prisma/seed/synthetic-data.ts
+++ b/prisma/seed/synthetic-data.ts
@@ -170,7 +170,6 @@ function computeOrderFinancials(
     taxableAmount + taxAmountInCents + shippingAmountInCents;
 
   return {
-    subtotalInCents,
     discountAmountInCents,
     taxAmountInCents,
     shippingAmountInCents,


### PR DESCRIPTION
## Summary
- Remove `subtotalInCents` from `computeOrderFinancials()` return object — it's not an Order model field and causes Prisma validation errors when spread into `order.create()`

## Test plan
- [x] Seed ran successfully after this fix (9 demo orders, 162 random-user orders)