### PR TITLE
fix: add pg/ws adapter packages to serverExternalPackages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.100.1 - 2026-04-12
+
+### Fixed
+
+- **Vercel build**: Added `pg`, `ws`, `@prisma/adapter-pg`, `@prisma/adapter-neon`, and `@neondatabase/serverless` to `serverExternalPackages` so Next.js does not attempt to bundle Node.js-native packages, resolving `Module not found: Can't resolve 'net'` build failures
+
 ## 0.100.0 - 2026-04-11
 
 ### Added

--- a/next.config.ts
+++ b/next.config.ts
@@ -28,7 +28,15 @@ const nextConfig: NextConfig = {
   env: {
     APP_VERSION,
   },
-  serverExternalPackages: ["@prisma/client", "prisma"],
+  serverExternalPackages: [
+    "@prisma/client",
+    "prisma",
+    "pg",
+    "ws",
+    "@prisma/adapter-pg",
+    "@prisma/adapter-neon",
+    "@neondatabase/serverless",
+  ],
   images: {
     // We must whitelist the domains we'll be using for our product images.
     // This is a security feature of Next.js Image Optimization.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.100.0",
+  "version": "0.100.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Adds `pg`, `ws`, `@prisma/adapter-pg`, `@prisma/adapter-neon`, and `@neondatabase/serverless` to `serverExternalPackages` in `next.config.ts`
- Fixes `Module not found: Can't resolve 'net'` build failures on Vercel (affected both `artisan-roast` and `artisan-roast-qa` deployments)

## Root Cause

Prisma 7 uses driver adapters (`@prisma/adapter-pg`, `@prisma/adapter-neon`) which pull in `pg` and `ws` as direct dependencies. These packages rely on Node.js built-ins (`net`, `tls`, `dns`) and cannot be bundled. The `serverExternalPackages` list was not updated when upgrading to Prisma 7 with adapter-based connections.

## Test plan

- [ ] Verify Vercel build passes on this PR's preview deployment
- [ ] Confirm `artisan-roast-qa` build passes after merge to main