### PR TITLE
Fix AC-KV-4: checkText now includes input/textarea/select values

### DIFF
--- a/scripts/qa-agent.js
+++ b/scripts/qa-agent.js
@@ -128,8 +128,18 @@ async function checkText(page, text) {
   const content = await page.evaluate(() => {
     const bodyText = document.body.innerText;
     const inputValues = Array.from(
-      document.querySelectorAll("input, textarea, select")
-    ).map((el) => el.value).join(" ");
+      document.querySelectorAll(
+        "textarea, select, input:not([type='password']):not([type='hidden']):not([type='checkbox']):not([type='radio'])"
+      )
+    )
+      .map((el) => {
+        if (el.tagName === "SELECT") {
+          const selectedOptions = Array.from(el.selectedOptions || []);
+          return selectedOptions.map((opt) => opt.textContent || "").join(" ");
+        }
+        return el.value;
+      })
+      .join(" ");
     return bodyText + " " + inputValues;
   });
   const matches = content.toLowerCase().includes(text.toLowerCase());


### PR DESCRIPTION
The checkText function only checked document.body.innerText, which
doesn't include values inside form input elements. The store name on
/admin/settings is rendered in an <input> field, so it was not found.

https://claude.ai/code/session_01LuCY8XGYpB3yf5rhVCAhoD