### PR TITLE
fix: Counter panel messages render from top, not bottom-anchored

### DIFF
--- a/app/(site)/_components/ai/ChatPanel.tsx
+++ b/app/(site)/_components/ai/ChatPanel.tsx
@@ -240,10 +240,9 @@ function PanelContent() {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Messages — anchored to bottom; spacer pushes up when few messages */}
-      <div className="flex-1 overflow-y-auto flex flex-col min-h-0">
-        <div className="flex-1" />
-        <div className="px-4 pb-3 pt-2 space-y-4">
+      {/* Messages — scrollable list, renders from top */}
+      <div className="flex-1 overflow-y-auto min-h-0">
+        <div className="px-4 pb-3 pt-4 space-y-4">
           {messages.map((msg) => (
             <MessageBubble
               key={msg.id}


### PR DESCRIPTION
## Summary

- Removes the `flex-1` spacer that was pushing all content to the bottom of the full-height panel
- On mobile with a full-height drawer, the single greeting message was appearing in the bottom ~20% of the screen with empty space above
- Messages now render from the top (standard chat pattern); `messagesEndRef` + auto-scroll still handles snapping to bottom when new messages arrive
- Added `pt-4` to give the greeting a bit of breathing room from the panel header