### PR TITLE
fix: restore navbar visibility when resizing to mobile

### DIFF
--- a/app/(site)/_components/layout/SiteHeader.tsx
+++ b/app/(site)/_components/layout/SiteHeader.tsx
@@ -193,7 +193,18 @@ export default function SiteHeader({
     setIsClient(true);
 
     window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
+
+    // Re-show header when resizing into mobile (scroll hide is desktop-only)
+    const mql = window.matchMedia("(max-width: 767px)");
+    const onBreakpoint = (e: MediaQueryListEvent) => {
+      if (e.matches) setIsHeaderVisible(true);
+    };
+    mql.addEventListener("change", onBreakpoint);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      mql.removeEventListener("change", onBreakpoint);
+    };
   }, [handleScroll]);
 
   function handleSearch(e: React.FormEvent) {


### PR DESCRIPTION
## Summary
- Fix navbar staying hidden when resizing from desktop to mobile after scroll-hide triggers
- Add `matchMedia` listener to re-show header when viewport crosses the 767px breakpoint

## Test plan
- [ ] At desktop width, scroll down so navbar hides
- [ ] Resize browser to mobile width — navbar should reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)