### PR TITLE
fix: convert remaining top-level Stripe/Resend to lazy singletons

### DIFF
--- a/app/api/customer-portal/route.ts
+++ b/app/api/customer-portal/route.ts
@@ -1,11 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import Stripe from "stripe";
+import { getStripe } from "@/lib/services/stripe";
 import { getErrorMessage } from "@/lib/error-utils";
-
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2026-01-28.clover",
-});
 
 /**
  * POST /api/customer-portal
@@ -13,6 +10,14 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
  */
 export async function POST(req: NextRequest) {
   try {
+    const stripe = getStripe();
+    if (!stripe) {
+      return NextResponse.json(
+        { error: "Payments not configured" },
+        { status: 503 }
+      );
+    }
+
     const session = await auth();
 
     if (!session?.user?.email) {

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
-import Stripe from "stripe";
-import { Resend } from "resend";
 
 import { prisma } from "@/lib/prisma";
 import { validateEnv } from "@/lib/validate-env";
+import { getStripe } from "@/lib/services/stripe";
+import { getResend } from "@/lib/services/resend";
 
 type CheckStatus = "ok" | "error" | "skipped";
 
@@ -24,14 +24,6 @@ type HealthResponse = {
 
 export const dynamic = "force-dynamic";
 
-const stripeClient = process.env.STRIPE_SECRET_KEY
-  ? new Stripe(process.env.STRIPE_SECRET_KEY)
-  : null;
-
-const resendClient = process.env.RESEND_API_KEY
-  ? new Resend(process.env.RESEND_API_KEY)
-  : null;
-
 async function checkDatabase(): Promise<CheckResult> {
   try {
     await prisma.$queryRaw`SELECT 1`;
@@ -42,12 +34,13 @@ async function checkDatabase(): Promise<CheckResult> {
 }
 
 async function checkStripe(): Promise<CheckResult> {
-  if (!stripeClient) {
+  const stripe = getStripe();
+  if (!stripe) {
     return { status: "skipped", message: "STRIPE_SECRET_KEY not set" };
   }
 
   try {
-    await stripeClient.balance.retrieve();
+    await stripe.balance.retrieve();
     return { status: "ok" };
   } catch (error) {
     return { status: "error", message: toMessage(error) };
@@ -55,12 +48,13 @@ async function checkStripe(): Promise<CheckResult> {
 }
 
 async function checkResend(): Promise<CheckResult> {
-  if (!resendClient) {
+  const resend = getResend();
+  if (!resend) {
     return { status: "skipped", message: "RESEND_API_KEY not set" };
   }
 
   try {
-    await resendClient.domains.list();
+    await resend.domains.list();
     return { status: "ok" };
   } catch (error) {
     return { status: "error", message: toMessage(error) };

--- a/app/api/user/orders/[orderId]/cancel/route.ts
+++ b/app/api/user/orders/[orderId]/cancel/route.ts
@@ -1,18 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import Stripe from "stripe";
+import { getStripe } from "@/lib/services/stripe";
 import { getErrorMessage } from "@/lib/error-utils";
-
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2026-01-28.clover",
-});
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ orderId: string }> }
 ) {
   try {
+    const stripe = getStripe();
+
     const session = await auth();
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -57,8 +55,8 @@ export async function POST(
       );
     }
 
-    // Process refund via Stripe if payment intent exists
-    if (order.stripePaymentIntentId) {
+    // Process refund via Stripe if payment intent exists and Stripe is configured
+    if (order.stripePaymentIntentId && stripe) {
       try {
         await stripe.refunds.create({
           payment_intent: order.stripePaymentIntentId,
@@ -105,7 +103,7 @@ export async function POST(
     });
 
     // If this is a subscription order, cancel the Stripe subscription
-    if (order.stripeSubscriptionId) {
+    if (order.stripeSubscriptionId && stripe) {
       try {
         console.log(
           `🔄 Canceling Stripe subscription ${order.stripeSubscriptionId}...`


### PR DESCRIPTION
## Summary

- Convert `/api/customer-portal`, `/api/health`, `/api/user/orders/[orderId]/cancel` from top-level `new Stripe()` to `getStripe()` lazy singleton
- These were missed in the Phase 2 graceful degradation work and caused build failures in the install matrix CI when `STRIPE_SECRET_KEY` is not set

## Test plan

- [ ] Install matrix CI passes (all 4 profiles build successfully)
- [ ] Health endpoint still works with and without Stripe/Resend keys
- [ ] Customer portal returns 503 when Stripe is unconfigured