### PR TITLE
chore: release 0.96.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.96.8 - 2026-03-22
+
+### Fixed
+
+- **Auth pages**: Added `force-dynamic` to auth layout to prevent nightly build failures when DB is unavailable at build time (all `/auth/*` pages call `getSiteMetadata()` which hits Prisma)
+- **QA agent**: `checkText` now includes `<input>`/`<textarea>`/`<select>` values so AC-KV-4 (store name on settings page) passes correctly
+- **track-activity test**: Mocked Prisma to prevent DB connection timeout in CI
+
 ## 0.96.7 - 2026-03-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.96.7",
+  "version": "0.96.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.96.7",
+      "version": "0.96.8",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.96.7",
+  "version": "0.96.8",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bump version to 0.96.8 and update CHANGELOG.

- Auth pages force-dynamic (nightly build fix)
- QA agent checkText includes input values (AC-KV-4)
- track-activity test Prisma mock (CI timeout fix)