### PR TITLE
chore: bump version to 0.93.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.93.4",
+  "version": "0.93.5",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Sync package.json version with git tag v0.93.5 for Vercel build compatibility.