### PR TITLE
fix: prevent focus retention on dropdown close

### DIFF
--- a/app/admin/_components/data-table/ColumnVisibilityToggle.tsx
+++ b/app/admin/_components/data-table/ColumnVisibilityToggle.tsx
@@ -33,7 +33,7 @@ export function ColumnVisibilityToggle({
             <Columns3 className="h-4 w-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
+        <DropdownMenuContent align="end" onCloseAutoFocus={(e) => e.preventDefault()}>
           {columns.map((col) => (
             <DropdownMenuCheckboxItem
               key={col.id}


### PR DESCRIPTION
## Summary
- Prevent focus from staying on the column visibility toggle button after closing the dropdown menu

## Test plan
- [ ] Open column visibility dropdown, close it, verify focus does not stay on trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)