### PR TITLE
chore: bump version to 0.92.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.92.10",
+  "version": "0.92.11",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Sync package.json version with git tag v0.92.11 for Vercel build compatibility.