### PR TITLE
chore: disable attribution and tighten GitHub ruleset

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -104,6 +104,10 @@
       "mcp__ide__getDiagnostics"
     ]
   },
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.93.2 - 2026-03-05
+
+### Changed
+
+- Disable Claude Code attribution on commits and PRs
+- Tighten GitHub ruleset: require review thread resolution before merge
+
 ## 0.93.1 - 2026-03-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Disable Claude Code commit and PR attribution in settings.json
- Tighten GitHub `main-protection` ruleset: require 1 approving review and review thread resolution before merge
- Version bump to 0.93.2

## Test plan

- [x] `npm run precheck` — 0 errors
- [x] `npm run test:ci` — 996 tests pass (87 suites)