### PR TITLE
fix: lazy-require pg to prevent Turbopack build failure

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,8 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 import { neonConfig } from "@neondatabase/serverless";
 import { PrismaNeon } from "@prisma/adapter-neon";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { Pool } from "pg";
 import ws from "ws";
 
 // Force node-api engine to avoid data-proxy/"client" engine requirements when no adapter is provided.
@@ -36,6 +34,12 @@ const createAdapter = (connectionString: string) => {
     return new PrismaNeon({ connectionString });
   }
 
+  // Lazy require to prevent Turbopack from statically analyzing pg's Node.js
+  // built-in dependencies (dns, fs, net, tls) during the client bundle phase.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Pool } = require("pg") as typeof import("pg");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { PrismaPg } = require("@prisma/adapter-pg") as typeof import("@prisma/adapter-pg");
   const pool = new Pool({ connectionString });
   return new PrismaPg(pool);
 };


### PR DESCRIPTION
## Summary

- Turbopack statically analyzes top-level `import { Pool } from "pg"` at build time and fails to resolve pg's Node.js built-ins (`dns`, `fs`, `net`, `tls`) — even with `pg` listed in `serverExternalPackages`
- Move `pg` and `@prisma/adapter-pg` to lazy `require()` calls inside `createAdapter()` so Turbopack never traverses them during the build
- The Neon adapter path (used on Vercel/neon.tech) is unaffected — this only impacts the non-Neon fallback path

## Root cause

`serverExternalPackages` prevents Webpack from *bundling* these packages, but Turbopack still performs static CJS analysis of `pg` at compile time to understand its exports. That analysis traverses `pg/lib/connection-parameters.js` which calls `require('dns')` — not available in the bundler context → 6 build errors.

## Test plan

- [x] `npm run precheck` — 0 errors
- [x] `npm run test:ci` — 1190 tests pass, 0 failures
- [ ] QA Vercel build passes after merge