### PR TITLE
fix(plans): render quota labels correctly from array shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- 2026-04-15 — fix(plans): render quota labels correctly from array shape — eliminated `[object Object] / month` on the plan detail page by aligning `PlanDetails.quotas` type with the actual API shape (array of `{icon, slug, label, limit}` objects) and updating the renderer to use `quota.label` / `quota.limit`; removed dead `formatQuotaLabel` helper
+
 ## 0.100.6 - 2026-04-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## 0.100.7 - 2026-04-15
 
-- 2026-04-15 — fix(plans): render quota labels correctly from array shape — eliminated `[object Object] / month` on the plan detail page by aligning `PlanDetails.quotas` type with the actual API shape (array of `{icon, slug, label, limit}` objects) and updating the renderer to use `quota.label` / `quota.limit`; removed dead `formatQuotaLabel` helper
+### Fixed
+
+- **Plan detail quotas**: eliminated `[object Object] / month` by aligning `PlanDetails.quotas` type with the actual API shape (array of `{icon, slug, label, limit}` objects); renderer updated to use `quota.label` / `quota.limit`; removed dead `formatQuotaLabel` helper
 
 ## 0.100.6 - 2026-04-14
 

--- a/app/admin/support/plans/[slug]/PlanDetailClient.tsx
+++ b/app/admin/support/plans/[slug]/PlanDetailClient.tsx
@@ -14,18 +14,6 @@ import type { Plan } from "@/lib/plan-types";
 import type { LicenseInfo } from "@/lib/license-types";
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function formatQuotaLabel(key: string): string {
-  if (/one.?on.?one/i.test(key)) return "1:1 Sessions";
-  return key
-    .replace(/([a-z])([A-Z])/g, "$1 $2")
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
-    .replace(/^./, (c) => c.toUpperCase());
-}
-
-// ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
 
@@ -56,7 +44,7 @@ export function PlanDetailClient({ plan, license }: PlanDetailClientProps) {
   const intervalLabel = isFree ? "" : plan.interval === "year" ? "/yr" : "/mo";
 
   const hasSlaOrQuotas =
-    details.sla || (details.quotas && Object.keys(details.quotas).length > 0);
+    details.sla || (details.quotas && details.quotas.length > 0);
 
   // Subtitle: "Your plan since {date}" for active subscribers, description otherwise
   const planSince = isActivePlan && license.plan?.snapshotAt
@@ -165,23 +153,21 @@ export function PlanDetailClient({ plan, license }: PlanDetailClientProps) {
                 </div>
               )}
 
-              {details.sla &&
-                details.quotas &&
-                Object.keys(details.quotas).length > 0 && <Separator />}
+              {details.sla && details.quotas && details.quotas.length > 0 && <Separator />}
 
-              {details.quotas && Object.keys(details.quotas).length > 0 && (
+              {details.quotas && details.quotas.length > 0 && (
                 <div className="space-y-3">
                   <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                     Monthly Quotas
                   </p>
                   <div className="space-y-2.5 text-sm">
-                    {Object.entries(details.quotas).map(([key, value]) => (
-                      <div key={key} className="flex justify-between">
+                    {details.quotas.map((quota) => (
+                      <div key={quota.slug} className="flex justify-between">
                         <span className="text-muted-foreground">
-                          {formatQuotaLabel(key)}
+                          {quota.label}
                         </span>
                         <span className="font-medium">
-                          {value === -1 ? "Unlimited" : `${value} / month`}
+                          {quota.limit === -1 ? "Unlimited" : `${quota.limit} / month`}
                         </span>
                       </div>
                     ))}

--- a/lib/plan-types.ts
+++ b/lib/plan-types.ts
@@ -48,8 +48,8 @@ export interface PlanDetails {
   scope?: string[];
   /** Billing terms and conditions */
   terms?: string[];
-  /** Usage quotas (e.g. tickets-per-month: 5) */
-  quotas?: Record<string, number>;
+  /** Usage quotas */
+  quotas?: Array<{ icon: string; slug: string; label: string; limit: number }>;
   /** Benefit bullet points */
   benefits?: string[];
   /** What the plan does NOT cover */

--- a/lib/plans.ts
+++ b/lib/plans.ts
@@ -116,7 +116,10 @@ const MOCK_PLANS: Plan[] = [
         responseTime: "48 hours",
         availability: "Business days (Mon\u2013Fri)",
       },
-      quotas: { SupportTickets: 5, OneOnOneSessions: 1 },
+      quotas: [
+        { icon: "ticket", slug: "tickets", label: "Priority Tickets", limit: 5 },
+        { icon: "calendar", slug: "one-on-one", label: "1:1 Sessions", limit: 1 },
+      ],
       scope: [
         "Setup & configuration",
         "Troubleshooting",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.100.6",
+  "version": "0.100.7",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- `PlanDetails.quotas` type was `Record<string, number>` but the platform API returns an array of `{icon, slug, label, limit}` objects
- `PlanDetailClient` was calling `Object.entries()` on the array, producing `[object Object] / month` for every quota row
- Removed the now-unused `formatQuotaLabel` helper

## Test plan
- [ ] Visit `/admin/support/plans/priority-support` on demo — Monthly Quotas section should show "Priority Tickets" and "1:1 Sessions" with correct limits
- [ ] Typecheck passes clean (`npm run typecheck`)
- [ ] No regressions on plans index page (`/admin/support/plans`)