### PR TITLE
fix(plans): fall back to self-hosted plans when platform API is unreachable (v0.105.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.105.2 - 2026-05-06
+
+### Fixed
+
+- **Plans page fallback**: `fetchPlans()` now returns Community + Priority Support plans on platform API error or timeout instead of an empty array, preventing the "Plans could not be loaded" blank state on self-hosted stores
+
 ## 0.105.1 - 2026-05-05
 
 ### Added

--- a/lib/__tests__/plans.test.ts
+++ b/lib/__tests__/plans.test.ts
@@ -30,10 +30,9 @@ describe("fetchPlans", () => {
 
     const plans = await fetchPlans();
 
-    expect(plans.length).toBeGreaterThan(0);
+    expect(plans).toHaveLength(2);
+    expect(plans.map((p) => p.slug)).toEqual(["free", "priority-support"]);
     expect(plans.every((p) => p.visibility === "self-hosted")).toBe(true);
-    expect(plans.map((p) => p.slug)).toContain("free");
-    expect(plans.map((p) => p.slug)).toContain("priority-support");
   });
 
   // AC-E2E-9: Platform returns 500 → self-hosted fallback
@@ -45,7 +44,8 @@ describe("fetchPlans", () => {
 
     const plans = await fetchPlans();
 
-    expect(plans.length).toBeGreaterThan(0);
+    expect(plans).toHaveLength(2);
+    expect(plans.map((p) => p.slug)).toEqual(["free", "priority-support"]);
     expect(plans.every((p) => p.visibility === "self-hosted")).toBe(true);
   });
 
@@ -58,7 +58,8 @@ describe("fetchPlans", () => {
 
     const plans = await fetchPlans();
 
-    expect(plans.length).toBeGreaterThan(0);
+    expect(plans).toHaveLength(2);
+    expect(plans.map((p) => p.slug)).toEqual(["free", "priority-support"]);
     expect(plans.every((p) => p.visibility === "self-hosted")).toBe(true);
   });
 

--- a/lib/__tests__/plans.test.ts
+++ b/lib/__tests__/plans.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for fetchPlans() from lib/plans.ts
  *
- * AC-E2E-9: Platform unreachable → returns empty array, no crash
+ * AC-E2E-9: Platform unreachable → returns self-hosted fallback plans (Community + Priority Support), no crash
  */
 
 // ---------------------------------------------------------------------------
@@ -24,17 +24,20 @@ describe("fetchPlans", () => {
     invalidatePlansCache();
   });
 
-  // AC-E2E-9: Network error → empty array, no crash
-  it("returns empty array when fetch throws (network error)", async () => {
+  // AC-E2E-9: Network error → self-hosted fallback, no crash
+  it("returns self-hosted fallback plans when fetch throws (network error)", async () => {
     mockFetch.mockRejectedValueOnce(new Error("fetch failed"));
 
     const plans = await fetchPlans();
 
-    expect(plans).toEqual([]);
+    expect(plans.length).toBeGreaterThan(0);
+    expect(plans.every((p) => p.visibility === "self-hosted")).toBe(true);
+    expect(plans.map((p) => p.slug)).toContain("free");
+    expect(plans.map((p) => p.slug)).toContain("priority-support");
   });
 
-  // AC-E2E-9: Platform returns 500 → empty array
-  it("returns empty array when platform returns 500", async () => {
+  // AC-E2E-9: Platform returns 500 → self-hosted fallback
+  it("returns self-hosted fallback plans when platform returns 500", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 500,
@@ -42,11 +45,12 @@ describe("fetchPlans", () => {
 
     const plans = await fetchPlans();
 
-    expect(plans).toEqual([]);
+    expect(plans.length).toBeGreaterThan(0);
+    expect(plans.every((p) => p.visibility === "self-hosted")).toBe(true);
   });
 
-  // AC-E2E-9: Platform returns 503 → empty array
-  it("returns empty array when platform returns 503", async () => {
+  // AC-E2E-9: Platform returns 503 → self-hosted fallback
+  it("returns self-hosted fallback plans when platform returns 503", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 503,
@@ -54,7 +58,8 @@ describe("fetchPlans", () => {
 
     const plans = await fetchPlans();
 
-    expect(plans).toEqual([]);
+    expect(plans.length).toBeGreaterThan(0);
+    expect(plans.every((p) => p.visibility === "self-hosted")).toBe(true);
   });
 
   // Happy path: platform returns plans

--- a/lib/plans.ts
+++ b/lib/plans.ts
@@ -2,7 +2,7 @@
  * Plans Module — Fetches available subscription plans from the platform.
  *
  * Public endpoint, no auth required. Cached for 24 hours.
- * Returns empty array on error (graceful fallback).
+ * Falls back to self-hosted plans on error so Community + Priority Support are always visible.
  */
 
 import type { Plan, PlansResponse } from "./plan-types";
@@ -45,7 +45,7 @@ export async function fetchPlans(): Promise<Plan[]> {
 
     if (!response.ok) {
       console.error("Plans fetch failed:", response.status);
-      return [];
+      return SELF_HOSTED_FALLBACK_PLANS;
     }
 
     const data = (await response.json()) as PlansResponse;
@@ -54,7 +54,7 @@ export async function fetchPlans(): Promise<Plan[]> {
     return plans;
   } catch (error) {
     console.error("Plans fetch error:", error);
-    return [];
+    return SELF_HOSTED_FALLBACK_PLANS;
   }
 }
 
@@ -79,7 +79,7 @@ export function filterPlansByVisibility(
 }
 
 // ---------------------------------------------------------------------------
-// Mock plans (for MOCK_LICENSE_TIER env var)
+// Mock plans (for MOCK_LICENSE_TIER env var) + self-hosted fallback
 // ---------------------------------------------------------------------------
 
 const MOCK_PLANS: Plan[] = [
@@ -238,3 +238,7 @@ const MOCK_PLANS: Plan[] = [
     },
   },
 ];
+
+const SELF_HOSTED_FALLBACK_PLANS: Plan[] = MOCK_PLANS.filter(
+  (p) => p.visibility === "self-hosted"
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.105.1",
+  "version": "0.105.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.105.1",
+      "version": "0.105.2",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.105.1",
+  "version": "0.105.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- `fetchPlans()` previously returned `[]` on both non-ok response and network error, causing the plans page to show "Plans could not be loaded" on self-hosted stores when the platform API was unreachable
- Now returns `SELF_HOSTED_FALLBACK_PLANS` (Community + Priority Support filtered from `MOCK_PLANS`) in both error paths
- Hosted plans (House Blend Trial, House Blend) are correctly excluded from the fallback — they should not appear on self-hosted instances
- Test expectations updated to assert the self-hosted fallback shape instead of `[]`

## Why

Community and Priority Support plans are always-on by design — self-hosted users must see them regardless of whether the platform API is reachable. This is a stopgap; the permanent fix comes with the `sdk-type-alignment` body of work which replaces `MOCK_PLANS` with `MOCK_HYDRATED_PLANS` from the SDK scaffolds.

## Test plan

- [ ] Verify plans page shows Community + Priority Support cards when platform API is down (set `PLATFORM_URL` to an unreachable host locally)
- [ ] Verify plans page still loads correctly when platform API is reachable
- [ ] Verify hosted build (`IS_HOSTED=true`) is unaffected — fallback is only reached when API errors, and hosted plans are excluded from the fallback set