### PR TITLE
fix: move column visibility toggle to left side

### DIFF
--- a/app/admin/products/ProductManagementClient.tsx
+++ b/app/admin/products/ProductManagementClient.tsx
@@ -275,8 +275,6 @@ export default function ProductManagementClient({
           onFilterChange: setActiveFilter,
           collapse: { icon: Filter },
         },
-      ],
-      right: [
         {
           type: "custom",
           content: (
@@ -287,6 +285,8 @@ export default function ProductManagementClient({
             />
           ),
         },
+      ],
+      right: [
         {
           type: "recordCount",
           count: table.getFilteredRowModel().rows.length,


### PR DESCRIPTION
## Summary
- Move column visibility toggle from right side to left side of action bar (after filter)

## Test plan
- [ ] Verify column visibility toggle appears after the filter button on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)