### PR TITLE
fix(hooks): support worktree PRs in pre-pr fingerprint check (v0.106.1)

### DIFF
--- a/.claude/hooks/pre-pr-via-release-node.js
+++ b/.claude/hooks/pre-pr-via-release-node.js
@@ -24,7 +24,7 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const path = require("path");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { execSync } = require("child_process");
+const { execSync, execFileSync } = require("child_process");
 
 // Matches the canonical `/release` HEAD commit fingerprints. Normal releases
 // create a `bump version to X.Y.Z` commit; `/release --docs-only` creates a
@@ -98,13 +98,24 @@ function main(input) {
   // Worktree support: if `--head <branch>` is specified (worktree PR), check
   // that branch's latest commit instead. The project dir is always the main
   // checkout but the PR branch may live in a worktree with its own HEAD.
-  const headMatch = command.match(/--head\s+(\S+)/);
+  //
+  // Match `--head` only within the `gh pr create` invocation — find the index
+  // of `gh pr create` in the command and search for `--head` only after it, so
+  // an unrelated `--head` flag in an earlier compound command can't bypass the gate.
+  //
+  // Use execFileSync (not string interpolation) to avoid command injection from
+  // a crafted branch name containing shell metacharacters.
+  const prCreateIndex = command.search(/(?:^|[\n;&|(])\s*gh\s+pr\s+create\b/i);
+  const commandAfterCreate = prCreateIndex >= 0 ? command.slice(prCreateIndex) : "";
+  const headMatch = commandAfterCreate.match(/--head\s+(\S+)/);
   if (headMatch) {
+    const headRef = headMatch[1];
     try {
-      const headBranchSubject = exec(
-        `git log -1 --format=%s ${headMatch[1]}`,
-        projectDir
-      );
+      const headBranchSubject = execFileSync(
+        "git",
+        ["log", "-1", "--format=%s", headRef],
+        { cwd: projectDir, encoding: "utf8" }
+      ).trim();
       if (RELEASE_FINGERPRINT_RE.test(headBranchSubject)) {
         process.exit(0);
       }

--- a/.claude/hooks/pre-pr-via-release-node.js
+++ b/.claude/hooks/pre-pr-via-release-node.js
@@ -95,6 +95,24 @@ function main(input) {
     process.exit(0);
   }
 
+  // Worktree support: if `--head <branch>` is specified (worktree PR), check
+  // that branch's latest commit instead. The project dir is always the main
+  // checkout but the PR branch may live in a worktree with its own HEAD.
+  const headMatch = command.match(/--head\s+(\S+)/);
+  if (headMatch) {
+    try {
+      const headBranchSubject = exec(
+        `git log -1 --format=%s ${headMatch[1]}`,
+        projectDir
+      );
+      if (RELEASE_FINGERPRINT_RE.test(headBranchSubject)) {
+        process.exit(0);
+      }
+    } catch {
+      // Branch not reachable from projectDir — fall through to deny
+    }
+  }
+
   deny(
     "BLOCKED: `gh pr create` is gated to the `/release` flow.\n\n" +
       `The latest commit on this branch is:\n  ${lastSubject}\n\n` +

--- a/.claude/retro-log.md
+++ b/.claude/retro-log.md
@@ -4,6 +4,22 @@ Running log of process lessons learned and applied. Each entry documents a gap d
 
 ---
 
+## 2026-05-07 — PR opened autonomously inside /release without explicit user instruction
+
+**Gap:** During the `provider-plan-sdk-alignment` session (Sessions 2+3, branch `feat/sdk-type-alignment`), the `/release minor` skill ran Phase A through to completion — bump, push, and then automatically ran `gh pr create` without pausing for user approval. The user's expectation was that PR creation is a deliberate, user-gated moment, not an automatic step in a release flow.
+
+**Root cause:** The release skill (`SKILL.md`) listed Phase A Step 5 "Open the PR" as a sequential step following Step 4 "Push the branch" — no pause, no check-in. From the agent's perspective, it was following the skill protocol correctly. The skill simply had no stop gate before `gh pr create`.
+
+**Fix applied to:**
+
+- `.claude/skills/release/SKILL.md` — Step A.5 replaced with a hard STOP instruction: "report that the branch is pushed, wait for explicit user go-ahead before running `gh pr create`." The `--docs-only` path received the same change.
+- `memory/feedback_no_pr_without_instruction.md` (new) — Feedback memory capturing the rule: never run `gh pr create` autonomously; stop after push and wait.
+- `memory/MEMORY.md` — Pointer added to the new feedback file.
+
+**Prevented by:** Release skill now has an explicit stop gate at Step A.5. Memory file captures the rule for sessions where the release skill isn't the context — any standalone `gh pr create` call should also pause first.
+
+---
+
 ## 2026-04-29 — Ephemeral verification scripts placed in `scripts/` instead of `.scratch/`
 
 **Gap:** During the hosted-store-s2 trial UI verification session, two feature-specific Playwright scripts (`scripts/verify-trial-ui.ts`, `scripts/verify-hosting-screenshots.ts`) were written to `scripts/` instead of `.scratch/`. The `scripts/` directory is committed; `.scratch/` is gitignored. Placing QC tooling in `scripts/` would have committed ephemeral verification artifacts to the project repo. The scripts were caught while still untracked and moved before commit.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -107,7 +107,14 @@ Then commit the changes on that branch and follow the feature-branch path below.
    git push -u origin <branch-name>
    ```
 
-5. **Open the PR:**
+5. **STOP — wait for explicit instruction to open the PR.**
+
+   Report to the user:
+   > Branch pushed. Ready to open the PR — say the word when you want it created.
+
+   Do NOT run `gh pr create` until the user explicitly says so (e.g. "open the PR", "create the PR", "go ahead"). This applies even when the release skill is the one driving the workflow — PR creation is always a user-gated step.
+
+   When the user gives the go-ahead, run:
 
    ```bash
    gh pr create --title "<conventional-format-title> (vX.Y.Z)" --body-file <body-path> --base main
@@ -127,7 +134,7 @@ Then commit the changes on that branch and follow the feature-branch path below.
 
    This is an empty commit with no content changes. It exists only to satisfy the structural gate. Any docs commits on the branch must come *before* this marker — the marker has to be the latest commit when `gh pr create` runs.
 
-3. **Push** and **open the PR** as in the normal flow. No version bump, no CHANGELOG entry — the PR body should make clear it's a docs-only change.
+3. **Push** the branch. Then **STOP — wait for explicit user instruction** before running `gh pr create`. No version bump, no CHANGELOG entry — the PR body should make clear it's a docs-only change.
 
 ##### After PR is open
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.106.1 - 2026-05-07
+
+### Fixed
+
+- **Pre-PR hook — worktree support**: `pre-pr-via-release-node.js` now checks the `--head <branch>` latest commit when the flag is present, allowing docs-only PRs opened from git worktrees to pass the release fingerprint gate
+
+### Changed
+
+- **Screenshot script**: `scripts/screenshot-plan-scenarios.ts` expanded to cover all SDK plan scenarios with numbered filenames and `SCREENSHOT_DIR` env override
+
 ## 0.106.0 - 2026-05-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.106.0",
+  "version": "0.106.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.106.0",
+      "version": "0.106.1",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.106.0",
+  "version": "0.106.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/scripts/screenshot-plan-scenarios.ts
+++ b/scripts/screenshot-plan-scenarios.ts
@@ -18,16 +18,26 @@ const ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD ?? "ivcF8ZV3FnGaBJ&#8j";
 const OUT_DIR = path.join(
   process.cwd(),
   ".screenshots",
-  "provider-plan-sdk-alignment-session3"
+  process.env.SCREENSHOT_DIR ?? "plan-scenarios-all"
 );
 
+// All SDK scenarios — covers every plan/state combination
 const SCENARIOS = [
-  { key: "PRIORITY_SUPPORT_NONE", file: "ps-none.png" },
-  { key: "PRIORITY_SUPPORT_ACTIVE", file: "ps-active.png" },
-  { key: "PRIORITY_SUPPORT_INACTIVE", file: "ps-inactive.png" },
-  { key: "SELF_HOSTED_FREE_WITH_ADDONS", file: "community-addons.png" },
-  { key: "TRIAL_ACTIVE_NO_CARD", file: "trial-active-no-card.png" },
-  { key: "TRIAL_EXPIRED", file: "trial-expired.png" },
+  // Self-hosted community plans
+  { key: "SELF_HOSTED_FREE",             file: "01-community-none.png" },
+  { key: "SELF_HOSTED_FREE_WITH_ADDONS", file: "02-community-addons.png" },
+  // Priority Support states
+  { key: "PRIORITY_SUPPORT_NONE",        file: "03-ps-none.png" },
+  { key: "PRIORITY_SUPPORT_ACTIVE",      file: "04-ps-active.png" },
+  { key: "PRIORITY_SUPPORT_INACTIVE",    file: "05-ps-inactive.png" },
+  // Trial states
+  { key: "TRIAL_ACTIVE_NO_CARD",         file: "06-trial-active-no-card.png" },
+  { key: "TRIAL_ACTIVE_CARD_ADDED",      file: "07-trial-active-card-added.png" },
+  { key: "TRIAL_EXPIRED",               file: "08-trial-expired.png" },
+  // Post-trial / converted states
+  { key: "CONVERTED",                   file: "09-converted.png" },
+  { key: "DIRECT_SUBSCRIBE",            file: "10-direct-subscribe.png" },
+  { key: "INACTIVE",                    file: "11-inactive.png" },
 ];
 
 async function waitForServer(url: string, retries = 20): Promise<void> {

--- a/scripts/screenshot-plan-scenarios.ts
+++ b/scripts/screenshot-plan-scenarios.ts
@@ -11,6 +11,7 @@
 import puppeteer from "puppeteer";
 import * as fs from "fs";
 import * as path from "path";
+import { SCENARIOS as SDK_SCENARIOS } from "artisan-roast-sdk/plans/scaffolds";
 
 const BASE_URL = process.env.BASE_URL ?? "http://localhost:3000";
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL ?? "admin@artisanroast.com";
@@ -54,6 +55,16 @@ async function waitForServer(url: string, retries = 20): Promise<void> {
 }
 
 async function main() {
+  // Fail fast if any scenario key is not in the SDK — prevents silent
+  // wrong-image generation when a scenario is renamed or removed.
+  const unknownKeys = SCENARIOS.filter(({ key }) => !(key in SDK_SCENARIOS));
+  if (unknownKeys.length > 0) {
+    console.error(
+      `Unknown scenario keys (not in SDK SCENARIOS): ${unknownKeys.map((s) => s.key).join(", ")}`
+    );
+    process.exit(1);
+  }
+
   fs.mkdirSync(OUT_DIR, { recursive: true });
 
   await waitForServer(BASE_URL);


### PR DESCRIPTION
## Summary

- `pre-pr-via-release-node.js` now checks the `--head <branch>` latest commit when present, allowing docs-only PRs opened from git worktrees to pass the release fingerprint gate
- Screenshot script expanded to cover all SDK plan scenarios with numbered filenames and `SCREENSHOT_DIR` env override

## Why

The hook was anchored to `git log -1` in the main project dir (always the checked-out branch there), so worktree PRs where the fingerprint commit lives on the `--head` branch were incorrectly blocked.

## Test plan

- [ ] `pre-pr-via-release-node.js` — `--head` branch with `docs-only release` as latest commit passes the gate
- [ ] Normal release (no `--head` flag, current branch has fingerprint) still passes
- [ ] Non-fingerprint `--head` branch still blocked