### PR TITLE
docs: provider-plan-sdk-alignment session renumber + plan-card-corrections ACs

### DIFF
--- a/.claude/retro-log.md
+++ b/.claude/retro-log.md
@@ -13,8 +13,8 @@ Running log of process lessons learned and applied. Each entry documents a gap d
 **Fix applied to:**
 
 - `.claude/skills/release/SKILL.md` — Step A.5 replaced with a hard STOP instruction: "report that the branch is pushed, wait for explicit user go-ahead before running `gh pr create`." The `--docs-only` path received the same change.
-- `memory/feedback_no_pr_without_instruction.md` (new) — Feedback memory capturing the rule: never run `gh pr create` autonomously; stop after push and wait.
-- `memory/MEMORY.md` — Pointer added to the new feedback file.
+- `~/.claude/projects/.../memory/feedback_no_pr_without_instruction.md` (new) — Feedback memory capturing the rule: never run `gh pr create` autonomously; stop after push and wait. Lives in Claude's user-level memory store (outside this repo).
+- `~/.claude/projects/.../memory/MEMORY.md` — Pointer added to the new feedback file. Also in user-level memory store.
 
 **Prevented by:** Release skill now has an explicit stop gate at Step A.5. Memory file captures the rule for sessions where the release skill isn't the context — any standalone `gh pr create` call should also pause first.
 

--- a/.claude/retro-log.md
+++ b/.claude/retro-log.md
@@ -4,6 +4,22 @@ Running log of process lessons learned and applied. Each entry documents a gap d
 
 ---
 
+## 2026-05-07 — PR opened autonomously inside /release without explicit user instruction
+
+**Gap:** During the `provider-plan-sdk-alignment` session (Sessions 2+3, branch `feat/sdk-type-alignment`), the `/release minor` skill ran Phase A through to completion — bump, push, and then automatically ran `gh pr create` without pausing for user approval. The user's expectation was that PR creation is a deliberate, user-gated moment, not an automatic step in a release flow.
+
+**Root cause:** The release skill (`SKILL.md`) listed Phase A Step 5 "Open the PR" as a sequential step following Step 4 "Push the branch" — no pause, no check-in. From the agent's perspective, it was following the skill protocol correctly. The skill simply had no stop gate before `gh pr create`.
+
+**Fix applied to:**
+
+- `.claude/skills/release/SKILL.md` — Step A.5 replaced with a hard STOP instruction: "report that the branch is pushed, wait for explicit user go-ahead before running `gh pr create`." The `--docs-only` path received the same change.
+- `memory/feedback_no_pr_without_instruction.md` (new) — Feedback memory capturing the rule: never run `gh pr create` autonomously; stop after push and wait.
+- `memory/MEMORY.md` — Pointer added to the new feedback file.
+
+**Prevented by:** Release skill now has an explicit stop gate at Step A.5. Memory file captures the rule for sessions where the release skill isn't the context — any standalone `gh pr create` call should also pause first.
+
+---
+
 ## 2026-04-29 — Ephemeral verification scripts placed in `scripts/` instead of `.scratch/`
 
 **Gap:** During the hosted-store-s2 trial UI verification session, two feature-specific Playwright scripts (`scripts/verify-trial-ui.ts`, `scripts/verify-hosting-screenshots.ts`) were written to `scripts/` instead of `.scratch/`. The `scripts/` directory is committed; `.scratch/` is gitignored. Placing QC tooling in `scripts/` would have committed ephemeral verification artifacts to the project repo. The scripts were caught while still untracked and moved before commit.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -107,7 +107,14 @@ Then commit the changes on that branch and follow the feature-branch path below.
    git push -u origin <branch-name>
    ```
 
-5. **Open the PR:**
+5. **STOP — wait for explicit instruction to open the PR.**
+
+   Report to the user:
+   > Branch pushed. Ready to open the PR — say the word when you want it created.
+
+   Do NOT run `gh pr create` until the user explicitly says so (e.g. "open the PR", "create the PR", "go ahead"). This applies even when the release skill is the one driving the workflow — PR creation is always a user-gated step.
+
+   When the user gives the go-ahead, run:
 
    ```bash
    gh pr create --title "<conventional-format-title> (vX.Y.Z)" --body-file <body-path> --base main
@@ -127,7 +134,7 @@ Then commit the changes on that branch and follow the feature-branch path below.
 
    This is an empty commit with no content changes. It exists only to satisfy the structural gate. Any docs commits on the branch must come *before* this marker — the marker has to be the latest commit when `gh pr create` runs.
 
-3. **Push** and **open the PR** as in the normal flow. No version bump, no CHANGELOG entry — the PR body should make clear it's a docs-only change.
+3. **Push** the branch. Then **STOP — wait for explicit user instruction** before running `gh pr create`. No version bump, no CHANGELOG entry — the PR body should make clear it's a docs-only change.
 
 ##### After PR is open
 

--- a/docs/features/provider-plan-sdk-alignment/plan.md
+++ b/docs/features/provider-plan-sdk-alignment/plan.md
@@ -1,18 +1,24 @@
 # provider-plan-sdk-alignment
 
-Three sequential sessions deleting the local `lib/plan-types.ts` and rewriting the plan card renderer to consume the `artisan-roast-sdk` `HydratedPlan` contract.
+Aligning the store's plan card renderer to consume the `artisan-roast-sdk` `HydratedPlan` contract — deleting local type duplicates and rendering all plan state from payload data with no hardcoded logic.
 
 ## Dependency order
 
-```
-Session 1 — SDK repo: Priority Support scaffolds + slug fix (v0.3.2)
+```text
+[SDK prereq]       Priority Support scaffolds + slug fix (v0.3.2)               ✓ merged
   ↓
-Session 2 — ecomm: sdk-type-alignment (install SDK, delete plan-types.ts, fix consumers)
+Session 1 — Store: sdk-type-alignment (install SDK, delete plan-types.ts)        ✓ merged
   ↓
-Session 3 — ecomm: provider-driven-plan-cards (PlanPageClient rewrite, dispatch on state.status)
+Session 2 — Store: provider-driven-plan-cards (PlanPageClient rewrite)           ✓ merged
+  ↓
+[SDK prereq]       usagepool-extension — ProgressBar→UsagePool, icon/countLabel  ← SDK work
+  ↓
+Session 3 — Store: plan-card-corrections (pool rendering, CTA layout, shim)      ← blocked on SDK
 ```
 
-## Session 1 — SDK: Priority Support scaffolds
+**SDK prerequisite docs:** `artisan-roast-sdk/docs/provider-plan-spec/usagepool-extension/`
+
+## SDK Prerequisite — Priority Support scaffolds
 
 **Repo:** `artisan-roast-sdk` | **Branch:** `feat/priority-support-scaffolds` | **Produces:** v0.3.2
 
@@ -26,13 +32,13 @@ Session 3 — ecomm: provider-driven-plan-cards (PlanPageClient rewrite, dispatc
 
 Use `mcp__artisan-roast-sdk__scaffold_plan_state` to generate initial shapes; use `mcp__artisan-roast-sdk__validate_plan_payload` to verify each before committing.
 
-**ACs:** `session-1/ACs.md` (tracked in SDK repo; copy here for cross-repo reference)
+**ACs:** tracked in SDK repo — `artisan-roast-sdk/docs/provider-plan-spec/priority-support-scaffolds/ACs.md`
 
 ---
 
-## Session 2 — Store: sdk-type-alignment
+## Session 1 — Store: sdk-type-alignment
 
-**Repo:** `ecomm-ai-app` | **Branch:** `feat/sdk-type-alignment` | **ACs:** `session-2/ACs.md`
+**Repo:** `ecomm-ai-app` | **Branch:** `feat/sdk-type-alignment` | **ACs:** `session-1/ACs.md`
 
 **Goal:** Delete `lib/plan-types.ts`. Import all types from SDK. No UI changes.
 
@@ -57,9 +63,9 @@ Use `mcp__artisan-roast-sdk__scaffold_plan_state` to generate initial shapes; us
 
 ---
 
-## Session 3 — Store: provider-driven-plan-cards
+## Session 2 — Store: provider-driven-plan-cards
 
-**Repo:** `ecomm-ai-app` | **Branch:** `feat/provider-driven-plan-cards` | **ACs:** `session-3/ACs.md`
+**Repo:** `ecomm-ai-app` | **Branch:** `feat/provider-driven-plan-cards` | **ACs:** `session-2/ACs.md`
 
 **Goal:** Rewrite `PlanPageClient` to dispatch on `plan.state.status`. No slug checks.
 
@@ -90,20 +96,60 @@ All 6 scenarios verified in `.screenshots/provider-plan-sdk-alignment-session3/`
 
 ---
 
-## Verification registration
+## SDK Prerequisite — usagepool-extension
 
-`.claude/verification-status.json`:
-- `feat/sdk-type-alignment` → `{ status: "planned", acs_total: 9 }`
-- `feat/provider-driven-plan-cards` → `{ status: "planned", acs_total: 12 }`
+**Repo:** `artisan-roast-sdk` | **Branch:** `feat/usagepool-extension` | **Produces:** v0.3.3
+**Full plan + ACs:** `artisan-roast-sdk/docs/provider-plan-spec/usagepool-extension/`
 
-## Commit schedule (Session 2)
+**Type changes:**
+
+- `ProgressBar` removed; `TrialState` + `ExpiredState` use `pools: UsagePool[]`
+- `UsagePool.icon?: string` — Lucide icon before pool label
+- `UsagePool.countLabel?: string` — unit suffix; store renders `{used} / {limit} {countLabel}`
+
+**Scaffold corrections:** description fix, pool icons/labels, trial pools shape, `TRIAL_ACTIVE_CARD_ADDED` actions, `TRIAL_EXPIRED` redesign, billing actions on `CONVERTED`/`DIRECT_SUBSCRIBE`, `INACTIVE` inactiveItems.
+
+---
+
+## Session 3 — Store: plan-card-corrections
+
+**Repo:** `ecomm-ai-app` | **Branch:** `feat/plan-card-corrections` | **ACs:** `session-3/ACs.md`
+**Prerequisite:** SDK `feat/usagepool-extension` (v0.3.3) merged + dep bumped in store
+
+### What to build
+
+**`PlanPageClient.tsx` — rendering corrections:**
+
+- **Pool icon**: render `pool.icon` (via `resolveIconComponent`) before pool label if present
+- **Pool count**: render `{pool.used} / {pool.limit} {pool.countLabel}` — store provides only the spaces and `/`; fall back to `{used} / {limit}` when `countLabel` absent
+- **Trial pools**: render `TrialState.pools` and `ExpiredState.pools` identically to `ActiveState.pools` — no separate `ProgressBar` renderer
+- **`descText` position**: render above pool bars, not below
+- **CTA layout rule** (replaces Session 3 rule):
+
+| CTAs total | Layout |
+|-----------|--------|
+| 1 | Single inline button |
+| 2 | Left: secondary/ghost · Right: primary |
+| 3+ | All in ⋮ overflow menu |
+| Mobile (any) | Single ⋮ menu, primary first |
+
+Pool CTAs count toward the total.
+
+**`page.tsx` — shim corrections:**
+
+- Fix `hydrateFromLicense`: NONE-state plans were returning `actions: []` — pass `plan.state.actions` through
+- Fix `TRIAL_EXPIRED` shim: produce `[extend-trial (primary), end-trial (ghost)]` actions and trial-days pool
+
+---
+
+## Commit schedule (Session 1 — sdk-type-alignment)
 
 1. `feat(sdk-align): install artisan-roast-sdk file dep`
 2. `feat(sdk-align): delete plan-types.ts + fix all consumers for SDK types`
 3. `feat(sdk-align): add MOCK_HYDRATED_PLANS from SDK scaffolds`
 4. `bump version to X.Y.Z`
 
-## Commit schedule (Session 3)
+## Commit schedule (Session 2 — provider-driven-plan-cards)
 
 1. `feat(plan-cards): rewrite PlanPageClient to dispatch on plan.state.status`
 2. `feat(plan-cards): wire page.tsx to pass HydratedPlan[] with local hydration shim`

--- a/docs/features/provider-plan-sdk-alignment/plan.md
+++ b/docs/features/provider-plan-sdk-alignment/plan.md
@@ -13,7 +13,7 @@ Session 2 — Store: provider-driven-plan-cards (PlanPageClient rewrite)        
   ↓
 [SDK prereq]       usagepool-extension — ProgressBar→UsagePool, icon/countLabel  ← SDK work
   ↓
-Session 3 — Store: plan-card-corrections (pool rendering, CTA layout, shim)      ← blocked on SDK
+Session 4 — Store: plan-card-corrections (pool rendering, CTA layout, shim)      ← blocked on SDK
 ```
 
 **SDK prerequisite docs:** `artisan-roast-sdk/docs/provider-plan-spec/usagepool-extension/`
@@ -111,9 +111,9 @@ All 6 scenarios verified in `.screenshots/provider-plan-sdk-alignment-session3/`
 
 ---
 
-## Session 3 — Store: plan-card-corrections
+## Session 4 — Store: plan-card-corrections
 
-**Repo:** `ecomm-ai-app` | **Branch:** `feat/plan-card-corrections` | **ACs:** `session-3/ACs.md`
+**Repo:** `ecomm-ai-app` | **Branch:** `feat/plan-card-corrections` | **ACs:** `session-4/ACs.md`
 **Prerequisite:** SDK `feat/usagepool-extension` (v0.3.3) merged + dep bumped in store
 
 ### What to build

--- a/docs/features/provider-plan-sdk-alignment/session-4/ACs.md
+++ b/docs/features/provider-plan-sdk-alignment/session-4/ACs.md
@@ -1,0 +1,44 @@
+# Session 4 — plan-card-corrections: ACs
+
+**Branch:** `feat/plan-card-corrections`
+**Prerequisite:** SDK `feat/usagepool-extension` (v0.3.3) merged + dep bumped in store
+
+---
+
+## UI Acceptance Criteria
+
+| AC | What | How | Pass | Agent | QC | Reviewer |
+|----|------|-----|------|-------|----|----------|
+| AC-UI-1 | Pool icons render on PRIORITY_SUPPORT_ACTIVE | Screenshot: `PRIORITY_SUPPORT_ACTIVE` scenario | Icons visible before "Priority Tickets" and "1:1 Sessions" pool labels | | | |
+| AC-UI-2 | Pool count renders with unit label | Screenshot: `PRIORITY_SUPPORT_ACTIVE` scenario | Count displays as `{used} / {limit} {countLabel}` (e.g. "2 / 5 used") | | | |
+| AC-UI-3 | Trial pools render on TRIAL_ACTIVE_NO_CARD | Screenshot: `TRIAL_ACTIVE_NO_CARD` scenario | Trial-days pool visible with icon, label "Trial remaining", count (e.g. "5 / 14 days") | | | |
+| AC-UI-4 | Trial pools render on TRIAL_EXPIRED | Screenshot: `TRIAL_EXPIRED` scenario | Trial-days pool with filled bar; `statusInfo.descText` above bar | | | |
+| AC-UI-5 | TRIAL_EXPIRED: 2-CTA left/right layout | Screenshot: `TRIAL_EXPIRED` scenario | End Trial (ghost) left · Extend Trial (primary) right; no overflow menu | | | |
+| AC-UI-6 | TRIAL_ACTIVE_CARD_ADDED: cancel-trial visible | Screenshot: `TRIAL_ACTIVE_CARD_ADDED` scenario | Cancel action visible; no add-billing action | | | |
+| AC-UI-7 | CONVERTED billing action visible | Screenshot: `CONVERTED` scenario | At least one billing management action rendered | | | |
+| AC-UI-8 | Community description corrected | Screenshot: `SELF_HOSTED_FREE` scenario | "Self hosted with community support" visible | | | |
+| AC-UI-9 | SELF_HOSTED_FREE_WITH_ADDONS pool icons | Screenshot: `SELF_HOSTED_FREE_WITH_ADDONS` scenario | Icons visible on both pools | | | |
+
+---
+
+## Functional Acceptance Criteria
+
+| AC | What | How | Pass | Agent | QC | Reviewer |
+|----|------|-----|------|-------|----|----------|
+| AC-FN-1 | No `ProgressBar` renderer in PlanPageClient | Code review: `PlanPageClient.tsx` | No `ProgressBar` component or `progress:` binding — trial/expired pools use pool renderer | | | |
+| AC-FN-2 | CTA layout rule: 1 CTA inline | Code review: `PlanPageClient.tsx` | Single-action states render one inline `<Button>` with no menu | | | |
+| AC-FN-3 | CTA layout rule: 2 CTAs left/right | Code review: `PlanPageClient.tsx` | Two-action states render secondary/ghost left + primary right in a flex row | | | |
+| AC-FN-4 | CTA layout rule: 3+ CTAs in menu | Code review: `PlanPageClient.tsx` | Three-or-more-action states render all actions inside a `DropdownMenu` | | | |
+| AC-FN-5 | No slug checks in PlanPageClient | `grep -n "plan\.slug" PlanPageClient.tsx` | 0 results | | | |
+| AC-FN-6 | Shim NONE state passes actions through | Code review: `page.tsx` `hydrateFromLicense` | NONE-state plans return non-empty `state.actions` from scaffold data | | | |
+| AC-FN-7 | Shim TRIAL_EXPIRED produces correct shape | Code review: `page.tsx` `hydrateFromLicense` | Returns trial-days pool + `[extend-trial, end-trial]` actions | | | |
+
+---
+
+## Regression Acceptance Criteria
+
+| AC | What | How | Pass | Agent | QC | Reviewer |
+|----|------|-----|------|-------|----|----------|
+| AC-REG-1 | TypeScript clean | `npm run typecheck` | 0 errors | | | |
+| AC-REG-2 | Tests pass | `npm run test:ci` | All pass | | | |
+| AC-REG-3 | Precheck passes | `npm run precheck` | 0 errors | | | |

--- a/docs/features/provider-plan-sdk-alignment/session-4/ACs.md
+++ b/docs/features/provider-plan-sdk-alignment/session-4/ACs.md
@@ -25,11 +25,11 @@
 
 | AC | What | How | Pass | Agent | QC | Reviewer |
 |----|------|-----|------|-------|----|----------|
-| AC-FN-1 | No `ProgressBar` renderer in PlanPageClient | Code review: `PlanPageClient.tsx` | No `ProgressBar` component or `progress:` binding — trial/expired pools use pool renderer | | | |
-| AC-FN-2 | CTA layout rule: 1 CTA inline | Code review: `PlanPageClient.tsx` | Single-action states render one inline `<Button>` with no menu | | | |
-| AC-FN-3 | CTA layout rule: 2 CTAs left/right | Code review: `PlanPageClient.tsx` | Two-action states render secondary/ghost left + primary right in a flex row | | | |
-| AC-FN-4 | CTA layout rule: 3+ CTAs in menu | Code review: `PlanPageClient.tsx` | Three-or-more-action states render all actions inside a `DropdownMenu` | | | |
-| AC-FN-5 | No slug checks in PlanPageClient | `grep -n "plan\.slug" PlanPageClient.tsx` | 0 results | | | |
+| AC-FN-1 | No `ProgressBar` renderer in PlanPageClient | Code review: `app/admin/support/plans/PlanPageClient.tsx` | No `ProgressBar` component or `progress:` binding — trial/expired pools use pool renderer | | | |
+| AC-FN-2 | CTA layout rule: 1 CTA inline | Code review: `app/admin/support/plans/PlanPageClient.tsx` | Single-action states render one inline `<Button>` with no menu | | | |
+| AC-FN-3 | CTA layout rule: 2 CTAs left/right | Code review: `app/admin/support/plans/PlanPageClient.tsx` | Two-action states render secondary/ghost left + primary right in a flex row | | | |
+| AC-FN-4 | CTA layout rule: 3+ CTAs in menu | Code review: `app/admin/support/plans/PlanPageClient.tsx` | Three-or-more-action states render all actions inside a `DropdownMenu` | | | |
+| AC-FN-5 | No slug checks in PlanPageClient | `grep -n "plan\.slug" app/admin/support/plans/PlanPageClient.tsx` | 0 results | | | |
 | AC-FN-6 | Shim NONE state passes actions through | Code review: `page.tsx` `hydrateFromLicense` | NONE-state plans return non-empty `state.actions` from scaffold data | | | |
 | AC-FN-7 | Shim TRIAL_EXPIRED produces correct shape | Code review: `page.tsx` `hydrateFromLicense` | Returns trial-days pool + `[extend-trial, end-trial]` actions | | | |
 


### PR DESCRIPTION
## Summary

- Renumbers store sessions to count independently of SDK prerequisites (store sessions 1–3 shipped; session 4 = `feat/plan-card-corrections`, blocked on SDK v0.3.3)
- Adds `session-4/ACs.md` for `feat/plan-card-corrections` (pool icons, CTA layout, trial pools replacing ProgressBar renderer, shim fixes)

## What changed

- `docs/features/provider-plan-sdk-alignment/plan.md` — session table renumbered; SDK work noted as prerequisite blocks, not numbered sessions
- `docs/features/provider-plan-sdk-alignment/session-4/ACs.md` — new ACs doc for the plan-card-corrections session

## Type

docs-only release — no code changes, no version bump.

## Test plan

- [ ] Verify no source files changed: `git diff main --name-only | grep -v docs/`