### PR TITLE
fix: release script skips sync PR when package.json is pre-bumped (v0.96.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.96.18 - 2026-03-24
+
+### Fixed
+
+- **Release script**: `npm run release:patch` no longer creates a redundant version-bump PR when `package.json` is already pre-bumped in the feature branch — detects the pre-bump and uses it as the tag version directly, making the release a fast tag+push with no extra CI run
+
 ## 0.96.17 - 2026-03-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.96.16",
+  "version": "0.96.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.96.16",
+      "version": "0.96.18",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.96.17",
+  "version": "0.96.18",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -119,6 +119,14 @@ function bumpVersion(version: string, type: BumpType): string {
   }
 }
 
+function semverGt(a: string, b: string): boolean {
+  const [aMaj, aMin, aPat] = a.split(".").map(Number);
+  const [bMaj, bMin, bPat] = b.split(".").map(Number);
+  if (aMaj !== bMaj) return aMaj > bMaj;
+  if (aMin !== bMin) return aMin > bMin;
+  return aPat > bPat;
+}
+
 function getLastTag(): string | null {
   const tags = exec("git tag -l v* --sort=-v:refname");
   if (!tags) return null;
@@ -378,13 +386,19 @@ async function main() {
 
   const lastTag = getLastTag();
   const currentVersion = getVersionFromTag(lastTag);
-  const newVersion = bumpVersion(currentVersion, bumpType as BumpType);
+  const pkgVersion = getPackageVersion();
+
+  // If package.json is already pre-bumped ahead of the last tag (set in the feature branch PR),
+  // use it directly — no sync PR needed. Otherwise, compute the bump from the tag.
+  const computedNewVersion = bumpVersion(currentVersion, bumpType as BumpType);
+  const preBumped = semverGt(pkgVersion, currentVersion);
+  const newVersion = preBumped ? pkgVersion : computedNewVersion;
   const newTag = `v${newVersion}`;
 
   console.log("\n📦 Release Script (tag-only)");
   console.log("─".repeat(50));
   console.log(`Current tag:     ${lastTag || "(none)"}`);
-  console.log(`New tag:         ${newTag} (${bumpType})`);
+  console.log(`New tag:         ${newTag} (${preBumped ? "pre-bumped in package.json" : bumpType})`);
   console.log(`Mode:            ${flags.yes ? "non-interactive" : "interactive"}`);
 
   // Show commits since last tag


### PR DESCRIPTION
## Summary

- `npm run release:patch` now detects when `package.json` is already pre-bumped in the feature branch PR and uses that version as the tag directly — no extra version-bump PR, no extra CI run
- When `package.json` > last tag: fast path → just `git tag + git push`
- When `package.json` = last tag (not pre-bumped): old behavior, sync PR created

## This PR is also a proof of concept

`package.json` is set to `0.96.18` here. After merge, `/release patch` should:
1. Detect `package.json (0.96.18) > last tag (v0.96.17)` → use `0.96.18`
2. `syncPackageJson(0.96.18)` → already at `0.96.18` → skip
3. Tag `v0.96.18` + push — done, no extra PR