### PR TITLE
perf(product): parallelize fetches + align search architecture docs (v0.103.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.103.2 - 2026-04-27
+
+### Performance
+
+- **Product page parallelizes related/addons/category-siblings fetches** — `app/(site)/products/[slug]/page.tsx` previously fired four DB queries sequentially (`getProductBySlug` → `getRelatedProducts` → `getProductAddOns` → `getProductsByCategorySlug`). The last three only depend on results from the first and are independent of each other, so series-mode meant ~3× round-trip latency for no benefit. Wrapped in `Promise.all`, fanning them out concurrently. On a typical ~80 ms per-query setup that's a ~250 ms reduction on every product navigation — large enough to make the result→product transition from the search drawer feel instant. No behavior change beyond timing; same data flows through `ProductClientPage`.
+
+---
+
 ## 0.103.1 - 2026-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Performance
 
-- **Product page parallelizes related/addons/category-siblings fetches** — `app/(site)/products/[slug]/page.tsx` previously fired four DB queries sequentially (`getProductBySlug` → `getRelatedProducts` → `getProductAddOns` → `getProductsByCategorySlug`). The last three only depend on results from the first and are independent of each other, so series-mode meant ~3× round-trip latency for no benefit. Wrapped in `Promise.all`, fanning them out concurrently. On a typical ~80 ms per-query setup that's a ~250 ms reduction on every product navigation — large enough to make the result→product transition from the search drawer feel instant. No behavior change beyond timing; same data flows through `ProductClientPage`.
+- **Product page parallelizes related/addons/category-siblings fetches** — `app/(site)/products/[slug]/page.tsx` previously ran four top-level fetch steps sequentially (`getProductBySlug` → `getRelatedProducts` → `getProductAddOns` → `getProductsByCategorySlug`). The last three only depend on results from the first and are independent of each other, so series-mode meant the page's total latency was the sum of all four for no benefit. Wrapped in `Promise.all`, fanning the latter three out concurrently — total latency now reduces to roughly the slowest top-level fetch (an individual helper like `getProductAddOns` still runs its own internal queries sequentially, so the absolute floor isn't a single round-trip). Net cut is large enough to make the result→product transition from the search drawer feel instant. No behavior change beyond timing; same data flows through `ProductClientPage`.
 
 ---
 

--- a/app/(site)/products/[slug]/page.tsx
+++ b/app/(site)/products/[slug]/page.tsx
@@ -88,17 +88,18 @@ export default async function ProductPage({
     notFound();
   }
 
-  // Fetch related products from the display category (follows user's journey)
-  const relatedProducts = await getRelatedProducts(
-    product.id,
-    displayCategory.slug
-  );
+  // The three remaining fetches all depend only on `product` + `displayCategory`
+  // (already resolved above) and are independent of each other — run in parallel
+  // so the user pays one round-trip's latency instead of three sequential ones.
+  // - relatedProducts: same category, follows the user's journey
+  // - addOns: per-product
+  // - categoryProducts: siblings in the same category for the breadcrumb dropdown
+  const [relatedProducts, addOns, categoryProducts] = await Promise.all([
+    getRelatedProducts(product.id, displayCategory.slug),
+    getProductAddOns(product.id),
+    getProductsByCategorySlug(displayCategory.slug),
+  ]);
 
-  // Fetch add-ons for this product
-  const addOns = await getProductAddOns(product.id);
-
-  // Fetch sibling products in the same category (for breadcrumb dropdown)
-  const categoryProducts = await getProductsByCategorySlug(displayCategory.slug);
   const siblingProducts = categoryProducts
     .filter((p) => p.id !== product.id)
     .map((p) => ({ name: p.name, slug: p.slug }));

--- a/app/(site)/products/[slug]/page.tsx
+++ b/app/(site)/products/[slug]/page.tsx
@@ -88,9 +88,12 @@ export default async function ProductPage({
     notFound();
   }
 
-  // The three remaining fetches all depend only on `product` + `displayCategory`
-  // (already resolved above) and are independent of each other — run in parallel
-  // so the user pays one round-trip's latency instead of three sequential ones.
+  // The three remaining top-level fetches all depend only on `product` +
+  // `displayCategory` (already resolved above) and are independent of each
+  // other, so start them together to reduce total latency to roughly the
+  // slowest top-level fetch — even if an individual helper still performs
+  // some sequential work internally (e.g. getProductAddOns reads SiteSettings
+  // for the weight unit on top of the add-on links).
   // - relatedProducts: same category, follows the user's journey
   // - addOns: per-product
   // - categoryProducts: siblings in the same category for the breadcrumb dropdown

--- a/docs/architecture/SEARCH-ARCHITECTURE.md
+++ b/docs/architecture/SEARCH-ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 > **Last Updated:** 2026-04-27
 > **Status:** Production
-> **Version:** 0.103.0+
+> **Version:** 0.103.2+
 > **Target catalog size:** small-to-mid storefronts (≤ ~200 products)
 
 ## Overview
@@ -32,7 +32,7 @@ Both surfaces include MERCH alongside COFFEE (the COFFEE-only hardcode was remov
 
 ### Data flow
 
-```
+```text
 storefront layout render
   └── getCachedSearchDrawerConfig()         [unstable_cache, 60s TTL, tag: "search-drawer-config"]
         └── getSearchDrawerConfig()         [lib/data.ts:888]
@@ -44,7 +44,7 @@ storefront layout render
 storefront drawer first open
   └── useSearchIndex()                      [app/(site)/_components/search/hooks/useSearchIndex.ts]
         └── GET /api/search/index           [Cache-Control: public, max-age=60, SWR=300]
-              └── findMany(enabled products) [productCardIncludes shape, no orderBy yet — see #12]
+              └── findMany(enabled products) [productCardIncludes shape, orderBy: PRODUCT_LIST_ORDER_BY]
         └── new MiniSearch({ ... }).addAll(products)
 
 every keystroke
@@ -77,6 +77,14 @@ onClick={(e) => {
 ```
 
 This deliberately replaces a `usePathname()` effect because pathname-based close doesn't fire when the destination route equals the current route — so a user already on `/products/foo` clicking the foo result in the drawer would otherwise leave the drawer / menu stranded over a non-navigation. Event delegation closes synchronously regardless. (See PR #348, commits `430cfac` and the mobile-menu mirror.)
+
+### Result-to-product navigation
+
+A drawer result click → product page is the only navigation path the drawer creates (chips filter in-drawer, no nav). The destination — [`app/(site)/products/[slug]/page.tsx`](../../app/(site)/products/[slug]/page.tsx) — runs four DB queries: `getProductBySlug` (sequential, drives breadcrumb logic) followed by `getRelatedProducts` + `getProductAddOns` + `getProductsByCategorySlug`.
+
+The latter three only depend on the product + display category resolved by the first, and are independent of each other, so they fan out via `Promise.all` rather than running in series. On a typical ~80 ms per-query setup that's a ~250 ms reduction on every product navigation — large enough that the result→product transition feels instant on warm caches and the gap is barely perceptible on cold caches. (Shipped v0.103.2.)
+
+The page itself uses `revalidate = 3600` ISR; first hit per product per Vercel edge node per hour is the cold path, subsequent hits within that window are cached HTML.
 
 ---
 
@@ -116,7 +124,7 @@ The admin PUT route calls `revalidateTag("search-drawer-config", "default")` so 
 
 This architecture is **deliberately tuned for small-to-mid catalogs (≤ ~200 enabled products).** The single-fetch full-catalog model is the load-bearing assumption — everything downstream (0 ms keystroke search, fuzzy + field-weighted ranking, no FTS round-trip per character) follows from it.
 
-The two scale-dependent risk areas below were reviewed during the v0.103.0 polish pass and **explicitly deferred** as out-of-scope for the target use case. They are documented here so a future revisit inherits the reasoning rather than the absence of a fix.
+The three scale-dependent risk areas below were reviewed during the v0.103.0 / v0.103.2 polish pass and **explicitly deferred** as out-of-scope for the target use case. They are documented here so a future revisit inherits the reasoning rather than the absence of a fix.
 
 ### Deferred — `/api/search/index` returns the full enabled catalog
 
@@ -145,6 +153,18 @@ The two scale-dependent risk areas below were reviewed during the v0.103.0 polis
   - Admin saves cause noticeable cache stampede (multiple visitors arrive within the same revalidation window), OR
   - Curated-products payload grows materially
 - **Correct mitigation when triggered** — Move `curatedProducts` out of `getSearchDrawerConfig` into a dedicated endpoint (e.g. `/api/search-drawer/curated`) fetched client-side on first drawer open, with its own cache tag. Drawer renders chips immediately (config payload shrinks to chip metadata + setting refs), curated grid renders after the round-trip with a skeleton in place.
+
+### Deferred — link prefetch on visible search results
+
+- **Decision** — Don't add Next.js Link prefetch (`prefetch={true}`) on result `<Link>`s in the drawer body. Rely on the v0.103.2 query parallelization for the result→product transition feel.
+- **Why this is fine for the target** — After the parallelization, cold-cache product page loads feel near-instant on the demo. With small catalog + low traffic, paying the latency once per actual click is preferable to prefetching every visible result.
+- **What prefetch would buy at scale** — Warming the destination route's RSC payload before the user clicks, so the click → render is instantaneous even on cold ISR caches. Useful when the destination has heavier-than-`Promise.all` data fetching, or when users browse rapidly and the pre-warm consistently lands.
+- **What it costs** — Each prefetch is a real HTTP request that runs the destination's data path. A drawer with 10 visible results × every drawer-open + filter session = 10 prefetched product pages even if the user clicks zero or one. At 200+ products with real traffic that's meaningful Vercel function invocations, DB load, and mobile data for users on metered connections — paid for results that go unviewed.
+- **Revisit triggers**
+  - Catalog grows to a scale where ISR cold-cache misses dominate the perceived navigation latency, OR
+  - Real-user telemetry shows the result→product transition is the slowest interaction in the drawer, OR
+  - We're on a usage tier where prefetch invocations are cheap and the latency fix is worth the bandwidth
+- **Correct mitigation when triggered** — Hover/focus prefetch via `useRouter().prefetch()` on `onMouseEnter` / `onFocus`, with `prefetch={false}` on the `<Link>`. Pays one prefetch per *near-click* (intent-driven) rather than one per *visible result* (viewport-driven). Mobile clients without hover skip the prefetch entirely and fall back to the click-only cold path — acceptable trade-off given the cost shape.
 
 ---
 

--- a/docs/architecture/SEARCH-ARCHITECTURE.md
+++ b/docs/architecture/SEARCH-ARCHITECTURE.md
@@ -81,9 +81,9 @@ This deliberately replaces a `usePathname()` effect because pathname-based close
 
 ### Result-to-product navigation
 
-A drawer result click → product page is the only navigation path the drawer creates (chips filter in-drawer, no nav). The destination — [`app/(site)/products/[slug]/page.tsx`](../../app/(site)/products/[slug]/page.tsx) — runs four DB queries: `getProductBySlug` (sequential, drives breadcrumb logic) followed by `getRelatedProducts` + `getProductAddOns` + `getProductsByCategorySlug`.
+A drawer result click → product page is the only navigation path the drawer creates (chips filter in-drawer, no nav). The destination — [`app/(site)/products/[slug]/page.tsx`](../../app/(site)/products/[slug]/page.tsx) — runs four top-level fetch steps on the cold path: `getProductBySlug` first (sequential, drives breadcrumb logic), then `getRelatedProducts`, `getProductAddOns`, and `getProductsByCategorySlug` fan out. Note that `getProductAddOns` itself is not a single round-trip — it does an add-on links query plus a `SiteSettings` lookup via `getWeightUnit()` — so the cold path includes five DB reads in total.
 
-The latter three only depend on the product + display category resolved by the first, and are independent of each other, so they fan out via `Promise.all` rather than running in series. On a typical ~80 ms per-query setup that's a ~250 ms reduction on every product navigation — large enough that the result→product transition feels instant on warm caches and the gap is barely perceptible on cold caches. (Shipped v0.103.2.)
+Those downstream loaders only depend on the product + display category resolved by the first, and are otherwise independent, so the page fans them out via `Promise.all` rather than running the top-level loaders in series. Total page latency reduces to roughly the slowest top-level fetch — large enough that the result→product transition feels instant on warm caches and the gap is barely perceptible on cold caches. (Shipped v0.103.2.)
 
 The page itself uses `revalidate = 3600` ISR; first hit per product per Vercel edge node per hour is the cold path, subsequent hits within that window are cached HTML.
 
@@ -102,7 +102,7 @@ The form auto-saves per field (debounced PUT to `/api/admin/settings/search-draw
 
 The admin PUT route calls `revalidateTag("search-drawer-config", "default")` so the storefront's server-side cache picks up the change on its next request. Menu Builder mutations that touch CategoryLabel / CategoryLabelCategory / Category rows also fire the same tag (via [`lib/cache/revalidate-search-drawer.ts`](../../lib/cache/revalidate-search-drawer.ts), shipped v0.103.1).
 
-> **Caveat — admin edits don't appear in already-open storefront tabs without a hard refresh.** When admin saves a chip-label or curated-category change, `revalidateTag("search-drawer-config")` busts the *server* cache. But any storefront tab already open holds the prior layout's RSC payload (in the browser HTTP cache + Next's client-side Router Cache), so a normal reload often serves the stale response. A hard refresh (Cmd/Ctrl + Shift + R) reliably shows the new data. Same behavior in dev and prod. Worth surfacing to admins so they don't read a stale chip row as "the save didn't work." Tracked as nitpick #13 in [`docs/features/keyword-search-drawer/nitpicks.md`](../features/keyword-search-drawer/nitpicks.md).
+> **Caveat — admin edits don't appear in already-open storefront tabs without a hard refresh.** When admin saves a chip-label or curated-category change, `revalidateTag("search-drawer-config", "default")` busts the *server* cache. But any storefront tab already open holds the prior layout's RSC payload (in the browser HTTP cache + Next's client-side Router Cache), so a normal reload often serves the stale response. A hard refresh (Cmd/Ctrl + Shift + R) reliably shows the new data. Same behavior in dev and prod. Worth surfacing to admins so they don't read a stale chip row as "the save didn't work." Tracked as nitpick #13 in [`docs/features/keyword-search-drawer/nitpicks.md`](../features/keyword-search-drawer/nitpicks.md).
 
 ---
 

--- a/docs/architecture/SEARCH-ARCHITECTURE.md
+++ b/docs/architecture/SEARCH-ARCHITECTURE.md
@@ -35,11 +35,12 @@ Both surfaces include MERCH alongside COFFEE (the COFFEE-only hardcode was remov
 ```text
 storefront layout render
   └── getCachedSearchDrawerConfig()         [unstable_cache, 60s TTL, tag: "search-drawer-config"]
-        └── getSearchDrawerConfig()         [lib/data.ts:888]
-              ├── chip-label categories     [orderBy: { CategoryLabelCategory.order } ]
-              ├── chips heading             [SiteSettings: search_drawer_chips_heading]
-              ├── curated category          [SiteSettings: search_drawer_curated_category]
-              └── curated products          [findMany with productCardIncludes, take: 6]
+        └── getSearchDrawerConfig()         [lib/data.ts:893]
+              ├── chip-label                [SiteSettings: search_drawer_chip_label → CategoryLabel.id]
+              │     └── categories          [orderBy: { CategoryLabelCategory.order }, take: MAX_CHIPS = 6]
+              ├── chips heading             [from CategoryLabel.name; fallback: "Top Categories"]
+              ├── curated category          [SiteSettings: search_drawer_curated_category → Category.slug]
+              └── curated products          [findMany with productCardIncludes, take: CURATED_PRODUCTS_LIMIT = 6]
 
 storefront drawer first open
   └── useSearchIndex()                      [app/(site)/_components/search/hooks/useSearchIndex.ts]
@@ -90,19 +91,18 @@ The page itself uses `revalidate = 3600` ISR; first hit per product per Vercel e
 
 ## Admin surface
 
-[`/admin/settings/search`](../../app/admin/settings/search/page.tsx) writes three `SiteSettings` keys:
+[`/admin/settings/search`](../../app/admin/settings/search/page.tsx) writes two `SiteSettings` keys (down from three in v1 — the v2 refactor consolidated heading + chip categories into a single CategoryLabel reference):
 
-| Key | Type | Purpose |
+| Key | Type (parsed) | Purpose |
 |---|---|---|
-| `search_drawer_chips_heading` | string | Heading above the chip row (default `"Top Categories"`) |
-| `search_drawer_chip_categories` | string (joined) | Up to 6 category slugs surfaced as chips (display order = the saved order) |
-| `search_drawer_curated_category` | string | Single category whose products fill the curated section + no-results fallback |
+| `search_drawer_chip_label` | string (CategoryLabel.id) | The label whose attached categories render as the chip row. **The chip-row heading is derived from `CategoryLabel.name`** — there is no separate "heading" key. Hidden labels (`isVisible: false`) are valid here; the search drawer reads them by id without filtering on visibility, cleanly separating "label exists for product menu" from "label exists for search curation." |
+| `search_drawer_curated_category` | string (Category.slug) | The category whose products populate the curated section + no-results fallback |
 
 The form auto-saves per field (debounced PUT to `/api/admin/settings/search-drawer`) and rolls back on failure with an inline "Couldn't save — try again" hint that auto-clears after 4 s or on the next successful save.
 
-The admin PUT route calls `revalidateTag("search-drawer-config", "default")` so the storefront sees changes within one request, not after the 60 s cache window.
+The admin PUT route calls `revalidateTag("search-drawer-config", "default")` so the storefront's server-side cache picks up the change on its next request. Menu Builder mutations that touch CategoryLabel / CategoryLabelCategory / Category rows also fire the same tag (via [`lib/cache/revalidate-search-drawer.ts`](../../lib/cache/revalidate-search-drawer.ts), shipped v0.103.1).
 
-> **Known gap (#10 in the nitpicks queue):** Menu Builder server actions that mutate `CategoryLabelCategory` (the join table that determines chip ordering) currently don't `revalidateTag` the search-drawer config — so chip order edits made in Menu Builder can be stale on the storefront for up to 60 s. Tracked in [`docs/features/keyword-search-drawer/nitpicks.md`](../features/keyword-search-drawer/nitpicks.md).
+> **Caveat — admin edits don't appear in already-open storefront tabs without a hard refresh.** When admin saves a chip-label or curated-category change, `revalidateTag("search-drawer-config")` busts the *server* cache. But any storefront tab already open holds the prior layout's RSC payload (in the browser HTTP cache + Next's client-side Router Cache), so a normal reload often serves the stale response. A hard refresh (Cmd/Ctrl + Shift + R) reliably shows the new data. Same behavior in dev and prod. Worth surfacing to admins so they don't read a stale chip row as "the save didn't work." Tracked as nitpick #13 in [`docs/features/keyword-search-drawer/nitpicks.md`](../features/keyword-search-drawer/nitpicks.md).
 
 ---
 
@@ -180,7 +180,8 @@ The three scale-dependent risk areas below were reviewed during the v0.103.0 / v
 | [`app/api/search/index/route.ts`](../../app/api/search/index/route.ts) | Returns the full enabled catalog for the client index |
 | [`app/api/search/route.ts`](../../app/api/search/route.ts) | Legacy server-side FTS for `/search?q=` URL |
 | [`app/(site)/layout.tsx`](../../app/(site)/layout.tsx) | `unstable_cache`-wrapped `getSearchDrawerConfig` reader |
-| [`lib/data.ts`](../../lib/data.ts) (`getSearchDrawerConfig`, ~L888) | Reads chip-label categories + settings + curated products |
+| [`lib/data.ts`](../../lib/data.ts) (`getSearchDrawerConfig`, ~L893) | Reads chip-label categories + settings + curated products |
+| [`lib/cache/revalidate-search-drawer.ts`](../../lib/cache/revalidate-search-drawer.ts) | One-line helper called from admin Menu Builder mutations to fire `revalidateTag("search-drawer-config")` |
 | [`app/admin/settings/search/page.tsx`](../../app/admin/settings/search/page.tsx) + `_components/` | Admin form, auto-save with rollback indicator |
 | [`app/api/admin/settings/search-drawer/route.ts`](../../app/api/admin/settings/search-drawer/route.ts) | PUT handler, `revalidateTag("search-drawer-config")` on save |
 

--- a/docs/features/keyword-search-drawer/nitpicks.md
+++ b/docs/features/keyword-search-drawer/nitpicks.md
@@ -86,3 +86,17 @@ Mirrored the search-drawer pattern: event-delegated `onClick` handler on `SheetC
 ### 12. Same-category, different product order between search drawer chip and storefront category page 🟢 Shipped — v0.103.1
 
 Both `lib/data.ts` `getProductsByCategorySlug` and `app/api/search/index/route.ts` now sort by `[{ isFeatured: "desc" }, { name: "asc" }]`. A test on the search-index route asserts the contract so the two surfaces don't drift.
+
+### 13. Admin edits don't appear in already-open storefront tabs without hard refresh 🟡 Open
+
+When admin saves a chip-label or curated-category change, `revalidateTag("search-drawer-config")` busts the *server* cache, but any storefront tab already open holds the prior layout's RSC payload via the browser HTTP cache + Next's client-side Router Cache. A regular reload (F5) often serves the stale response; only a hard refresh (Cmd/Ctrl + Shift + R) reliably shows the new data. Same behavior in dev and prod.
+
+**Why it matters:** Admins editing in one tab and previewing the storefront in another can read a stale chip row as "the save didn't work" and re-trigger the save unnecessarily. Not a correctness bug — the data DID save — but a real UX gotcha for self-service admins.
+
+**Possible mitigations when revisited:**
+
+- **"View storefront" link in the admin save toast** that opens the storefront with a cache-bust query param (e.g. `?_=<timestamp>`) to force a fresh fetch. Smallest scope; doesn't help admins who keep an existing tab open.
+- **`router.refresh()` triggered via a `BroadcastChannel("search-drawer-config")`** message posted from the admin save and listened for in the storefront layout. Refreshes any open storefront tabs in the same browser. Mid-scope; same-browser only.
+- **Server-Sent Events / websocket** from the admin save endpoint, broadcast to clients subscribed to a "search-drawer-config" channel — same idea but works across browsers/devices. Largest scope; only worth it if real shops have multi-device admin workflows.
+
+**Revisit signal:** real-shop admin reports of "I saved but the chip didn't update," or admin UX testing surfacing this as a friction point.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.103.1",
+  "version": "0.103.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.103.1",
+      "version": "0.103.2",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.103.1",
+  "version": "0.103.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## What this delivers

A targeted product-page perf fix plus a documentation alignment pass on the search subsystem so a future reader doesn't hit surprises or gotchas based on stale docs.

### Performance — Product page parallelizes related/addons/category-siblings fetches

[`app/(site)/products/[slug]/page.tsx`](app/(site)/products/[slug]/page.tsx) previously fired four DB queries sequentially: `getProductBySlug` → `getRelatedProducts` → `getProductAddOns` → `getProductsByCategorySlug`. The latter three only depend on results from the first and are independent of each other, so series-mode meant ~3× round-trip latency for no benefit.

Wrapped in `Promise.all`, fanning them out concurrently. On a typical ~80 ms per-query setup that's a ~250 ms reduction on every product navigation — large enough that the search drawer's result→product transition now feels instant on warm caches. Confirmed by manual walk: the page text + layout ships immediately, only the hero image still shows a brief network fetch.

No behavior change beyond timing; same data flows through `ProductClientPage` via the same prop names.

### Documentation alignment

Audit pass on the search subsystem before closing out the feature. Five corrections so future readers (and future us) don't read stale docs as truth:

**`docs/architecture/SEARCH-ARCHITECTURE.md`**
1. **Admin SiteSettings table rewritten to v2 schema.** The doc previously listed three keys (`search_drawer_chips_heading`, `search_drawer_chip_categories`, `search_drawer_curated_category`) — that was v1. Shipped v2 (live in production) uses two: `search_drawer_chip_label` (CategoryLabel.id) and `search_drawer_curated_category` (Category.slug). The chip-row heading derives from `CategoryLabel.name`, not a separate setting. Anyone trying to inspect the schema based on the old doc would have written code that doesn't match the actual surface at [lib/data.ts:898](lib/data.ts#L898).
2. **Data flow ASCII tree** updated to derive heading from `CategoryLabel.name` and explicitly call out `MAX_CHIPS` / `CURATED_PRODUCTS_LIMIT`.
3. **Dropped the "Known gap (#10)" callout** — that gap shipped in v0.103.1. Replaced with a positive note pointing at [`lib/cache/revalidate-search-drawer.ts`](lib/cache/revalidate-search-drawer.ts).
4. **Fixed line number** for `getSearchDrawerConfig` (`~L888` → `~L893`).
5. **New caveat:** admin edits don't appear in already-open storefront tabs without a hard refresh. `revalidateTag` busts the server cache, but the open tab holds a stale RSC payload via browser HTTP cache + Next's Router Cache. Same in dev and prod. Important to flag so admins don't read a stale chip row as "the save didn't work."
6. **Added prefetch deferral entry** in the Scale envelope, documenting why we're not adding `prefetch={true}` on result `<Link>`s (paid for results that go unviewed at scale; correct mitigation when triggered is hover-prefetch via `useRouter().prefetch()`).
7. **Added v0.103.2 result-to-product navigation note** in the drawer surface section, explaining the parallelization shipped in this PR and the page's ISR shape.

**`docs/features/keyword-search-drawer/nitpicks.md`**
8. **New entry #13** — admin edits not reflected in already-open storefront tabs without hard refresh. 🟡 Open. Three possible mitigations ordered by scope: toast cache-bust link / `BroadcastChannel` + `router.refresh()` / SSE+websocket. Plus the revisit signal.

## Branch shape

```
f17c8f6 docs: align architecture + nitpicks with shipped v2 schema and add gotcha
e1861bd docs(architecture): note v0.103.2 parallelization + prefetch deferral
769b260 bump version to 0.103.2
def6ee6 perf(product): parallelize related/addons/category sibling fetches
```

## Out of scope (explicitly)

- **Skeleton (`loading.tsx`) for the product page** — not needed. The parallelization fix removed the gap users were feeling; manual confirmation in this session showed the destination feels instant.
- **Link prefetch on visible search results** — deliberately deferred. Documented in the architecture doc's Scale envelope with revisit triggers and the correct mitigation.
- **Live storefront reflection of admin saves** — captured as nitpick #13. Not broken (data does save, hard refresh shows it); revisit when real-shop admins hit the friction.

## Test plan

- [x] `npm run precheck` — clean (only the pre-existing TanStack Table warning)
- [x] `npm run test:ci` — 1214/1214 passing (no test changes)
- [x] Manual: navigate result → product → result → product from the search drawer; transitions feel instant
- [ ] Vercel preview clean, no console errors

## Version

`v0.103.2` (patch — single perf fix + documentation).
