### PR TITLE
docs: add product roadmap and agentic search feature spec

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,7 +41,7 @@ _Nothing in progress. v0.98.4 just shipped._
 
 | Priority | Feature | Spec / Notes |
 |----------|---------|--------------|
-| P1 | Reviews Tier 2 — AI Roast Master | [`docs/internal/product-reviews-tier2.md`](internal/product-reviews-tier2.md) — depends on Phase B data |
+| P1 | Reviews Tier 2 — AI Roast Master | `docs/internal/product-reviews-tier2.md` — depends on Phase B data |
 | P2 | A1: AI Assist Tests | `app/admin/(cms)/pages/[id]/ai-assist/` — unit + component tests |
 | P3 | Agentic search Phase B + Reviews Tier 2 integration | Platform search uses review utility scores |
 
@@ -86,7 +86,7 @@ _Nothing in progress. v0.98.4 just shipped._
 ## Convention
 
 - **Before starting a feature:** add it to Next or Backlog with a link to its spec
-- **When planning a sprint:** create `docs/features/<name>/spec.md` and `docs/plans/<name>-plan.md`
+- **When planning a sprint:** ensure `docs/features/<name>/spec.md` exists and create `docs/plans/<name>-plan.md`
 - **When shipping:** move the item from Next/Backlog to Shipped, bump the version row
 - **`docs/plans/`** — per-sprint ACs and implementation plans (granular, created at sprint start)
 - **`docs/features/`** — durable feature specs (created when feature is first planned, updated as it evolves)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,93 @@
+# Artisan Roast — Product Roadmap
+
+> **Single source of truth for what's being built.**
+> Update this doc on every release and before starting any new feature.
+> Details live in `docs/features/<name>/` — this is the navigation layer only.
+
+---
+
+## Now — v0.99.x
+
+_Nothing in progress. v0.98.4 just shipped._
+
+---
+
+## Next — Agentic Product Discovery
+
+> **The claim:** Free-tier agentic product discovery — no other e-commerce platform ships this natively in 2026. Platform tier adds personalization on top.
+
+### Phase A — Free Tier (ships as one PR or two)
+
+| # | Item | Notes |
+|---|------|-------|
+| A0 | Homepage hero swap | Video or image slides; remove floating AI-Barista widget |
+| A1 | Structured search JSON backbone | Evolve `/api/search` response shape |
+| A2 | NL filter extraction | Gemini Flash: query → intent + filters → explanation |
+| A3 | Conversational follow-ups | Session-scoped, stateless, no persistence |
+
+**Spec:** [`docs/features/agentic-search/spec.md`](features/agentic-search/spec.md)
+
+### Phase B — Platform Tier (follows Phase A)
+
+| # | Item | Notes |
+|---|------|-------|
+| B1 | User context aggregation | `getUserPurchaseHistory`, `getUserRecentViews`, etc. |
+| B2 | Personalized search ranking | Inject user context into agentic search prompt |
+| B3 | "Recommended For You" | Authenticated carousel, homepage |
+
+---
+
+## Backlog — Prioritized
+
+| Priority | Feature | Spec / Notes |
+|----------|---------|--------------|
+| P1 | Reviews Tier 2 — AI Roast Master | [`docs/internal/product-reviews-tier2.md`](internal/product-reviews-tier2.md) — depends on Phase B data |
+| P2 | A1: AI Assist Tests | `app/admin/(cms)/pages/[id]/ai-assist/` — unit + component tests |
+| P3 | Agentic search Phase B + Reviews Tier 2 integration | Platform search uses review utility scores |
+
+---
+
+## Shipped
+
+| Version | Feature |
+|---------|---------|
+| v0.98.4 | Repo cleanup — dev-tools removed, docs/internal tsconfig excluded |
+| v0.98.3 | Security — patched 17 npm vulnerabilities |
+| v0.98.2 | Platform — acceptedAt/acceptedVersions wiring + ticket reply thread |
+| v0.98.1 | Profile — admin password change via SecurityTab |
+| v0.98.0 | QA — self-healing pipeline (auto-classify, repair, close issues) |
+| v0.97.x | Demo mode — build variant system, amber toast, demo badges, banner hydration |
+| v0.96.x | Install — graceful degradation, auto-seed, setup checklist, QA agent |
+| v0.95.x | Platform — SaaS wiring, legal/EULA gate, platform API |
+| v0.94.x | Admin — order detail page, dashboard mobile responsiveness |
+| v0.93.x | Analytics — custom date ranges, analytics page restyle |
+| v0.92.x | Images — Vercel Blob migration |
+| v0.91.x | Reviews — full Brew Report system (Tier 1 all 8 phases) |
+| v0.90.x | Storefront — theme switcher, storefront polish |
+| v0.89.x | Tables — shared data-table, table UI polish |
+| v0.88.x | Admin — orders, subscriptions responsive, refund flow |
+| v0.87.x | Products — table v1/v2, add/edit form |
+| v0.86.x | Mobile — audit, nav, responsive polish |
+| v0.85.x | Email — provider settings, SVG logo, templates |
+| v0.84.x | Support — services, nav, ticket system |
+| v0.83.x | Stripe — promo codes, billing portal |
+| v0.82.x | Cart — add-to-cart standardization, price alignment |
+| v0.81.x | Add-ons — undo/redo, add-on links |
+| v0.80.x | Auth — admin profile API, version check endpoint |
+| v0.79.x | Telemetry — install tracking, heartbeat cron |
+| v0.78.x | Feedback — in-app widget, `/api/feedback` |
+| v0.77.x | Orders — failed order status, FAILED badge |
+| v0.76.x | Version system — `lib/version.ts`, update banner |
+| v0.75.x | Menu Builder — v1.0 launch (all 3 phases complete) |
+| v0.72.x | AI — pages CMS, About Page wizard, AI content generation |
+
+---
+
+## Convention
+
+- **Before starting a feature:** add it to Next or Backlog with a link to its spec
+- **When planning a sprint:** create `docs/features/<name>/spec.md` and `docs/plans/<name>-plan.md`
+- **When shipping:** move the item from Next/Backlog to Shipped, bump the version row
+- **`docs/plans/`** — per-sprint ACs and implementation plans (granular, created at sprint start)
+- **`docs/features/`** — durable feature specs (created when feature is first planned, updated as it evolves)
+- **`docs/internal/`** — gitignored, strategy/competitive/private notes

--- a/docs/features/agentic-search/spec.md
+++ b/docs/features/agentic-search/spec.md
@@ -1,0 +1,166 @@
+# Agentic Product Discovery — Feature Spec
+
+**Status:** Planned — Phase A next  
+**Roadmap:** [`docs/ROADMAP.md`](../../ROADMAP.md)  
+**Internal strategy:** `docs/internal/ai-recommendations-internal-plan.md` (gitignored)
+
+---
+
+## What It Is
+
+The search bar becomes the primary AI entry point. Instead of filtering by keyword, customers describe what they want in natural language. The system extracts intent, runs a structured query, and explains the results conversationally.
+
+The floating AI-Barista chat widget is retired. Search *is* the barista.
+
+---
+
+## Tier Boundary
+
+| Capability | Free | Platform |
+|---|---|---|
+| NL → filter extraction (brew method, roast, origin, flavor) | ✅ | ✅ |
+| "Why these results" explanation | ✅ | ✅ |
+| Conversational follow-up suggestions | ✅ | ✅ |
+| Structured JSON response backbone | ✅ | ✅ |
+| Session-scoped turn context (stateless, no persistence) | ✅ | ✅ |
+| Per-user context (order history, past views, searches) | ❌ | ✅ |
+| Personalized result ranking | ❌ | ✅ |
+| "Recommended For You" authenticated carousel | ❌ | ✅ |
+| Reviews Tier 2 utility scores in results | ❌ | ✅ |
+
+**Free = discoverability for any visitor.** No account. No data stored beyond the session.  
+**Platform = the AI knows you.** Order history, preference learning, cross-session memory.
+
+---
+
+## Search Response Shape (the backbone)
+
+Both free and Platform tier populate this same contract. The Platform tier enriches `explanation` and `followUps` with user-specific context.
+
+```typescript
+interface AgenticSearchResponse {
+  query: string
+  intent: "product_discovery" | "recommendation" | "how_to" | "reorder"
+  filtersExtracted: {
+    brewMethod?: string        // "V60", "espresso", "french press"
+    roastLevel?: string        // "light", "medium", "dark"
+    flavorProfile?: string[]   // ["fruity", "bright", "low-acid"]
+    origin?: string            // "Ethiopia", "Kenya"
+    priceMax?: number
+  }
+  results: ProductResult[]
+  explanation: string          // "These 3 work great for morning V60 brews because..."
+  followUps: string[]          // ["Prefer light or medium roast?", "Want our V60 brew guide?"]
+  context: {
+    sessionId: string
+    turnCount: number          // increments per query in the same session
+  }
+}
+```
+
+---
+
+## Phase A — Free Tier
+
+### A0: Homepage Hero Swap
+
+Replace the AI-Barista hero section with a video (preferred) or image slides:
+- Video: roasting footage, pour-over process, origin farm — autoplay muted
+- Slides: seasonal offerings, featured origins, new arrivals — CMS-controlled
+- Search bar becomes prominent below or overlaid on the hero
+- Floating AI-Barista chat widget removed entirely
+
+This is a standalone visual change. Ships first, independently.
+
+### A1: Structured Search Backbone
+
+Evolve `/api/search` to return `AgenticSearchResponse` instead of a flat product list.  
+The NL extraction step (A2) populates `filtersExtracted`, `explanation`, and `followUps`.  
+Falls back gracefully if LLM step fails — returns results without explanation.
+
+### A2: NL Filter Extraction
+
+Add a Gemini Flash preprocessing step before the Prisma query:
+
+```
+"something smooth and fruity for my morning V60"
+  → { brewMethod: "V60", flavorProfile: ["smooth", "fruity"], roastLevel: "light" }
+  → Prisma query with extracted filters
+  → explanation: "These 3 work great for V60 morning brews..."
+```
+
+Target: under 800ms total. Flash is fast enough — no streaming needed for search.
+
+### A3: Conversational Follow-ups
+
+Session-scoped turn context — in-memory only, never persisted:
+- `sessionId` generated client-side on first query
+- `turnCount` passed back so server knows conversation depth
+- `followUps` in response surface as quick-tap chips in the search UI
+- Tapping a follow-up appends to or replaces the current query
+
+---
+
+## Phase B — Platform Tier
+
+### B1: User Context Aggregation
+
+New data layer functions (`lib/data.ts`):
+- `getUserPurchaseHistory(userId)` — past orders with product details
+- `getUserRecentViews(userId, limit)` — last N `PRODUCT_VIEW` activities
+- `getUserSearchHistory(userId, limit)` — last N `SEARCH` activities
+- `getUserRecommendationContext(userId?)` — aggregated object for prompt injection
+
+### B2: Personalized Search Ranking
+
+When authenticated, inject user context into the agentic search prompt:
+```typescript
+// Added to system prompt for Platform-tier users
+USER CONTEXT:
+- Past purchases: Ethiopian Yirgacheffe (Light), Death Valley Espresso (Dark)
+- Recently viewed: Kenyan AA, Colombian Supremo
+- Inferred preferences: bright fruity lights + bold darks
+```
+
+Results are re-ranked and explanation references personal history.
+
+### B3: "Recommended For You" Carousel
+
+- Authenticated-only section on homepage, below hero
+- Endpoint: `/api/recommendations/personalized`
+- Algorithm: purchase history → match roast/origin/tasting notes → exclude already-purchased → boost by view count
+- Falls back to trending (same as free tier) for anonymous visitors
+- Reuses existing `ProductCard`
+
+---
+
+## Data Foundation (Already Shipped)
+
+The activity tracking infrastructure is already in production:
+
+- `UserActivity` model with `PRODUCT_VIEW`, `ADD_TO_CART`, `SEARCH`, `PAGE_VIEW`, `REMOVE_FROM_CART`
+- `/api/track-activity` — fire-and-forget endpoint
+- `/api/search` — logs `SEARCH` activities automatically
+- Product page — tracks `PRODUCT_VIEW` + `ADD_TO_CART`
+- Admin analytics (`/admin/analytics`) — `trendingProducts`, `topSearches`, behavior funnel
+
+Phase B only needs the *consumption* layer on top of this existing data.
+
+---
+
+## What This Replaces
+
+| Before | After |
+|--------|-------|
+| Floating AI-Barista chat widget | Removed |
+| Keyword-only search | Agentic NL search |
+| Static hero section | Video / image slides |
+| "AI Helper" modal (anonymous, generic) | Retained for Platform tier with user context |
+
+---
+
+## Open Questions
+
+- **Always-on or mode toggle?** Current lean: always-on with graceful degradation for short queries
+- **Video vs. slides for hero?** TBD — video is higher impact, slides are easier to keep fresh via CMS
+- **Phase A + B as one release or two?** Likely two — Phase A is the free-tier claim, Phase B is additive

--- a/docs/features/agentic-search/spec.md
+++ b/docs/features/agentic-search/spec.md
@@ -105,11 +105,16 @@ Session-scoped turn context — in-memory only, never persisted:
 
 ### B1: User Context Aggregation
 
-New data layer functions (`lib/data.ts`):
-- `getUserPurchaseHistory(userId)` — past orders with product details
-- `getUserRecentViews(userId, limit)` — last N `PRODUCT_VIEW` activities
-- `getUserSearchHistory(userId, limit)` — last N `SEARCH` activities
-- `getUserRecommendationContext(userId?)` — aggregated object for prompt injection
+Reuse and expand the existing data layer functions in `lib/data.ts`:
+- `getUserPurchaseHistory(userId)` — reuse for past orders with product details; extend only if additional joins/fields are needed for ranking or explanations
+- `getUserRecentViews(userId, limit)` — reuse for last N `PRODUCT_VIEW` activities; tune limits/windowing if needed for prompt quality
+- `getUserSearchHistory(userId, limit)` — reuse for last N `SEARCH` activities; tune limits/windowing if needed for prompt quality
+- `getUserRecommendationContext(userId?)` — reuse as the primary aggregated object for prompt injection and personalized ranking inputs
+
+Phase B gaps to add (if not already covered):
+- Normalize the aggregated payload shape for agentic search prompt injection
+- Include inferred preferences/summaries derived from purchases, views, and searches
+- Apply authenticated/platform-tier gating at the consumption layer
 
 ### B2: Personalized Search Ranking
 


### PR DESCRIPTION
## Summary

- Adds `docs/ROADMAP.md` — single source of truth for what's being built. Covers Now / Next / Backlog / Shipped with links to feature specs. Includes a convention section for keeping it in sync.
- Adds `docs/features/agentic-search/spec.md` — full feature spec for agentic product discovery: tier boundary table, JSON backbone shape, Phase A (free tier) and Phase B (Platform tier) breakdown, open questions.

## Convention going forward

- Before starting a feature → add to ROADMAP.md + create `docs/features/<name>/spec.md`
- When planning a sprint → create `docs/plans/<name>-plan.md` + ACs
- When shipping → move ROADMAP item to Shipped, bump version row