### PR TITLE
fix: prod UI bugs — theme preview, scroll reveal, mobile image height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.92.1 - 2026-02-26
+
+### Fixed
+
+- **Theme preview card**: Use default shadcn Badge for proper contrast, replace "Add to Cart" with icon + "Add" to prevent wrapping, add type scale preview (2xl–xs), remove misleading accent area
+- **Storefront button text alignment**: Normalize vertical centering for custom theme fonts (Outfit, Noto Serif SC) via scoped `leading-none` on site layout
+- **Recommended For You images**: Show immediately on page load when above the fold instead of waiting for scroll
+- **Product image height on mobile**: Cut image height in half on xs–sm breakpoints (cropped, not stretched) for better mobile UX
+
+### Changed
+
+- **Theme save button**: Moved below title with amber/green status dot indicating save state
+
 ## 0.92.0 - 2026-02-26
 
 ### Added

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -49,7 +49,7 @@ export default async function SiteLayout({
           <link rel="stylesheet" href={`/themes/${theme}.css`} />
         </>
       )}
-      <div className="relative flex min-h-screen flex-col">
+      <div data-site="" className="relative flex min-h-screen flex-col">
         {/* Demo banner - only shows when NEXT_PUBLIC_DEMO_MODE=true */}
         <DemoBanner />
 

--- a/app/(site)/products/[slug]/ProductClientPage.tsx
+++ b/app/(site)/products/[slug]/ProductClientPage.tsx
@@ -396,6 +396,7 @@ export default function ProductClientPage({
           key={selectedVariant.id}
           images={galleryImages}
           aspectRatio="square"
+          mobileAspectRatio="2/1"
           showThumbnails={showThumbs}
           showDots={true}
         />

--- a/app/admin/settings/appearance/page.tsx
+++ b/app/admin/settings/appearance/page.tsx
@@ -2,10 +2,9 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useTheme } from "next-themes";
-import { Check, Moon, Palette, Sun, Terminal } from "lucide-react";
+import { Check, Loader2, Moon, Palette, Save, ShoppingCart, Sun, Terminal } from "lucide-react";
 import { PageTitle } from "@/app/admin/_components/forms/PageTitle";
 import { SettingsSection } from "@/app/admin/_components/forms/SettingsSection";
-import { SaveButton } from "@/app/admin/_components/forms/SaveButton";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -203,6 +202,7 @@ export default function AppearanceSettingsPage() {
   }
   // Also set foreground variants for the preview
   previewStyle["--primary-foreground"] = previewColors.background;
+  previewStyle["--secondary-foreground"] = previewColors.foreground;
   previewStyle["--muted-foreground"] = previewColors.foreground;
   previewStyle["--card"] = previewColors.background;
   previewStyle["--card-foreground"] = previewColors.foreground;
@@ -225,21 +225,28 @@ export default function AppearanceSettingsPage() {
         icon={<Palette className="h-5 w-5" />}
         title="Storefront Theme"
         description="Choose a color theme for your customer-facing storefront. Admin pages always use the default neutral theme."
-        action={
-          <div className="flex items-center gap-3">
-            {isDirty && (
-              <span className="text-sm text-muted-foreground whitespace-nowrap">
-                Unsaved changes
-              </span>
-            )}
-            <SaveButton
-              onClick={handleSave}
-              isSaving={isSaving}
-              disabled={!isDirty}
-            />
-          </div>
-        }
       >
+        <div className="flex justify-end -mt-2">
+          <Button
+            size="sm"
+            onClick={isDirty ? handleSave : undefined}
+            disabled={isSaving}
+          >
+            {isSaving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="h-4 w-4" />
+            )}
+            <span className="ml-2">{isSaving ? "Saving" : "Save"}</span>
+            <span
+              className={cn(
+                "ml-2 size-2 rounded-full",
+                isDirty ? "bg-amber-400" : "bg-green-400"
+              )}
+            />
+          </Button>
+        </div>
+
         {isLoading ? (
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
             {Array.from({ length: 6 }).map((_, i) => (
@@ -319,21 +326,14 @@ export default function AppearanceSettingsPage() {
               >
                 <div className="space-y-4">
                   {/* Header row */}
-                  <div className="flex items-center justify-between">
+                  <div className="flex items-center justify-between gap-2">
                     <h3
                       className="text-lg font-bold"
                       style={{ color: "var(--foreground)" }}
                     >
                       Ethiopian Yirgacheffe
                     </h3>
-                    <Badge
-                      style={{
-                        backgroundColor: "var(--secondary)",
-                        color: "var(--foreground)",
-                      }}
-                    >
-                      New Arrival
-                    </Badge>
+                    <Badge className="shrink-0">New Arrival</Badge>
                   </div>
 
                   {/* Description */}
@@ -355,17 +355,18 @@ export default function AppearanceSettingsPage() {
                     </span>
                     <button
                       type="button"
-                      className="rounded-md px-4 py-2 text-sm font-medium"
+                      className="inline-flex items-center gap-1.5 rounded-md px-4 py-2.5 text-sm leading-none font-medium"
                       style={{
                         backgroundColor: "var(--primary)",
                         color: "var(--primary-foreground)",
                       }}
                     >
-                      Add to Cart
+                      <ShoppingCart className="h-4 w-4" />
+                      Add
                     </button>
                     <button
                       type="button"
-                      className="rounded-md px-4 py-2 text-sm font-medium border"
+                      className="rounded-md px-4 py-2.5 text-sm leading-none font-medium border"
                       style={{
                         backgroundColor: "var(--destructive)",
                         color: "var(--primary-foreground)",
@@ -376,18 +377,42 @@ export default function AppearanceSettingsPage() {
                     </button>
                   </div>
 
-                  {/* Accent/muted area */}
+                  {/* Type scale + inline styles */}
                   <div
-                    className="rounded-md p-3"
-                    style={{ backgroundColor: "var(--accent)" }}
+                    className="border-t pt-4 space-y-1"
+                    style={{ borderColor: "var(--border)" }}
                   >
-                    <p
-                      className="text-sm"
-                      style={{ color: "var(--foreground)" }}
-                    >
-                      Free shipping on orders over $50
+                    <p className="text-2xl font-bold" style={{ color: "var(--foreground)" }}>
+                      2xl — Page Title
+                    </p>
+                    <p className="text-xl font-bold" style={{ color: "var(--foreground)" }}>
+                      xl — Section Heading
+                    </p>
+                    <p className="text-lg font-semibold" style={{ color: "var(--foreground)" }}>
+                      lg — Card Title
+                    </p>
+                    <p className="text-base font-semibold" style={{ color: "var(--foreground)" }}>
+                      base — Subheading
+                    </p>
+                    <p className="text-sm font-medium uppercase tracking-wide" style={{ color: "var(--muted-foreground)" }}>
+                      sm — Label
+                    </p>
+                    <p className="text-xs font-medium uppercase tracking-wider" style={{ color: "var(--muted-foreground)" }}>
+                      xs — Caption
+                    </p>
+                    <p className="text-sm pt-1" style={{ color: "var(--muted-foreground)" }}>
+                      Body with{" "}
+                      <em>italic</em>,{" "}
+                      <strong style={{ color: "var(--foreground)" }}>bold</strong>, and{" "}
+                      <span
+                        className="underline underline-offset-4"
+                        style={{ color: "var(--primary)" }}
+                      >
+                        link
+                      </span>.
                     </p>
                   </div>
+
                 </div>
               </Card>
             </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -161,6 +161,11 @@ We define CSS variables for each theme.
   [role="button"]:not(:disabled) {
     cursor: pointer;
   }
+  /* Normalize vertical text alignment for custom theme fonts (Outfit, Noto Serif SC, etc.)
+     that have different ascender/descender metrics than Inter. Scoped to storefront only. */
+  [data-site] [data-slot="button"] {
+    line-height: 1;
+  }
 }
 
 /* Global prose typography - apply .prose class to content blocks */

--- a/components/shared/ScrollReveal.tsx
+++ b/components/shared/ScrollReveal.tsx
@@ -19,6 +19,14 @@ export function ScrollReveal({
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
+
+    // Elements already in viewport on mount — reveal before next paint (no scroll needed)
+    const rect = el.getBoundingClientRect();
+    if (rect.top < window.innerHeight && rect.bottom > 0) {
+      const raf = requestAnimationFrame(() => setVisible(true));
+      return () => cancelAnimationFrame(raf);
+    }
+
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
@@ -26,7 +34,7 @@ export function ScrollReveal({
           observer.disconnect();
         }
       },
-      { threshold: 0.3 }
+      { threshold: 0.15 }
     );
     observer.observe(el);
     return () => observer.disconnect();

--- a/components/shared/media/ImageCarousel.tsx
+++ b/components/shared/media/ImageCarousel.tsx
@@ -11,6 +11,8 @@ import { cn } from "@/lib/utils";
 interface ImageCarouselProps {
   images: Array<{ url: string; alt?: string }>;
   aspectRatio?: "4/3" | "16/9" | "square";
+  /** Override aspect ratio on mobile (<md). Container crops with object-cover. */
+  mobileAspectRatio?: "4/3" | "16/9" | "2/1";
   className?: string;
   fallbackIcon?: React.ReactNode;
   defaultAlt?: string;
@@ -25,6 +27,7 @@ interface ImageCarouselProps {
 export function ImageCarousel({
   images,
   aspectRatio = "4/3",
+  mobileAspectRatio,
   className = "",
   fallbackIcon,
   defaultAlt = "Image",
@@ -43,11 +46,21 @@ export function ImageCarousel({
   );
   const hasImages = images && images.length > 0;
 
-  const aspectRatioClass = {
+  const desktopAspectMap = {
     "4/3": "aspect-4/3",
     "16/9": "aspect-video",
     square: "aspect-square",
-  }[aspectRatio];
+  } as const;
+
+  const mobileAspectMap = {
+    "4/3": "max-md:aspect-4/3",
+    "16/9": "max-md:aspect-video",
+    "2/1": "max-md:aspect-[2/1]",
+  } as const;
+
+  const aspectRatioClass = mobileAspectRatio
+    ? `${mobileAspectMap[mobileAspectRatio]} md:${desktopAspectMap[aspectRatio]}`
+    : desktopAspectMap[aspectRatio];
 
   useEffect(() => {
     if (!emblaApi) return;
@@ -120,7 +133,7 @@ export function ImageCarousel({
                     alt={img.alt || defaultAlt}
                     fill
                     className="object-cover"
-                    sizes="(max-width: 768px) 90vw, 45vw"
+                    sizes="(max-width: 768px) calc(100vw - 2rem), (max-width: 1280px) 45vw, 560px"
                     priority={idx === 0}
                   />
                 </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.92.0",
+  "version": "0.92.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- **Theme preview card**: Default Badge for contrast, icon + "Add" button, type scale (2xl–xs), removed accent area
- **Theme save button**: Moved below title/desc with amber/green status dot
- **Storefront button alignment**: Scoped `leading-none` via `[data-site]` wrapper for custom theme fonts
- **Recommended For You**: Images above the fold show immediately on page load
- **Product image mobile**: Half-height on xs–sm via `mobileAspectRatio="2/1"` (cropped, not stretched)
- **Image sizes optimized**: `calc(100vw - 2rem)` on mobile, capped at `560px` on large screens

## Test plan
- [x] Precheck passes (tsc + eslint)
- [x] AddToCartButton tests pass (14/14)
- [ ] Visual check: theme preview card at all themes (Default, AstroVista, Lush, Orient)
- [ ] Visual check: Recommended For You images load without scrolling
- [ ] Visual check: product page image height on mobile