### PR TITLE
fix: hero 16:9 on mobile, theme switcher visibility, stepper border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.100.4 - 2026-04-13
+
+### Fixed
+
+- **Hero aspect ratio on mobile**: VideoHero now uses `aspect-video` (16:9) on xs/sm breakpoints instead of `aspect-[3/1]`, preventing the hero from appearing too narrow on phones
+- **Theme switcher Sun icon**: Added `relative` to the ghost button wrapper so the absolutely-positioned Sun icon anchors correctly within the button bounds; fixes Sun icon not appearing in dark mode
+- **Stepper input border**: Changed `border-border` → `border-input` on the quantity input so it matches the `outline` button variant border on either side (consistent stepper appearance)
+- **Product card image aspect ratio on mobile**: `ProductCard` image now uses `aspect-[2/1]` below md breakpoint (consistent with the PDP image carousel), instead of `aspect-square`; keeps square on md+ grid layouts
+
 ## 0.100.3 - 2026-04-13
 
 ### Added

--- a/app/(site)/_components/content/VideoHero.tsx
+++ b/app/(site)/_components/content/VideoHero.tsx
@@ -34,7 +34,7 @@ export function VideoHero({ videoUrl, posterUrl, heading, tagline }: VideoHeroPr
   };
 
   return (
-    <div className="relative w-full aspect-[3/1] overflow-hidden bg-black">
+    <div className="relative w-full aspect-video sm:aspect-[3/1] overflow-hidden bg-black">
       <video
         ref={videoRef}
         src={videoUrl}

--- a/app/(site)/_components/content/VideoHero.tsx
+++ b/app/(site)/_components/content/VideoHero.tsx
@@ -34,7 +34,7 @@ export function VideoHero({ videoUrl, posterUrl, heading, tagline }: VideoHeroPr
   };
 
   return (
-    <div className="relative w-full aspect-video sm:aspect-[3/1] overflow-hidden bg-black">
+    <div className="relative w-full aspect-video md:aspect-[3/1] overflow-hidden bg-black">
       <video
         ref={videoRef}
         src={videoUrl}

--- a/app/(site)/_components/product/ProductCard.tsx
+++ b/app/(site)/_components/product/ProductCard.tsx
@@ -112,7 +112,7 @@ export default function ProductCard({
         )}
       >
         {/* 1. Image container. The parent <Card> clips its top corners. */}
-        <CardHeader className="relative w-full aspect-square rounded-t-lg p-0 overflow-hidden">
+        <CardHeader className="relative w-full aspect-[2/1] md:aspect-square rounded-t-lg p-0 overflow-hidden">
           <Image
             src={displayImage}
             alt={altText}

--- a/app/(site)/_components/product/ProductQuantityCart.tsx
+++ b/app/(site)/_components/product/ProductQuantityCart.tsx
@@ -65,7 +65,7 @@ export function ProductQuantityCart({
           readOnly
           tabIndex={-1}
           value={quantity}
-          className="h-14 flex-1 min-w-0 text-center text-base font-semibold border border-border bg-transparent outline-none"
+          className="h-14 flex-1 min-w-0 text-center text-base font-semibold border border-input bg-transparent outline-none"
         />
         <Button
           type="button"

--- a/components/shared/ThemeSwitcher.tsx
+++ b/components/shared/ThemeSwitcher.tsx
@@ -15,6 +15,7 @@ export function ThemeSwitcher() {
     <Button
       variant="ghost"
       size="icon"
+      className="relative"
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
     >
       <Moon className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.100.3",
+  "version": "0.100.4",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- `VideoHero.tsx`: `aspect-video sm:aspect-[3/1]` — 16:9 on xs/sm, 3:1 on desktop
- `ThemeSwitcher.tsx`: add `relative` to ghost button so `absolute` Sun icon anchors within bounds (fixes invisible button in dark mode)
- `ProductQuantityCart.tsx`: `border-input` on quantity input to match `variant="outline"` button border color

## Notes

This PR should merge **after** #331 (`feat/counter-ux`) — version 0.100.4 assumes #331 lands as 0.100.3.

## Test plan

- [ ] Resize homepage to mobile width — hero shows 16:9 ratio
- [ ] Toggle dark mode in footer — Sun icon visible, click switches to light mode
- [ ] Open product detail page — stepper +/- buttons and input have matching border color