### PR TITLE
fix: close mobile menu Sheet before opening search drawer (v0.102.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.102.2 - 2026-04-26
+
+### Fixed
+
+- **Mobile menu Sheet closes before opening the search drawer** — on mobile, tapping the Search item inside the hamburger menu was leaving the menu Sheet open behind the search drawer. Tapping a search result then navigated, search drawer auto-closed (per v0.102.1), but the menu Sheet stayed mounted over the destination. `SearchTrigger` now accepts an optional `onBeforeOpen` callback that runs synchronously before the search drawer opens; the mobile-menu wiring passes a closer for the menu Sheet so the two overlays no longer stack. Desktop is unaffected (it uses `NavigationMenu`, not Sheet).
+
+---
+
 ## 0.102.1 - 2026-04-26
 
 ### Fixed

--- a/app/(site)/_components/layout/SiteHeader.tsx
+++ b/app/(site)/_components/layout/SiteHeader.tsx
@@ -127,6 +127,12 @@ export default function SiteHeader({
   const [isBannerDismissed, setIsBannerDismissed] = useState(false);
   const [isClient, setIsClient] = useState(false);
   const [isHeaderVisible, setIsHeaderVisible] = useState(true);
+  // Controlled mobile menu Sheet state — lifted so the SearchTrigger inside
+  // can close the menu *before* opening the search drawer (otherwise both
+  // overlays mount stacked and tapping a search result leaves the menu
+  // hanging behind the destination page). Desktop uses NavigationMenu, not
+  // Sheet, so this is mobile-only.
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const lastScrollY = useRef(0);
   const { settings } = useSiteSettings();
   const { visible: visiblePages, overflow: overflowPages } = useNavOverflow(
@@ -230,7 +236,7 @@ export default function SiteHeader({
           {isClient && (
             <>
               {/* Mobile hamburger */}
-              <Sheet>
+              <Sheet open={isMobileMenuOpen} onOpenChange={setIsMobileMenuOpen}>
                 <SheetTrigger asChild className="md:hidden">
                   <Button
                     variant="outline"
@@ -269,9 +275,14 @@ export default function SiteHeader({
                           </span>
                         </Link>
                       </SheetClose>
-                      <SheetClose asChild>
-                        <SearchTrigger variant="mobile-sheet" />
-                      </SheetClose>
+                      {/* Close the menu Sheet before the search drawer opens
+                          so the two overlays don't stack — otherwise tapping
+                          a search result navigates but the menu hangs behind
+                          the destination page. */}
+                      <SearchTrigger
+                        variant="mobile-sheet"
+                        onBeforeOpen={() => setIsMobileMenuOpen(false)}
+                      />
                       <SheetClose asChild>
                         <Link
                           href="/orders"

--- a/app/(site)/_components/search/SearchTrigger.tsx
+++ b/app/(site)/_components/search/SearchTrigger.tsx
@@ -8,20 +8,31 @@ import { cn } from "@/lib/utils";
 /**
  * Search drawer trigger button. Opens the SearchDrawer overlay.
  * Mounted in SiteHeader (desktop icon + mobile sheet item).
+ *
+ * `onBeforeOpen` runs synchronously before the search drawer opens — used
+ * by the mobile-sheet variant to close the parent menu Sheet so the two
+ * overlays don't stack. Desktop variant ignores it (no parent overlay).
  */
 export function SearchTrigger({
   variant = "icon",
   className,
+  onBeforeOpen,
 }: {
   variant?: "icon" | "mobile-sheet";
   className?: string;
+  onBeforeOpen?: () => void;
 }) {
   const open = useSearchDrawerStore((s) => s.open);
+
+  const handleClick = () => {
+    onBeforeOpen?.();
+    open();
+  };
 
   if (variant === "mobile-sheet") {
     return (
       <button
-        onClick={open}
+        onClick={handleClick}
         className={cn(
           "inline-flex flex-1 flex-col items-center justify-center gap-1 py-2 rounded-md text-foreground hover:text-primary hover:bg-accent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary",
           className
@@ -39,7 +50,7 @@ export function SearchTrigger({
     <Button
       variant="ghost"
       size="icon"
-      onClick={open}
+      onClick={handleClick}
       className={cn("hidden md:flex", className)}
     >
       <Search className="h-5 w-5" />

--- a/app/(site)/_components/search/__tests__/SearchTrigger.test.tsx
+++ b/app/(site)/_components/search/__tests__/SearchTrigger.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SearchTrigger } from "../SearchTrigger";
+import { useSearchDrawerStore } from "../store";
+
+function resetStore() {
+  useSearchDrawerStore.setState({ isOpen: false, activeChipSlug: null });
+}
+
+describe("SearchTrigger", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it("desktop variant: clicking opens the search drawer", () => {
+    render(<SearchTrigger />);
+    expect(useSearchDrawerStore.getState().isOpen).toBe(false);
+    fireEvent.click(screen.getByRole("button"));
+    expect(useSearchDrawerStore.getState().isOpen).toBe(true);
+  });
+
+  it("mobile-sheet variant: clicking opens the search drawer", () => {
+    render(<SearchTrigger variant="mobile-sheet" />);
+    expect(useSearchDrawerStore.getState().isOpen).toBe(false);
+    fireEvent.click(screen.getByRole("button"));
+    expect(useSearchDrawerStore.getState().isOpen).toBe(true);
+  });
+
+  it("mobile-sheet: invokes onBeforeOpen BEFORE opening the search drawer", () => {
+    // Order matters — onBeforeOpen exists so the parent menu Sheet can close
+    // BEFORE the search drawer opens. If open() fired first, the two overlays
+    // would briefly stack.
+    const calls: string[] = [];
+    const onBeforeOpen = jest.fn(() => calls.push("before"));
+    const originalOpen = useSearchDrawerStore.getState().open;
+    const wrappedOpen = jest.fn(() => {
+      calls.push("open");
+      originalOpen();
+    });
+    useSearchDrawerStore.setState({ open: wrappedOpen });
+
+    render(
+      <SearchTrigger variant="mobile-sheet" onBeforeOpen={onBeforeOpen} />
+    );
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(onBeforeOpen).toHaveBeenCalledTimes(1);
+    expect(wrappedOpen).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(["before", "open"]);
+
+    // Restore original open for other tests
+    useSearchDrawerStore.setState({ open: originalOpen });
+  });
+
+  it("desktop variant: also forwards onBeforeOpen if provided", () => {
+    const onBeforeOpen = jest.fn();
+    render(<SearchTrigger onBeforeOpen={onBeforeOpen} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onBeforeOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not error when onBeforeOpen is omitted", () => {
+    render(<SearchTrigger variant="mobile-sheet" />);
+    expect(() =>
+      fireEvent.click(screen.getByRole("button"))
+    ).not.toThrow();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.102.1",
+  "version": "0.102.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.102.1",
+      "version": "0.102.2",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.102.1",
+  "version": "0.102.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Hotfix for v0.102.1 — on mobile, tapping the Search item inside the hamburger menu was leaving the menu Sheet mounted under the search drawer. Tapping a search result then navigated and auto-closed the search drawer (per v0.102.1), but the menu Sheet hung behind the destination page.

## Fix

- Lift menu Sheet to controlled state (`isMobileMenuOpen`)
- Add `onBeforeOpen` callback prop to `SearchTrigger`
- Mobile-menu wiring passes a closer that synchronously closes the menu before the search drawer opens

Desktop is unaffected — it uses `NavigationMenu`, not Sheet.

## Test plan

- [ ] Mobile: open hamburger → tap Search → menu closes, search drawer opens, no two overlays stacked
- [ ] Mobile: tap a search result → navigates, no leftover overlays
- [ ] Desktop: search icon in header still works
- [ ] `npm run test:ci` (103 suites / 1182 tests / 0 failures)
- [ ] `npm run precheck` clean