### PR TITLE
fix: address Copilot review feedback on blob and email routes

### DIFF
--- a/app/_og/og-layout.tsx
+++ b/app/_og/og-layout.tsx
@@ -27,8 +27,8 @@ export async function loadOgFonts() {
 export async function renderOgLayout({ title, subtitle, badge, siteUrl, logoUrl }: OgLayoutProps) {
   let logoSrc: string;
 
-  if (logoUrl && logoUrl.startsWith("https://")) {
-    // External URL (blob storage, CDN) — use directly
+  if (logoUrl && (logoUrl.startsWith("https://") || logoUrl.startsWith("http://"))) {
+    // External URL (blob storage, CDN, localhost) — use directly
     logoSrc = logoUrl;
   } else {
     // Fallback: read default SVG from filesystem

--- a/app/api/admin/orders/[orderId]/refund/route.ts
+++ b/app/api/admin/orders/[orderId]/refund/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireAdmin } from "@/lib/admin";
+import { requireAdminApi } from "@/lib/admin";
 import { stripe } from "@/lib/services/stripe";
 import { resend } from "@/lib/services/resend";
 import { render } from "@react-email/components";
@@ -16,7 +16,13 @@ export async function POST(
   { params }: { params: Promise<{ orderId: string }> }
 ) {
   try {
-    await requireAdmin();
+    const auth = await requireAdminApi();
+    if (!auth.authorized) {
+      return NextResponse.json(
+        { error: "Admin access required" },
+        { status: 403 }
+      );
+    }
 
     const { orderId } = await params;
     const body = await request.json();
@@ -127,8 +133,12 @@ export async function POST(
           getEmailBranding(),
           prisma.siteSettings.findUnique({ where: { key: "contactEmail" } }),
         ]);
+        // Extract plain email address (RESEND_FROM_EMAIL may use "Name <email>" format)
+        const fromEnv = process.env.RESEND_FROM_EMAIL || "";
+        const addrMatch = fromEnv.match(/<([^>]+)>/);
+        const fallbackEmail = addrMatch ? addrMatch[1] : fromEnv;
         const supportEmail =
-          contactEmailSetting?.value || process.env.RESEND_FROM_EMAIL;
+          contactEmailSetting?.value || fallbackEmail;
 
         const isFullRefund =
           updatedOrder.refundedAmountInCents >= order.totalInCents;
@@ -186,13 +196,6 @@ export async function POST(
     });
   } catch (error: unknown) {
     console.error("Refund error:", error);
-
-    if (error instanceof Error && error.message.includes("Unauthorized")) {
-      return NextResponse.json(
-        { error: "Admin access required" },
-        { status: 403 }
-      );
-    }
 
     return NextResponse.json(
       { error: "Failed to process refund" },

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,8 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { uploadToBlob, deleteFromBlob, isBlobUrl } from "@/lib/blob";
+import { requireAdminApi } from "@/lib/admin";
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
 
 export async function POST(request: NextRequest) {
   try {
+    const auth = await requireAdminApi();
+    if (!auth.authorized) {
+      return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+    }
+
     const formData = await request.formData();
     const file = formData.get("file") as File;
     const oldPath = formData.get("oldPath") as string | null;
@@ -15,6 +23,13 @@ export async function POST(request: NextRequest) {
     if (!file.type.startsWith("image/")) {
       return NextResponse.json(
         { error: "File must be an image" },
+        { status: 400 }
+      );
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json(
+        { error: "File size must be under 5 MB" },
         { status: 400 }
       );
     }
@@ -49,6 +64,11 @@ export async function POST(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   try {
+    const auth = await requireAdminApi();
+    if (!auth.authorized) {
+      return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+    }
+
     const { searchParams } = new URL(request.url);
     const imagePath = searchParams.get("path");
 

--- a/emails/_components.tsx
+++ b/emails/_components.tsx
@@ -19,7 +19,9 @@ import * as s from "./_styles";
 // Shared constants — single source of truth for all email templates
 // ---------------------------------------------------------------------------
 
-export const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "";
+export const APP_URL =
+  process.env.NEXT_PUBLIC_APP_URL ||
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000");
 
 // ---------------------------------------------------------------------------
 // EmailBranding — every template extends this so branding props are declared
@@ -140,9 +142,11 @@ export function Footer({
           />
         </Link>
       ) : (
-        <Link href={appUrl} style={{ textDecoration: "none" }}>
-          <Text style={s.footerStoreName}>{storeName}</Text>
-        </Link>
+        <Text style={s.footerStoreName}>
+          <Link href={appUrl} style={{ color: "inherit", textDecoration: "none" }}>
+            {storeName}
+          </Link>
+        </Text>
       )}
       <Link href={appUrl} style={s.footerUrl}>
         {domain}

--- a/lib/blob.ts
+++ b/lib/blob.ts
@@ -49,5 +49,15 @@ export async function deleteFromBlob(url: string): Promise<void> {
 
 /** Check if a URL is a Vercel Blob URL (vs a relative local path). */
 export function isBlobUrl(url: string): boolean {
-  return url.startsWith("https://") && url.includes(".blob.vercel-storage.com");
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") return false;
+    const { hostname } = parsed;
+    return (
+      hostname === "blob.vercel-storage.com" ||
+      hostname.endsWith(".blob.vercel-storage.com")
+    );
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
Addresses 8 of 10 Copilot review comments from PR #193 (blob migration):

- **Security**: Add `requireAdminApi()` auth to general upload POST/DELETE routes (were unauthenticated)
- **Security**: Add 5 MB file size limit to general upload route
- **Security**: Harden `isBlobUrl()` — parse URL hostname instead of substring `includes()` check
- **HTML validity**: Fix email footer — `<Link>` inside `<Text>` instead of wrapping it (invalid `<a><p>`)
- **API correctness**: Refund route uses `requireAdminApi()` (returns JSON 403) instead of `requireAdmin()` (redirects)
- **Mailto fix**: Parse plain email address from `RESEND_FROM_EMAIL` display-name format (`"Name <email>"`)
- **Dev experience**: OG layout accepts `http://` URLs (local dev with localhost)
- **Robustness**: `APP_URL` falls back to `VERCEL_URL` / `localhost:3000` for email link generation

**Dismissed (not applicable):**
- `BLOB_READ_WRITE_TOKEN` optional — intentional (Vercel auto-injects)
- Version bump without changelog — handled by our release workflow

## Test plan
- [ ] Upload route rejects unauthenticated requests with 403
- [ ] Upload route rejects files over 5 MB
- [ ] `isBlobUrl()` correctly identifies blob URLs and rejects non-blob URLs
- [ ] Email footer renders valid HTML (no `<a><p>` nesting)
- [ ] Refund route returns JSON 403 when not admin (no redirect)
- [ ] `npm run precheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)