### PR TITLE
fix: enable custom date ranges on all dashboard pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.93.3 - 2026-03-05
+
+### Fixed
+
+- **Custom date ranges**: Calendar date picker now works on all dashboard pages (Overview, Sales, User Analytics) — previously only User Analytics responded to custom selections
+- **Shared date utilities**: Extract `resolveRange` and `validateCustomDateParams` to eliminate duplication across 3 API routes and 3 services
+
+### Added
+
+- Unit tests for `resolveRange` and `validateCustomDateParams`
+
 ## 0.93.2 - 2026-03-05
 
 ### Changed

--- a/app/admin/_components/analytics/DateRangePicker.tsx
+++ b/app/admin/_components/analytics/DateRangePicker.tsx
@@ -101,11 +101,15 @@ function UrlSyncedDateRangePicker({ className, hideCompare }: { className?: stri
   const searchParams = useSearchParams();
   const currentPeriod = parsePeriodParam(searchParams.get("period"));
   const currentCompare = parseCompareParam(searchParams.get("compare"));
+  const customFrom = searchParams.get("from") ?? undefined;
+  const customTo = searchParams.get("to") ?? undefined;
 
   const handlePeriodChange = useCallback(
     (preset: PeriodPreset) => {
       const params = new URLSearchParams(searchParams.toString());
       params.set("period", preset);
+      params.delete("from");
+      params.delete("to");
       router.push(`?${params.toString()}`);
     },
     [router, searchParams]
@@ -120,12 +124,26 @@ function UrlSyncedDateRangePicker({ className, hideCompare }: { className?: stri
     [router, searchParams]
   );
 
+  const handleCustomRangeChange = useCallback(
+    (from: string, to: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("from", from);
+      params.set("to", to);
+      params.delete("period");
+      router.push(`?${params.toString()}`);
+    },
+    [router, searchParams]
+  );
+
   return (
     <DateRangePickerView
       period={currentPeriod}
       compare={currentCompare}
       onPeriodChange={handlePeriodChange}
       onCompareChange={handleCompareChange}
+      customFrom={customFrom}
+      customTo={customTo}
+      onCustomRangeChange={handleCustomRangeChange}
       className={className}
       hideCompare={hideCompare}
     />
@@ -173,8 +191,8 @@ function DateRangePickerView({
   const displayTo = isCustom ? new Date(customTo) : getDateRange(period).to;
   const presetLabel = !isCustom ? PERIOD_PRESETS.find((p) => p.key === period)?.label : null;
   const triggerPreset = presetLabel ? `Last ${presetLabel}` : "Custom";
-  // displayTo is exclusive (start-of-next-day); show the inclusive end date
-  const displayToInclusive = isCustom ? displayTo : subDays(displayTo, 1);
+  // displayTo is always exclusive (start-of-next-day); show the inclusive end date
+  const displayToInclusive = subDays(displayTo, 1);
   const triggerDates = `${format(displayFrom, "MMM d")} – ${format(displayToInclusive, "MMM d, yyyy")}`;
 
   // Calendar selection — show pending custom range or pending preset range

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { getSiteMetadata } from "@/lib/site-metadata";
-import { parsePeriodParam, parseCompareParam } from "@/lib/admin/analytics/time";
+import { parsePeriodParam, parseCompareParam, validateCustomDateParams } from "@/lib/admin/analytics/time";
 import { getDashboardAnalytics } from "@/lib/admin/analytics/services/get-dashboard-analytics";
 import AdminDashboardClient from "./AdminDashboardClient";
 
@@ -15,7 +15,7 @@ export async function generateMetadata() {
 }
 
 interface AdminDashboardPageProps {
-  searchParams: Promise<{ period?: string; compare?: string }>;
+  searchParams: Promise<{ period?: string; compare?: string; from?: string; to?: string }>;
 }
 
 export default async function AdminDashboardPage({
@@ -37,10 +37,12 @@ export default async function AdminDashboardPage({
   }
 
   const params = await searchParams;
-  const period = parsePeriodParam(params.period);
   const compare = parseCompareParam(params.compare);
 
-  const data = await getDashboardAnalytics({ period, compare });
+  const isCustom = !!(params.from && params.to && !validateCustomDateParams(params.from, params.to));
+  const data = isCustom
+    ? await getDashboardAnalytics({ customFrom: params.from!, customTo: params.to!, compare })
+    : await getDashboardAnalytics({ period: parsePeriodParam(params.period), compare });
 
   return (
     <AdminDashboardClient

--- a/app/admin/sales/SalesClient.tsx
+++ b/app/admin/sales/SalesClient.tsx
@@ -48,6 +48,8 @@ interface SalesClientProps {
 export default function SalesClient({ weightUnit }: SalesClientProps) {
   const [period, setPeriod] = useState<PeriodPreset>("30d");
   const [compare, setCompare] = useState<CompareMode>("previous");
+  const [customFrom, setCustomFrom] = useState<string | undefined>();
+  const [customTo, setCustomTo] = useState<string | undefined>();
   const [activeFilter, setActiveFilter] = useState<ActiveFilter | null>(null);
   const { columnVisibility, handleVisibilityChange } =
     useColumnVisibility("sales-table-cols");
@@ -66,23 +68,35 @@ export default function SalesClient({ weightUnit }: SalesClientProps) {
 
   // Build filter query params from activeFilter state
   const filterParams = buildFilterQueryParams(activeFilter);
+  const isCustom = !!(customFrom && customTo);
 
-  const apiUrl = `/api/admin/sales?period=${period}&compare=${compare}&page=${pagination.pageIndex}&pageSize=${pagination.pageSize}&sort=${sortCol}&dir=${sortDir}${filterParams}`;
+  const dateParams = isCustom
+    ? `from=${customFrom}&to=${customTo}&compare=${compare}`
+    : `period=${period}&compare=${compare}`;
+  const apiUrl = `/api/admin/sales?${dateParams}&page=${pagination.pageIndex}&pageSize=${pagination.pageSize}&sort=${sortCol}&dir=${sortDir}${filterParams}`;
 
   const { data, isLoading } = useSWR<SalesResponse>(apiUrl, fetcher, {
     keepPreviousData: true,
   });
 
   const handleExportCsv = useCallback(() => {
-    window.open(
-      `/api/admin/sales?period=${period}&compare=${compare}&export=csv`,
-      "_blank"
-    );
-  }, [period, compare]);
+    const exportDateParams = isCustom
+      ? `from=${customFrom}&to=${customTo}&compare=${compare}`
+      : `period=${period}&compare=${compare}`;
+    window.open(`/api/admin/sales?${exportDateParams}&export=csv`, "_blank");
+  }, [period, compare, isCustom, customFrom, customTo]);
 
   // Reset pagination when period/compare changes
   const handlePeriodChange = useCallback((p: PeriodPreset) => {
     setPeriod(p);
+    setCustomFrom(undefined);
+    setCustomTo(undefined);
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  }, []);
+
+  const handleCustomRangeChange = useCallback((from: string, to: string) => {
+    setCustomFrom(from);
+    setCustomTo(to);
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
   }, []);
 
@@ -215,6 +229,9 @@ export default function SalesClient({ weightUnit }: SalesClientProps) {
           compare={compare}
           onPeriodChange={handlePeriodChange}
           onCompareChange={handleCompareChange}
+          customFrom={customFrom}
+          customTo={customTo}
+          onCustomRangeChange={handleCustomRangeChange}
           hideCompare
         />
       </DashboardToolbar>

--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireAdminApi } from "@/lib/admin";
-import { parsePeriodParam, parseCompareParam } from "@/lib/admin/analytics/time";
+import { parsePeriodParam, parseCompareParam, validateCustomDateParams } from "@/lib/admin/analytics/time";
 import { getUserAnalytics } from "@/lib/admin/analytics/services/get-user-analytics";
 import { buildCsvString } from "@/lib/admin/analytics/csv-export";
 
@@ -20,19 +20,9 @@ export async function GET(request: Request) {
 
     let data;
     if (fromParam && toParam) {
-      // Validate ISO dates
-      const fromDate = new Date(fromParam);
-      const toDate = new Date(toParam);
-      if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
-        return NextResponse.json({ error: "Invalid date format — use ISO 8601" }, { status: 400 });
-      }
-      if (fromDate >= toDate) {
-        return NextResponse.json({ error: "from must be before to" }, { status: 400 });
-      }
-      // Enforce max 366-day range
-      const daySpan = (toDate.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24);
-      if (daySpan > 366) {
-        return NextResponse.json({ error: "Date range must not exceed 366 days" }, { status: 400 });
+      const dateError = validateCustomDateParams(fromParam, toParam);
+      if (dateError) {
+        return NextResponse.json({ error: dateError }, { status: 400 });
       }
       data = await getUserAnalytics({ customFrom: fromParam, customTo: toParam, compare });
     } else {

--- a/app/api/admin/dashboard/route.ts
+++ b/app/api/admin/dashboard/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireAdminApi } from "@/lib/admin";
-import { parsePeriodParam, parseCompareParam } from "@/lib/admin/analytics/time";
+import { parsePeriodParam, parseCompareParam, validateCustomDateParams } from "@/lib/admin/analytics/time";
 import { getDashboardAnalytics } from "@/lib/admin/analytics/services/get-dashboard-analytics";
 
 export async function GET(request: Request) {
@@ -11,10 +11,20 @@ export async function GET(request: Request) {
     }
 
     const { searchParams } = new URL(request.url);
-    const period = parsePeriodParam(searchParams.get("period"));
     const compare = parseCompareParam(searchParams.get("compare"));
+    const fromParam = searchParams.get("from");
+    const toParam = searchParams.get("to");
 
-    const data = await getDashboardAnalytics({ period, compare });
+    let data;
+    if (fromParam && toParam) {
+      const error = validateCustomDateParams(fromParam, toParam);
+      if (error) {
+        return NextResponse.json({ error }, { status: 400 });
+      }
+      data = await getDashboardAnalytics({ customFrom: fromParam, customTo: toParam, compare });
+    } else {
+      data = await getDashboardAnalytics({ period: parsePeriodParam(searchParams.get("period")), compare });
+    }
 
     return NextResponse.json(data);
   } catch (error) {

--- a/app/api/admin/sales/route.ts
+++ b/app/api/admin/sales/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { OrderStatus } from "@prisma/client";
 import { requireAdminApi } from "@/lib/admin";
-import { parsePeriodParam, parseCompareParam } from "@/lib/admin/analytics/time";
+import { parsePeriodParam, parseCompareParam, validateCustomDateParams } from "@/lib/admin/analytics/time";
 import { getSalesAnalytics } from "@/lib/admin/analytics/services/get-sales-analytics";
 import { buildCsvString } from "@/lib/admin/analytics/csv-export";
 import { formatCurrency } from "@/lib/admin/analytics/formatters";
@@ -18,11 +18,23 @@ export async function GET(request: Request) {
     }
 
     const { searchParams } = new URL(request.url);
-    const period = parsePeriodParam(searchParams.get("period"));
     const compare = parseCompareParam(searchParams.get("compare"));
+    const fromParam = searchParams.get("from");
+    const toParam = searchParams.get("to");
+
+    if (fromParam && toParam) {
+      const dateError = validateCustomDateParams(fromParam, toParam);
+      if (dateError) {
+        return NextResponse.json({ error: dateError }, { status: 400 });
+      }
+    }
+
+    const dateParams = fromParam && toParam
+      ? { customFrom: fromParam, customTo: toParam } as const
+      : { period: parsePeriodParam(searchParams.get("period")) } as const;
 
     const data = await getSalesAnalytics({
-      period,
+      ...dateParams,
       compare,
       orderType: parseOrderType(searchParams.get("orderType")),
       statuses: parseStatuses(searchParams.get("status")),

--- a/lib/admin/analytics/__tests__/time.test.ts
+++ b/lib/admin/analytics/__tests__/time.test.ts
@@ -6,6 +6,8 @@ import {
   toDateKey,
   generateDateKeys,
   bucketByDay,
+  validateCustomDateParams,
+  resolveRange,
 } from "../time";
 
 describe("parsePeriodParam", () => {
@@ -96,5 +98,97 @@ describe("bucketByDay", () => {
     const map = bucketByDay(items, (i) => i.createdAt);
     expect(map.get("2026-03-01")?.length).toBe(2);
     expect(map.get("2026-03-02")?.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateCustomDateParams
+// ---------------------------------------------------------------------------
+
+describe("validateCustomDateParams", () => {
+  it("returns null for valid date ranges", () => {
+    expect(validateCustomDateParams("2026-01-01T00:00:00Z", "2026-01-15T00:00:00Z")).toBeNull();
+    expect(validateCustomDateParams("2026-01-01", "2026-02-01")).toBeNull();
+  });
+
+  it("rejects invalid date strings", () => {
+    expect(validateCustomDateParams("not-a-date", "2026-01-15")).toBe(
+      "Invalid date format — use ISO 8601"
+    );
+    expect(validateCustomDateParams("2026-01-01", "nope")).toBe(
+      "Invalid date format — use ISO 8601"
+    );
+  });
+
+  it("rejects from >= to", () => {
+    expect(validateCustomDateParams("2026-03-10", "2026-03-01")).toBe(
+      "from must be before to"
+    );
+  });
+
+  it("rejects from equal to to", () => {
+    expect(validateCustomDateParams("2026-03-01", "2026-03-01")).toBe(
+      "from must be before to"
+    );
+  });
+
+  it("rejects ranges exceeding 366 days", () => {
+    expect(validateCustomDateParams("2024-01-01", "2025-01-03")).toBe(
+      "Date range must not exceed 366 days"
+    );
+  });
+
+  it("allows exactly 366 days (leap year boundary)", () => {
+    // 2024 is a leap year: Jan 1 2024 → Jan 1 2025 = exactly 366 days
+    expect(validateCustomDateParams("2024-01-01", "2025-01-01")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRange
+// ---------------------------------------------------------------------------
+
+describe("resolveRange", () => {
+  it("resolves a preset period via getDateRange", () => {
+    const range = resolveRange({ period: "7d" });
+    const expected = getDateRange("7d");
+    expect(range.from.getTime()).toBe(expected.from.getTime());
+    expect(range.to.getTime()).toBe(expected.to.getTime());
+  });
+
+  it("resolves custom from/to into a DateRange with UTC midnight boundaries", () => {
+    const range = resolveRange({
+      customFrom: "2026-02-01T10:30:00Z",
+      customTo: "2026-02-15T18:45:00Z",
+    });
+    expect(toDateKey(range.from)).toBe("2026-02-01");
+    expect(range.from.getUTCHours()).toBe(0);
+    expect(toDateKey(range.to)).toBe("2026-02-15");
+    expect(range.to.getUTCHours()).toBe(0);
+  });
+
+  it("falls back to 30d for invalid custom from", () => {
+    const range = resolveRange({ customFrom: "bad", customTo: "2026-02-15" });
+    const fallback = getDateRange("30d");
+    expect(range.from.getTime()).toBe(fallback.from.getTime());
+    expect(range.to.getTime()).toBe(fallback.to.getTime());
+  });
+
+  it("falls back to 30d for invalid custom to", () => {
+    const range = resolveRange({ customFrom: "2026-02-01", customTo: "bad" });
+    const fallback = getDateRange("30d");
+    expect(range.from.getTime()).toBe(fallback.from.getTime());
+  });
+
+  it("falls back to 30d when from >= to", () => {
+    const range = resolveRange({ customFrom: "2026-03-10", customTo: "2026-03-01" });
+    const fallback = getDateRange("30d");
+    expect(range.from.getTime()).toBe(fallback.from.getTime());
+  });
+
+  it("handles ISO date strings without time component", () => {
+    const range = resolveRange({ customFrom: "2026-01-15", customTo: "2026-02-15" });
+    expect(toDateKey(range.from)).toBe("2026-01-15");
+    expect(toDateKey(range.to)).toBe("2026-02-15");
   });
 });

--- a/lib/admin/analytics/services/get-dashboard-analytics.ts
+++ b/lib/admin/analytics/services/get-dashboard-analytics.ts
@@ -14,8 +14,8 @@ import type {
   CompareMode,
 } from "../contracts";
 import {
-  getDateRange,
   getComparisonRange,
+  resolveRange,
   toDateRangeDTO,
   type DateRange,
 } from "../time";
@@ -46,15 +46,16 @@ import {
   getCustomerSplit,
 } from "../queries/entity-queries";
 
-export interface GetDashboardParams {
-  period: PeriodPreset;
-  compare: CompareMode;
-}
+export type GetDashboardParams =
+  | { period: PeriodPreset; compare: CompareMode }
+  | { customFrom: string; customTo: string; compare: CompareMode };
 
 export async function getDashboardAnalytics(
   params: GetDashboardParams
 ): Promise<DashboardResponse> {
-  const range = getDateRange(params.period);
+  const range = "customFrom" in params
+    ? resolveRange({ customFrom: params.customFrom, customTo: params.customTo })
+    : resolveRange({ period: params.period });
   const compRange = getComparisonRange(range, params.compare);
 
   const kpiWhere = buildKpiOrderWhere({ range });

--- a/lib/admin/analytics/services/get-sales-analytics.ts
+++ b/lib/admin/analytics/services/get-sales-analytics.ts
@@ -13,8 +13,8 @@ import type {
   CompareMode,
 } from "../contracts";
 import {
-  getDateRange,
   getComparisonRange,
+  resolveRange,
   toDateRangeDTO,
   type DateRange,
 } from "../time";
@@ -47,8 +47,7 @@ import {
   getSalesTable,
 } from "../queries/order-aggregates";
 
-export interface GetSalesParams {
-  period: PeriodPreset;
+export type GetSalesParams = {
   compare: CompareMode;
   orderType?: "ALL" | "ONE_TIME" | "SUBSCRIPTION";
   statuses?: OrderStatus[];
@@ -62,12 +61,14 @@ export interface GetSalesParams {
   pageSize?: number;
   sort?: string;
   dir?: "asc" | "desc";
-}
+} & ({ period: PeriodPreset } | { customFrom: string; customTo: string });
 
 export async function getSalesAnalytics(
   params: GetSalesParams
 ): Promise<SalesResponse> {
-  const range = getDateRange(params.period);
+  const range = "customFrom" in params
+    ? resolveRange({ customFrom: params.customFrom, customTo: params.customTo })
+    : resolveRange({ period: params.period });
   const compRange = getComparisonRange(range, params.compare);
 
   // Base params (period only) — KPIs and charts are unaffected by table filters

--- a/lib/admin/analytics/services/get-user-analytics.ts
+++ b/lib/admin/analytics/services/get-user-analytics.ts
@@ -13,8 +13,8 @@ import type {
   FunnelStep,
 } from "../contracts";
 import {
-  getDateRange,
   getComparisonRange,
+  resolveRange,
   toDateRangeDTO,
   type DateRange,
 } from "../time";
@@ -74,24 +74,12 @@ async function buildKpisForRange(range: DateRange): Promise<UserAnalyticsKpis> {
   return kpisFromFunnel(funnel, totalSearches, totalPageViews);
 }
 
-function resolveRange(params: GetUserAnalyticsParams): DateRange {
-  if ("customFrom" in params) {
-    const from = new Date(params.customFrom);
-    const to = new Date(params.customTo);
-    if (isNaN(from.getTime()) || isNaN(to.getTime()) || from >= to) {
-      return getDateRange("30d");
-    }
-    from.setUTCHours(0, 0, 0, 0);
-    to.setUTCHours(0, 0, 0, 0);
-    return { from, to };
-  }
-  return getDateRange(params.period);
-}
-
 export async function getUserAnalytics(
   params: GetUserAnalyticsParams
 ): Promise<UserAnalyticsResponse> {
-  const range = resolveRange(params);
+  const range = "customFrom" in params
+    ? resolveRange({ customFrom: params.customFrom, customTo: params.customTo })
+    : resolveRange({ period: params.period });
   const compRange = getComparisonRange(range, params.compare);
 
   // Order count needed for funnel

--- a/lib/admin/analytics/time.ts
+++ b/lib/admin/analytics/time.ts
@@ -60,7 +60,7 @@ export interface DateRange {
 }
 
 /** Start of day in UTC (zeroes hours/minutes/seconds/ms). */
-function startOfDayUTC(date: Date): Date {
+export function startOfDayUTC(date: Date): Date {
   const d = new Date(date);
   d.setUTCHours(0, 0, 0, 0);
   return d;
@@ -113,6 +113,50 @@ export function getComparisonRange(
     from: subDays(range.from, days),
     to: range.from,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Custom date range helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate custom date params for API routes.
+ * Returns an error message string or null if valid.
+ */
+export function validateCustomDateParams(from: string, to: string): string | null {
+  const fromDate = new Date(from);
+  const toDate = new Date(to);
+  if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
+    return "Invalid date format — use ISO 8601";
+  }
+  if (fromDate >= toDate) {
+    return "from must be before to";
+  }
+  const daySpan = (toDate.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24);
+  if (daySpan > 366) {
+    return "Date range must not exceed 366 days";
+  }
+  return null;
+}
+
+/**
+ * Resolve a preset or custom from/to into a concrete DateRange.
+ * Falls back to 30d if custom dates are invalid.
+ */
+export function resolveRange(
+  params: { period: PeriodPreset } | { customFrom: string; customTo: string }
+): DateRange {
+  if ("customFrom" in params) {
+    const from = new Date(params.customFrom);
+    const to = new Date(params.customTo);
+    if (isNaN(from.getTime()) || isNaN(to.getTime()) || from >= to) {
+      return getDateRange("30d");
+    }
+    from.setUTCHours(0, 0, 0, 0);
+    to.setUTCHours(0, 0, 0, 0);
+    return { from, to };
+  }
+  return getDateRange(params.period);
 }
 
 // ---------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.93.2",
+  "version": "0.93.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Custom date range selections from the calendar picker now work on **all three dashboard pages** (Overview, Sales, User Analytics) — previously only User Analytics responded to custom calendar selections
- Extracted shared `resolveRange` and `validateCustomDateParams` into `time.ts` to eliminate duplication across 3 API routes and 3 services
- Added unit tests for both new shared functions (24 total time.test.ts tests pass)

## Changes

| File | Change |
|------|--------|
| `lib/admin/analytics/time.ts` | Add `resolveRange`, `validateCustomDateParams`, export `startOfDayUTC` |
| `app/admin/_components/analytics/DateRangePicker.tsx` | URL mode: wire custom from/to; fix displayTo for custom ranges |
| `app/admin/page.tsx` | Read from/to searchParams, pass to service |
| `lib/admin/analytics/services/get-dashboard-analytics.ts` | Union params type, use `resolveRange` |
| `app/api/admin/dashboard/route.ts` | Parse/validate from/to, pass to service |
| `app/admin/sales/SalesClient.tsx` | Add custom state + picker props + API URL |
| `app/api/admin/sales/route.ts` | Parse/validate from/to, pass to service |
| `lib/admin/analytics/services/get-sales-analytics.ts` | Union params type, use `resolveRange` |
| `lib/admin/analytics/services/get-user-analytics.ts` | Import shared `resolveRange`, remove local |
| `app/api/admin/analytics/route.ts` | Use shared `validateCustomDateParams` |
| `lib/admin/analytics/__tests__/time.test.ts` | Tests for `resolveRange` and `validateCustomDateParams` |

## Test plan

- [x] `npm run precheck` — 0 errors
- [x] `npm run test:ci` — 1008 tests pass
- [x] Select custom date range on Overview → data updates
- [ ] Select custom date range on Sales → data updates
- [ ] Switch back to preset → custom range clears
- [ ] Invalid dates (from > to) → API returns 400
- [ ] CSV export with custom range → correct data