### PR TITLE
fix: remove --skip-seed from prisma migrate reset (Prisma v7)

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.QA_DATABASE_URL }}
           DIRECT_URL: ${{ secrets.QA_DIRECT_URL }}
-        run: npx prisma migrate reset --force --skip-seed
+        run: npx prisma migrate reset --force
 
       # ── Wait for QA deployment to be ready ───────────────────────────────
       - name: Wait for deployment


### PR DESCRIPTION
Prisma v7 dropped the `--skip-seed` flag from `migrate reset`. Remove it — `--force` is sufficient for CI DB reset.