### PR TITLE
chore(claude): structural gates for PR creation and merge

### DIFF
--- a/.claude/hooks/pre-pr-via-release-node.js
+++ b/.claude/hooks/pre-pr-via-release-node.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// .claude/hooks/pre-pr-via-release-node.js
+//
+// Claude Code PreToolUse hook — intercepts `gh pr create` and ensures the
+// caller is going through the `/release` flow rather than opening a PR
+// directly from `/commit`, `/review`, or an ad-hoc bash command.
+//
+// The signal: the latest commit on the current branch must match
+// `bump version to X.Y.Z`. That commit is the unique fingerprint produced
+// by `/release` Step 5 (commit version bump). If the latest commit does NOT
+// match that shape, the caller hasn't run `/release` and we block.
+//
+// Why a structural gate beats a memory/skill rule:
+//   - Skills can read their own instructions in isolation and miss
+//     standing rules that say "use a different skill instead."
+//   - Memory entries describing "always use /release" get bypassed
+//     mid-flow once a skill is in motion.
+//   - A hook that checks a real git artifact can't be talked around.
+//
+// Exit 0 = allow, Exit 2 = block (stderr shown to model)
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require("path");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { execSync } = require("child_process");
+
+// Matches the canonical `/release` version-bump commit. Tolerates a trailing
+// suffix (e.g. `(#123)` from squash-merge replays) so we don't over-block
+// after a release that re-runs against main.
+const VERSION_BUMP_RE = /^bump version to \d+\.\d+\.\d+\b/i;
+
+function deny(reason) {
+  process.stderr.write(reason);
+  process.exit(2);
+}
+
+function exec(cmd, cwd) {
+  return execSync(cmd, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim();
+}
+
+function main(input) {
+  let command = "";
+  try {
+    const parsed = JSON.parse(input);
+    command = (parsed.tool_input && parsed.tool_input.command) || "";
+  } catch {
+    process.exit(0);
+  }
+
+  // Only intercept `gh pr create` when it appears at a shell-command position —
+  // start-of-string, or after a shell operator (`;`, `&&`, `||`, `|`, newline,
+  // open paren). This prevents false matches when the literal text "gh pr create"
+  // appears inside a heredoc / quoted string (e.g. inside a commit message body
+  // referencing the command by name).
+  if (!/(^|[\n;&|(]\s*)gh\s+pr\s+create\b/i.test(command)) {
+    process.exit(0);
+  }
+
+  const projectDir = path.resolve(__dirname, "..", "..");
+
+  // Read the latest commit subject on the current HEAD
+  let lastSubject = "";
+  try {
+    lastSubject = exec("git log -1 --format=%s", projectDir);
+  } catch {
+    // If we can't read git state, fail open — better to let the user proceed
+    // than to block on an unrelated environment issue.
+    process.exit(0);
+  }
+
+  if (VERSION_BUMP_RE.test(lastSubject)) {
+    // `/release` produced this commit; PR creation is authorized.
+    process.exit(0);
+  }
+
+  deny(
+    "BLOCKED: `gh pr create` is gated to the `/release` flow.\n\n" +
+      `The latest commit on this branch is:\n  ${lastSubject}\n\n` +
+      "It must be a `bump version to X.Y.Z` commit (the `/release` skill's\n" +
+      "version-bump fingerprint). Do not open a PR directly from `/commit`,\n" +
+      "`/review`, or an ad-hoc bash invocation.\n\n" +
+      "── How to proceed ──\n" +
+      "1. Run `/release <patch|minor|major>` — it bumps package.json, updates\n" +
+      "   CHANGELOG.md, commits the bump, and creates the PR.\n" +
+      "2. If you have an exceptional reason to bypass (e.g. recovering from a\n" +
+      "   crashed release flow), check with the user before forcing it.\n"
+  );
+}
+
+let input = "";
+process.stdin.on("data", (chunk) => (input += chunk));
+process.stdin.on("end", () => main(input));

--- a/.claude/hooks/pre-pr-via-release-node.js
+++ b/.claude/hooks/pre-pr-via-release-node.js
@@ -53,10 +53,12 @@ function main(input) {
 
   // Only intercept `gh pr create` when it appears at a shell-command position —
   // start-of-string, or after a shell operator (`;`, `&&`, `||`, `|`, newline,
-  // open paren). This prevents false matches when the literal text "gh pr create"
-  // appears inside a heredoc / quoted string (e.g. inside a commit message body
-  // referencing the command by name).
-  if (!/(^|[\n;&|(]\s*)gh\s+pr\s+create\b/i.test(command)) {
+  // open paren) — and tolerate optional shell whitespace after that boundary.
+  // This prevents false matches when the literal text "gh pr create" appears
+  // inside a heredoc / quoted string (e.g. inside a commit message body
+  // referencing the command by name), while still catching leading-whitespace
+  // variants such as `  gh pr create`.
+  if (!/(?:^|[\n;&|(])\s*gh\s+pr\s+create\b/i.test(command)) {
     process.exit(0);
   }
 

--- a/.claude/hooks/review-before-merge-node.js
+++ b/.claude/hooks/review-before-merge-node.js
@@ -16,6 +16,13 @@
 //     b. New commits pushed AFTER the Copilot review (feedback addressed)
 //     c. Ack file exists: .claude/.copilot-ack-{pr}.json (reviewed, no changes needed)
 //
+// Gate 3 — Resolve every standing review thread:
+//   Blocks if any review thread on the PR remains unresolved (isResolved == false).
+//   This is independent of Gate 2's "newer commit" heuristic — replying to a
+//   comment OR pushing a fix doesn't mark a thread resolved in the GitHub UI.
+//   Resolution requires explicit GraphQL `resolveReviewThread` calls.
+//   Bypass: ack file (.claude/.copilot-ack-{pr}.json) skips this gate too.
+//
 // Error policy: API failures BLOCK the merge (fail-closed). If the hook can't
 // verify Copilot's review status, it's safer to block than to silently allow.
 //
@@ -67,8 +74,11 @@ function main(input) {
     process.exit(0);
   }
 
-  // Only intercept gh pr merge commands
-  if (!/gh\s+pr\s+merge/i.test(command)) {
+  // Only intercept `gh pr merge` when it appears at a shell-command position —
+  // start-of-string, or after a shell operator (`;`, `&&`, `||`, `|`, newline,
+  // open paren). This prevents false matches when the literal text "gh pr merge"
+  // appears inside a heredoc / quoted string (e.g. inside a commit message body).
+  if (!/(^|[\n;&|(]\s*)gh\s+pr\s+merge\b/i.test(command)) {
     process.exit(0);
   }
 
@@ -197,6 +207,7 @@ function main(input) {
   }
 
   // Check if commits were pushed after the Copilot review (feedback addressed)
+  let gate2Passed = false;
   try {
     const rawReviewsForTime = exec(
       `gh api --paginate repos/${repo}/pulls/${prNumber}/reviews`,
@@ -223,14 +234,76 @@ function main(input) {
       lastCommitTime &&
       new Date(lastCommitTime) > new Date(reviewTime)
     ) {
-      // Newer commits exist — feedback was addressed
-      process.exit(0);
+      gate2Passed = true; // Newer commits exist — feedback presumed addressed
     }
   } catch {
-    // Timestamp comparison failed — fall through to block (fail-closed)
+    // Timestamp comparison failed — leave gate2Passed false (fail-closed)
   }
 
-  // Block: Copilot left unaddressed comments
+  if (!gate2Passed) {
+    denyForUnaddressedComments(prNumber, comments);
+  }
+
+  // ── Gate 3: All review threads resolved ──────────────────────────────
+  //
+  // GitHub's review-thread state is independent of comment replies and
+  // commit timestamps. Gate 2's "newer commit" heuristic lets feedback
+  // through but doesn't close threads in the UI — so Gate 3 enforces
+  // explicit resolution via the GraphQL `resolveReviewThread` mutation.
+  let unresolvedThreads = [];
+  try {
+    const owner = repo.split("/")[0];
+    const name = repo.split("/")[1];
+    const graphqlQuery = `query { repository(owner: \"${owner}\", name: \"${name}\") { pullRequest(number: ${prNumber}) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 1) { nodes { author { login } path body } } } } } } }`;
+    const rawThreads = exec(
+      `gh api graphql -f query='${graphqlQuery.replace(/'/g, "'\\''")}'`,
+      projectDir
+    );
+    const parsed = rawThreads ? JSON.parse(rawThreads) : null;
+    const nodes =
+      parsed?.data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
+    unresolvedThreads = nodes
+      .filter((t) => !t.isResolved)
+      .map((t) => ({
+        id: t.id,
+        path: t.comments?.nodes?.[0]?.path || "",
+        body: t.comments?.nodes?.[0]?.body || "",
+        author: t.comments?.nodes?.[0]?.author?.login || "",
+      }));
+  } catch {
+    // GraphQL failure — fall back to Gate 2 result and allow merge.
+    // We've already passed Gate 2 (newer commit exists), so don't
+    // fail-closed on a transient API issue.
+    process.exit(0);
+  }
+
+  if (unresolvedThreads.length === 0) {
+    process.exit(0); // All threads resolved — allow merge
+  }
+
+  // Block: unresolved review threads remain
+  let msg = `BLOCKED: PR #${prNumber} has ${unresolvedThreads.length} unresolved review thread(s).\n\n`;
+
+  unresolvedThreads.forEach((t, i) => {
+    const body = t.body.length > 200 ? t.body.slice(0, 197) + "..." : t.body;
+    msg += `${i + 1}. [${t.author} on ${t.path}]\n`;
+    msg += `   ${body.replace(/\n/g, "\n   ")}\n`;
+    msg += `   Thread id: ${t.id}\n\n`;
+  });
+
+  msg += "── How to proceed ──\n";
+  msg += "Resolve each thread via the GraphQL `resolveReviewThread` mutation:\n\n";
+  msg +=
+    "  gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: \"<THREAD_ID>\"}) { thread { isResolved } } }'\n\n";
+  msg += "A reply alone (or a newer commit) does NOT mark a thread resolved.\n";
+  msg += "After resolving all threads, retry the merge.\n";
+
+  deny(msg);
+}
+
+// (Gate 2's original "all comments unaddressed" branch lives below; kept
+// here as a fall-through for the case where there's no newer commit.)
+function denyForUnaddressedComments(prNumber, comments) {
   let msg = `BLOCKED: Copilot left ${comments.length} review comment(s) on PR #${prNumber} that have not been addressed.\n\n`;
 
   comments.forEach((c, i) => {
@@ -244,7 +317,7 @@ function main(input) {
   msg += "1. Evaluate each comment — make code changes where warranted\n";
   msg += "2. Push changes (new commits after the review auto-clear this gate)\n";
   msg += "3. If NO code changes are needed after review, acknowledge:\n";
-  msg += `   Write { "reviewed": true } to .claude/.copilot-ack-${prNumber}.json\n`;
+  msg += `   Write { \"reviewed\": true } to .claude/.copilot-ack-${prNumber}.json\n`;
   msg += "4. Retry the merge\n";
 
   deny(msg);

--- a/.claude/hooks/review-before-merge-node.js
+++ b/.claude/hooks/review-before-merge-node.js
@@ -23,8 +23,12 @@
 //   Resolution requires explicit GraphQL `resolveReviewThread` calls.
 //   Bypass: ack file (.claude/.copilot-ack-{pr}.json) skips this gate too.
 //
-// Error policy: API failures BLOCK the merge (fail-closed). If the hook can't
-// verify Copilot's review status, it's safer to block than to silently allow.
+// Error policy: Gates 1 and 2 are fail-closed on API/CLI verification errors.
+// Gate 3 has a narrower fail-open exception: if its GraphQL fetch fails at the
+// transport / parsing layer, the hook allows the merge rather than blocking on
+// an indeterminate thread-resolution check (Gate 2 has already passed by that
+// point — feedback is presumed addressed). Keep this comment in sync with the
+// enforcement logic below if either gate's failure mode changes.
 //
 // Exit 0 = allow, Exit 2 = block (stderr shown to model)
 
@@ -76,9 +80,12 @@ function main(input) {
 
   // Only intercept `gh pr merge` when it appears at a shell-command position —
   // start-of-string, or after a shell operator (`;`, `&&`, `||`, `|`, newline,
-  // open paren). This prevents false matches when the literal text "gh pr merge"
-  // appears inside a heredoc / quoted string (e.g. inside a commit message body).
-  if (!/(^|[\n;&|(]\s*)gh\s+pr\s+merge\b/i.test(command)) {
+  // open paren) — and tolerate optional shell whitespace after that boundary.
+  // This prevents false matches when the literal text "gh pr merge" appears
+  // inside a heredoc / quoted string (e.g. inside a commit message body
+  // referencing the command by name), while still catching leading-whitespace
+  // variants such as `  gh pr merge`.
+  if (!/(?:^|[\n;&|(])\s*gh\s+pr\s+merge\b/i.test(command)) {
     process.exit(0);
   }
 
@@ -250,26 +257,43 @@ function main(input) {
   // commit timestamps. Gate 2's "newer commit" heuristic lets feedback
   // through but doesn't close threads in the UI — so Gate 3 enforces
   // explicit resolution via the GraphQL `resolveReviewThread` mutation.
-  let unresolvedThreads = [];
+  // Paginate through all review threads (GraphQL caps at 100 per page).
+  // Without pagination, PRs with >100 threads would skip checks for any
+  // thread past the first page — an unresolved thread on page 2 would
+  // silently allow merge.
+  const unresolvedThreads = [];
   try {
     const owner = repo.split("/")[0];
     const name = repo.split("/")[1];
-    const graphqlQuery = `query { repository(owner: \"${owner}\", name: \"${name}\") { pullRequest(number: ${prNumber}) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 1) { nodes { author { login } path body } } } } } } }`;
-    const rawThreads = exec(
-      `gh api graphql -f query='${graphqlQuery.replace(/'/g, "'\\''")}'`,
-      projectDir
-    );
-    const parsed = rawThreads ? JSON.parse(rawThreads) : null;
-    const nodes =
-      parsed?.data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
-    unresolvedThreads = nodes
-      .filter((t) => !t.isResolved)
-      .map((t) => ({
-        id: t.id,
-        path: t.comments?.nodes?.[0]?.path || "",
-        body: t.comments?.nodes?.[0]?.body || "",
-        author: t.comments?.nodes?.[0]?.author?.login || "",
-      }));
+    let hasNextPage = true;
+    let endCursor = null;
+
+    while (hasNextPage) {
+      const afterClause = endCursor ? `, after: \"${endCursor}\"` : "";
+      const graphqlQuery = `query { repository(owner: \"${owner}\", name: \"${name}\") { pullRequest(number: ${prNumber}) { reviewThreads(first: 100${afterClause}) { nodes { id isResolved comments(first: 1) { nodes { author { login } path body } } } pageInfo { hasNextPage endCursor } } } } }`;
+      const rawThreads = exec(
+        `gh api graphql -f query='${graphqlQuery.replace(/'/g, "'\\''")}'`,
+        projectDir
+      );
+      const parsed = rawThreads ? JSON.parse(rawThreads) : null;
+      const reviewThreads =
+        parsed?.data?.repository?.pullRequest?.reviewThreads ?? {};
+      const nodes = reviewThreads.nodes ?? [];
+
+      unresolvedThreads.push(
+        ...nodes
+          .filter((t) => !t.isResolved)
+          .map((t) => ({
+            id: t.id,
+            path: t.comments?.nodes?.[0]?.path || "",
+            body: t.comments?.nodes?.[0]?.body || "",
+            author: t.comments?.nodes?.[0]?.author?.login || "",
+          }))
+      );
+
+      hasNextPage = reviewThreads.pageInfo?.hasNextPage ?? false;
+      endCursor = reviewThreads.pageInfo?.endCursor ?? null;
+    }
   } catch {
     // GraphQL failure — fall back to Gate 2 result and allow merge.
     // We've already passed Gate 2 (newer commit exists), so don't

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -144,6 +144,11 @@
           },
           {
             "type": "command",
+            "command": "if [ -f .claude/hooks/pre-pr-via-release-node.js ]; then node .claude/hooks/pre-pr-via-release-node.js; else exit 0; fi",
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "if [ -f .claude/hooks/pre-migrate-backup-node.js ]; then node .claude/hooks/pre-migrate-backup-node.js; else exit 0; fi",
             "timeout": 10
           }


### PR DESCRIPTION
## What this delivers

Two Claude Code hooks plus a settings registration so PR-flow rules are enforced by the harness, not by skill text or memory entries.

### Why structural beats procedural

In this session's earlier work we hit two recurring failure modes:

1. **Auto-PR creation:** the `/release` skill went straight from `git push` → opening a PR without pausing for a human walk-through, despite a memory entry instructing otherwise. Memory rules get bypassed once a skill is in motion.
2. **Unresolved review threads on merge:** Copilot threads stayed open in the GitHub UI because replying to a comment (or pushing a fix commit) never marks the thread resolved. The user historically had to prompt explicit resolution every time.

Skill text fixes problem (1) only inside the skill, and the merge gate hook's "newer commit = addressed" heuristic missed problem (2) entirely. Hooks check real git/GitHub artifacts and intercept the bash invocation regardless of which skill or path produced it — structural enforcement, not prompt obedience.

### `pre-pr-via-release-node.js` (new)

Intercepts the PR-creation command. Allows only if the latest commit on the current branch matches `^bump version to \d+\.\d+\.\d+\b` — the unique fingerprint produced by `/release` Step 5 (commit version bump). If not, blocks with a message pointing the caller at `/release <patch|minor|major>`.

`/release` is now the only sanctioned PR-creation path. `/commit`, `/review`, or ad-hoc invocations are blocked unless they follow `/release`.

### `review-before-merge-node.js` — Gate 3 added

The existing hook had two gates: Gate 1 waits for Copilot review on code PRs, Gate 2 blocks if Copilot has unaddressed comments (heuristic: "newer commit after review = addressed"). Both let the merge through once a fix commit was pushed, even with threads still open in the GitHub UI.

**Gate 3:** queries `reviewThreads` via GraphQL and blocks if any node has `isResolved == false`. Block message lists each unresolved thread with body + id, plus the GraphQL `resolveReviewThread` mutation. Independent of Gate 2 — replying or pushing a fix doesn't satisfy Gate 3.

Refactored Gate 2 to set a `gate2Passed` flag rather than `exit(0)` on success, so flow falls through to Gate 3 cleanly. Gate 3 fails open on GraphQL transport errors.

### Regex hardening (both hooks)

The original `gh\s+pr\s+(create|merge)` patterns triggered on literal text appearing inside heredoc / quoted strings — discovered the hard way when the first commit attempt was blocked by its own commit message body referencing the command by name. Tightened both to anchor on shell-command position (start-of-string, or after `;` `&&` `||` `|` newline `(`). Catches real chained invocations like `cmd1 && gh pr ...` but ignores text inside strings.

### Settings registration

`.claude/settings.json` adds the new hook to PreToolUse > Bash, between the existing precheck-stamps hook and the migration-backup hook.

### Companion changes (out of this PR)

- `/release` skill (in `dev/artisan-roast-platform`): drops the in-skill HALT step and the explicit resolve-threads step. Both are now enforced by the hooks here. Ships separately in the platform repo.
- Memory entry `feedback_review_before_pr.md`: rewritten to point at the hooks as the source of truth.

### Bootstrap note

The hook itself blocks non-versioned PR creation. This very PR (`chore/...`, no version bump) couldn't satisfy that rule by definition — the user explicitly authorized shipping as a docs-style change without a bump. Bypass was a one-time temporary removal of the hook entry from the working tree's `settings.json` for the duration of `gh pr create`; the committed branch state has the registration intact and will be enforced from the next session forward.

## Branch shape

```
13fe8f6 chore(claude): structural gates for PR creation and merge
```

Single commit. No version bump, no CHANGELOG entry.

## Test plan

- [x] Both hooks pass `node --check` syntax validation
- [x] Regex hardening verified end-to-end (this PR's commit message body referenced the gated commands by name without triggering the hook)
- [ ] Vercel preview clean
- [ ] In a future session: `gh pr create` without a `bump version to X.Y.Z` commit yields the expected block message
- [ ] In a future session: `gh pr merge` with an unresolved thread yields Gate 3 block
