### PR TITLE
fix: address Copilot review feedback from PR #325

### DIFF
--- a/app/(site)/_components/ai/ChatPanel.tsx
+++ b/app/(site)/_components/ai/ChatPanel.tsx
@@ -376,9 +376,14 @@ function ProductCard({ product }: { product: ProductSummary }) {
 
 export function ChatPanel() {
   const { isOpen, close, open, clearMessages, addMessage } = useChatPanelStore();
+  const bodyCleanupRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Lock #site-scroll when drawer is open and clean up stale vaul body styles on close.
   useEffect(() => {
+    if (bodyCleanupRef.current !== null) {
+      clearTimeout(bodyCleanupRef.current);
+      bodyCleanupRef.current = null;
+    }
     if (!isOpen) return;
     const siteScroll = document.getElementById("site-scroll");
     if (siteScroll) siteScroll.style.overflow = "hidden";
@@ -387,7 +392,8 @@ export function ChatPanel() {
       // Vaul direction="right" leaves stale pointer-events/overflow on body
       // after its close animation. Only clear if Vaul is no longer scroll-locking
       // so we don't interfere with other overlays that may still be open.
-      setTimeout(() => {
+      bodyCleanupRef.current = setTimeout(() => {
+        bodyCleanupRef.current = null;
         if (document.body.hasAttribute("data-scroll-locked")) return;
         if (document.body.style.pointerEvents === "none") {
           document.body.style.pointerEvents = "";

--- a/app/(site)/_components/ai/ChatPanel.tsx
+++ b/app/(site)/_components/ai/ChatPanel.tsx
@@ -144,6 +144,9 @@ function PanelContent() {
         sessionId: sessionId.current,
         turnCount: String(turnCount),
       });
+      if (contextTitle) {
+        params.set("pageTitle", contextTitle);
+      }
       const res = await fetch(`/api/search?${params.toString()}`);
       const data = (await res.json()) as SearchResponse;
 
@@ -382,10 +385,16 @@ export function ChatPanel() {
     return () => {
       if (siteScroll) siteScroll.style.overflow = "";
       // Vaul direction="right" leaves stale pointer-events/overflow on body
-      // after its close animation. Clean up after animation completes.
+      // after its close animation. Only clear if Vaul is no longer scroll-locking
+      // so we don't interfere with other overlays that may still be open.
       setTimeout(() => {
-        document.body.style.pointerEvents = "";
-        document.body.style.overflow = "";
+        if (document.body.hasAttribute("data-scroll-locked")) return;
+        if (document.body.style.pointerEvents === "none") {
+          document.body.style.pointerEvents = "";
+        }
+        if (document.body.style.overflow === "hidden") {
+          document.body.style.overflow = "";
+        }
       }, 500);
     };
   }, [isOpen]);

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -412,11 +412,15 @@ export async function GET(request: NextRequest) {
         if (sortBy) {
           const sortMap: Record<string, object> = {
             newest: { createdAt: "desc" },
-            price_asc: { variants: { _min: { purchaseOptions: { _min: { priceInCents: "asc" } } } } },
-            price_desc: { variants: { _min: { purchaseOptions: { _min: { priceInCents: "desc" } } } } },
-            top_rated: { createdAt: "desc" }, // fallback: no rating field yet
+            top_rated: { averageRating: "desc" },
+            // price_asc/price_desc omitted — current schema requires nested
+            // aggregate orderBy through variants→purchaseOptions which Prisma
+            // doesn't support. Revisit when a denormalized minPrice column exists.
           };
-          orderBy = sortMap[sortBy];
+          const supportedSort = sortMap[sortBy];
+          if (supportedSort) {
+            orderBy = supportedSort;
+          }
         }
 
         // Lock to COFFEE type when any coffee-specific semantic filter was extracted.

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -172,7 +172,7 @@ async function extractAgenticFilters(
         ? rawFilters.roastLevel.toLowerCase()
         : undefined;
 
-    const validSortBy = ["newest", "price_asc", "price_desc", "top_rated"] as const;
+    const validSortBy = ["newest", "top_rated"] as const;
     type SortBy = (typeof validSortBy)[number];
 
     const filtersExtracted: FiltersExtracted = {

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -863,6 +863,7 @@ const publicSettingsKeys = [
   "homepage_hero_video_poster_url",
   "homepage_hero_heading",
   "homepage_hero_tagline",
+  "ai_voice_persona",
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

Fixes 5 of 6 Copilot review comments from #325 (the 6th — `setPageContext` never called — is already fixed on the Phase 2 branch).

- **`ai_voice_persona` missing from `publicSettingsKeys`** — admin-configured persona was never reaching the search prompt (always defaulted to "")
- **`top_rated` sort used `createdAt` fallback** — schema has `averageRating`, now uses it
- **`price_asc`/`price_desc` sort was invalid Prisma** — nested aggregate orderBy through variants→purchaseOptions not supported; removed until denormalized column exists
- **`pageTitle` not sent from ChatPanel** — search API supports it for context-aware prompts but ChatPanel wasn't sending it
- **Body overflow cleanup interference** — now checks `data-scroll-locked` before clearing body styles to avoid clobbering other Vaul/Radix overlays

## Test plan

- [x] Precheck passes (0 TS errors, 0 ESLint errors)
- [x] test:ci passes (100 suites, 1182 tests, 0 failures)
- [x] `contextTitle` is in scope where `pageTitle` param is set
- [x] `averageRating` field exists in Prisma Product model
- [x] `data-scroll-locked` is standard Vaul attribute for active overlays