### PR TITLE
fix: search drawer auto-closes on navigation (v0.102.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.102.1 - 2026-04-26
+
+### Fixed
+
+- **Search drawer auto-closes on navigation** — clicking a search result, curated card, or chip-active card was navigating to the product page but leaving the drawer overlay up over the destination, making the click feel unresponsive. Added a `usePathname()` effect to close the drawer on any pathname change, so every Link inside (current and future) just works without each one needing an explicit `onClick={close}`.
+
+---
+
 ## 0.102.0 - 2026-04-26
 
 ### Added

--- a/app/(site)/_components/search/SearchDrawer.tsx
+++ b/app/(site)/_components/search/SearchDrawer.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { usePathname } from "next/navigation";
 import { Search, X, MoveRight } from "lucide-react";
 import { ProductType } from "@prisma/client";
 import { RoastLevelBar } from "@/app/(site)/_components/product/RoastLevelBar";
@@ -47,6 +48,20 @@ export function SearchDrawer({ config }: SearchDrawerProps) {
   useSearchAnalytics(query, isOpen);
   const results = search(query);
   const hasQuery = query.trim().length > 0;
+
+  // Auto-close on navigation. Without this, clicking any link inside the
+  // drawer (search result, curated card, chip) navigates but the drawer
+  // stays open over the destination, making the click feel like a no-op.
+  // Closing on pathname change keeps every Link inside the drawer working
+  // without each one needing its own onClick={close}.
+  const pathname = usePathname();
+  const prevPathnameRef = useRef(pathname);
+  useEffect(() => {
+    if (prevPathnameRef.current !== pathname && isOpen) {
+      close();
+    }
+    prevPathnameRef.current = pathname;
+  }, [pathname, isOpen, close]);
 
   const curatedHeading = config.curatedCategoryName ?? "Featured";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.102.0",
+  "version": "0.102.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.102.0",
+      "version": "0.102.1",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.102.0",
+  "version": "0.102.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Hotfix for v0.102.0 — clicking any link inside the search drawer (search result, curated card, chip-active card) was navigating to the product page but leaving the vaul drawer overlay up over the destination, making the click feel unresponsive.

## Root cause

v1 had explicit `onClick={onClose}` on each Link. Commit `1c10646` (ProductCard refactor) and `cf290d1` (mini-card extraction) both dropped that handler without replacing the close trigger.

## Fix

`usePathname()` effect that closes the drawer on any pathname change. Every Link inside the drawer (current and future) now works without each one needing its own `onClick={close}`.

```tsx
const pathname = usePathname();
const prevPathnameRef = useRef(pathname);
useEffect(() => {
  if (prevPathnameRef.current !== pathname && isOpen) {
    close();
  }
  prevPathnameRef.current = pathname;
}, [pathname, isOpen, close]);
```

## Test plan

- [ ] Open search drawer → click any curated ProductCard → navigates AND drawer closes
- [ ] Type "ethiopia" → click any mini-card result → navigates AND drawer closes
- [ ] Click a chip → click any chip-active product → navigates AND drawer closes
- [ ] `npm run test:ci` (103 suites / 1182 tests / 0 failures)
- [ ] `npm run precheck` clean