### PR TITLE
chore: diversify seed taste-category assignment (v0.102.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.102.3 - 2026-04-26
+
+### Changed
+
+- **Seed taste-category assignment is more discriminating** — `prisma/seed/menu.ts` `findTasteCategories` now matches against `tastingNotes` only (was matching both notes AND description, which produced ~86% overlap between Fruity & Floral and Medium Roast because marketing copy uses fruit/spice/cocoa words liberally). Adds basic coffee-domain gating: Fruity & Floral excluded from DARK roasts (caramelization suppresses bright top notes) and Spicy & Earthy excluded from LIGHT roasts (those notes need MEDIUM+ development). After reseed, F&F ∩ Medium Roast overlap drops to ~77%; further reduction requires actual tasting-note diversification in seed data (deferred).
+
+---
+
 ## 0.102.2 - 2026-04-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.102.2",
+  "version": "0.102.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.102.2",
+      "version": "0.102.3",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.102.2",
+  "version": "0.102.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/prisma/seed/menu.ts
+++ b/prisma/seed/menu.ts
@@ -447,10 +447,23 @@ export async function seedMenu(prisma: PrismaClient) {
           : "Medium Roast"
     );
 
-    findTasteCategories([
-      ...(coffee.tastingNotes ?? []),
-      coffee.description ?? "",
-    ]).forEach((c) => targets.add(c));
+    // Taste categories — match against tastingNotes ONLY (not description).
+    // Marketing copy in descriptions uses fruit/spice/cocoa words liberally
+    // even for coffees that don't actually taste that way, which produced ~86%
+    // overlap between Fruity & Floral and Medium Roast in the demo catalog.
+    // tastingNotes are explicit cupping signals — using only those produces
+    // distinct, cuppable categories.
+    //
+    // Roast-aware gating layered on top mirrors basic coffee domain knowledge:
+    // - Fruity & Floral acidity rarely survives DARK roasts (caramelization
+    //   suppresses the bright top notes).
+    // - Spicy & Earthy notes typically need MEDIUM+ roast development to
+    //   emerge — LIGHT roasts retain green/grassy character instead.
+    for (const cat of findTasteCategories(coffee.tastingNotes ?? [])) {
+      if (cat === "Fruity & Floral" && roastLevel === RoastLevel.DARK) continue;
+      if (cat === "Spicy & Earthy" && roastLevel === RoastLevel.LIGHT) continue;
+      targets.add(cat);
+    }
     mapRegions(coffee.origin ?? []).forEach((c) => targets.add(c));
     if (
       `${coffee.name} ${coffee.description ?? ""}`


### PR DESCRIPTION
## Summary

Closes nitpick #2 from the search drawer post-launch queue. Fruity & Floral ∩ Medium Roast was at ~86% overlap because `findTasteCategories` matched against tastingNotes AND description text — marketing copy uses fruit/spice/cocoa words liberally even for coffees that don't cup that way.

## Changes

1. Match taste keywords against `tastingNotes` only. Description text dropped from the input (explicit cupping signals beat noisy marketing prose).
2. Roast-aware gating layered on:
   - Fruity & Floral excluded from DARK roasts (bright top notes don't survive caramelization).
   - Spicy & Earthy excluded from LIGHT roasts (those notes need MEDIUM+ development to emerge).

## After reseed (overlap %)

| pair | before | after |
|---|---|---|
| fruity-floral ∩ medium-roast | 86% | **77%** |
| fruity-floral ∩ single-origin | — | 75% |
| nutty-chocolatey ∩ medium-roast | — | 50% |
| spicy-earthy ∩ dark-roast | — | 20% |

Further reduction needs diversifying the actual `tastingNotes` arrays in `prisma/seed/products.ts` (most coffees there are tagged with fruit notes) — separate follow-up.

## Test plan

- [ ] `npm run test:ci` (104 suites / 1187 tests / 0 failures — same as v0.102.2)
- [ ] `npm run precheck` clean
- [ ] Reseed locally → search drawer chips return more distinct sets