### PR TITLE
feat(hosting): wire trial cancel endpoint (v0.106.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **Trial cancellation wiring**: `submitCancellation` no-card variant now calls the hosted platform cancel endpoint instead of logging; adds `docs/features/hosting-extension/trial-cancellation.md`
+- **Trial cancellation wiring**: `submitCancellation` no-card variant now calls the hosted platform cancel endpoint; guards for missing env vars, 10s timeout, try/catch consistent with card-added variant; adds `docs/features/hosting-extension/trial-cancellation.md`
 
 ## 0.106.1 - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **Trial cancellation wiring**: `submitCancellation` no-card variant now calls the hosted platform cancel endpoint; guards for missing env vars, 10s timeout, try/catch consistent with card-added variant; adds `docs/features/hosting-extension/trial-cancellation.md`
+- **Trial cancellation wiring**: `submitCancellation` no-card variant now calls the hosted platform cancel endpoint; guards for missing env vars, 10s timeout, try/catch, user-friendly error messages; adds cancellation tests and `docs/features/hosting-extension/trial-cancellation.md`
 
 ## 0.106.1 - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.106.2 - 2026-05-07
+
+### Changed
+
+- **Trial cancellation wiring**: `submitCancellation` no-card variant now calls the hosted platform cancel endpoint instead of logging; adds `docs/features/hosting-extension/trial-cancellation.md`
+
 ## 0.106.1 - 2026-05-07
 
 ### Fixed

--- a/app/admin/support/plans/__tests__/cancellation.test.ts
+++ b/app/admin/support/plans/__tests__/cancellation.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for submitCancellation server action — no-card variant.
+ *
+ * PLATFORM_API_URL is a module-level const (evaluated at require time).
+ * HOSTED_TRIAL_ID is read from process.env at call time.
+ * Each describe group loads the module via jest.isolateModules with the
+ * required env state, keeps that state for the duration of the group,
+ * and cleans up in afterAll.
+ */
+
+// ---------------------------------------------------------------------------
+// Shared mock setup (hoisted by Jest before any require calls)
+// ---------------------------------------------------------------------------
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/admin", () => ({
+  requireAdmin: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/lib/telemetry", () => ({
+  getInstanceId: jest.fn(),
+}));
+
+jest.mock("@prisma/client", () => {
+  const mockPrisma = { siteSettings: { findUnique: jest.fn() } };
+  return { PrismaClient: jest.fn(() => mockPrisma), __mockPrisma: mockPrisma };
+});
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: jest.requireMock("@prisma/client").__mockPrisma,
+}));
+
+// ---------------------------------------------------------------------------
+// Group 1: both env vars present
+// ---------------------------------------------------------------------------
+
+describe("submitCancellation — no-card variant (env configured)", () => {
+  let submitCancellation: (input: Record<string, unknown>) => Promise<{ success: boolean; error?: string }>;
+
+  beforeAll(() => {
+    process.env.PLATFORM_API_URL = "http://localhost:3001";
+    process.env.HOSTED_TRIAL_ID = "trial_abc123";
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = require("../actions") as typeof import("../actions");
+      submitCancellation = mod.submitCancellation as typeof submitCancellation;
+    });
+  });
+
+  afterAll(() => {
+    delete process.env.PLATFORM_API_URL;
+    delete process.env.HOSTED_TRIAL_ID;
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns success on 200 from platform", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const result = await submitCancellation({ variant: "no-card", reason: "too-expensive" });
+
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:3001/api/trial/hosted/trial_abc123/cancel",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("maps known error codes to user-friendly messages", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ error: "already_cancelled" }),
+    });
+
+    const result = await submitCancellation({ variant: "no-card", reason: "switching" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Your trial has already been cancelled.");
+  });
+
+  it("returns fallback message for unknown error codes", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ error: "unknown_code" }),
+    });
+
+    const result = await submitCancellation({ variant: "no-card", reason: "too-soon" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Something went wrong — please try again.");
+  });
+
+  it("returns error when platform is unreachable", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("fetch failed"));
+
+    const result = await submitCancellation({ variant: "no-card", reason: "missing-features" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Could not reach the hosting service");
+  });
+
+  it("returns validation error for invalid reason", async () => {
+    const result = await submitCancellation({ variant: "no-card", reason: "" });
+
+    expect(result.success).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 2: PLATFORM_API_URL missing
+// ---------------------------------------------------------------------------
+
+describe("submitCancellation — no-card variant (PLATFORM_API_URL missing)", () => {
+  let submitCancellation: (input: Record<string, unknown>) => Promise<{ success: boolean; error?: string }>;
+
+  beforeAll(() => {
+    delete process.env.PLATFORM_API_URL;
+    process.env.HOSTED_TRIAL_ID = "trial_abc123";
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = require("../actions") as typeof import("../actions");
+      submitCancellation = mod.submitCancellation as typeof submitCancellation;
+    });
+  });
+
+  afterAll(() => {
+    delete process.env.HOSTED_TRIAL_ID;
+  });
+
+  it("returns config error", async () => {
+    const result = await submitCancellation({ variant: "no-card", reason: "too-expensive" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Hosting service not configured");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 3: HOSTED_TRIAL_ID missing
+// ---------------------------------------------------------------------------
+
+describe("submitCancellation — no-card variant (HOSTED_TRIAL_ID missing)", () => {
+  let submitCancellation: (input: Record<string, unknown>) => Promise<{ success: boolean; error?: string }>;
+
+  beforeAll(() => {
+    process.env.PLATFORM_API_URL = "http://localhost:3001";
+    delete process.env.HOSTED_TRIAL_ID;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = require("../actions") as typeof import("../actions");
+      submitCancellation = mod.submitCancellation as typeof submitCancellation;
+    });
+  });
+
+  afterAll(() => {
+    delete process.env.PLATFORM_API_URL;
+  });
+
+  it("returns config error", async () => {
+    const result = await submitCancellation({ variant: "no-card", reason: "too-expensive" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Trial ID not configured");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/app/admin/support/plans/actions.ts
+++ b/app/admin/support/plans/actions.ts
@@ -111,10 +111,8 @@ interface CancelTrialResult {
  * Submit a trial cancellation with a captured reason.
  *
  * Variants:
- * - "no-card" — UI mock for v1; the upstream cancel endpoint is not yet
- *   shipped. Returns success without persisting. The wiring is identical
- *   to the card-added variant; only the upstream destination changes when
- *   the endpoint becomes available.
+ * - "no-card" — calls the hosted platform cancel endpoint. Sets trial
+ *   status to CANCELLED and queues deprovisioning (≤1hr cron cycle).
  * - "card-added" — calls the upstream billing portal endpoint and returns
  *   the Stripe Portal URL. The customer completes cancellation through
  *   Stripe Portal in a new tab.
@@ -130,26 +128,37 @@ export async function submitCancellation(
   }
 
   if (parsed.data.variant === "no-card") {
-    const trialId = process.env.HOSTED_TRIAL_ID;
-    const res = await fetch(
-      `${PLATFORM_API_URL}/api/trial/hosted/${trialId}/cancel`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          reason: parsed.data.reason,
-          otherText: parsed.data.otherText,
-        }),
-      }
-    );
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({}));
-      return {
-        success: false,
-        error: (data as { error?: string }).error ?? "cancel_failed",
-      };
+    if (!PLATFORM_API_URL) {
+      return { success: false, error: "Hosting service not configured" };
     }
-    return { success: true };
+    const trialId = process.env.HOSTED_TRIAL_ID;
+    if (!trialId) {
+      return { success: false, error: "Trial ID not configured" };
+    }
+    try {
+      const res = await fetch(
+        `${PLATFORM_API_URL}/api/trial/hosted/${trialId}/cancel`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            reason: parsed.data.reason,
+            otherText: parsed.data.otherText,
+          }),
+          signal: AbortSignal.timeout(10_000),
+        }
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        return {
+          success: false,
+          error: (data as { error?: string }).error ?? "cancel_failed",
+        };
+      }
+      return { success: true };
+    } catch {
+      return { success: false, error: "Could not reach the hosting service" };
+    }
   }
 
   // Card-added variant: fetch a Stripe Portal session URL.

--- a/app/admin/support/plans/actions.ts
+++ b/app/admin/support/plans/actions.ts
@@ -150,9 +150,16 @@ export async function submitCancellation(
       );
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
+        const code = (data as { error?: string }).error;
+        const userMessage: Record<string, string> = {
+          already_cancelled: "Your trial has already been cancelled.",
+          not_cancellable: "Your trial cannot be cancelled at this time.",
+          use_stripe_portal: "Please cancel through your billing portal.",
+          not_found: "Trial not found — please contact support.",
+        };
         return {
           success: false,
-          error: (data as { error?: string }).error ?? "cancel_failed",
+          error: userMessage[code ?? ""] ?? "Something went wrong — please try again.",
         };
       }
       return { success: true };

--- a/app/admin/support/plans/actions.ts
+++ b/app/admin/support/plans/actions.ts
@@ -129,13 +129,26 @@ export async function submitCancellation(
     return { success: false, error: "Invalid cancellation request" };
   }
 
-  // No-card variant: upstream cancel endpoint not yet shipped. Log the reason
-  // so feedback isn't silently lost — replace with upstream call when it lands.
   if (parsed.data.variant === "no-card") {
-    console.info("trial:cancel:no-card", {
-      reason: parsed.data.reason,
-      otherText: parsed.data.otherText,
-    });
+    const trialId = process.env.HOSTED_TRIAL_ID;
+    const res = await fetch(
+      `${PLATFORM_API_URL}/api/trial/hosted/${trialId}/cancel`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          reason: parsed.data.reason,
+          otherText: parsed.data.otherText,
+        }),
+      }
+    );
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      return {
+        success: false,
+        error: (data as { error?: string }).error ?? "cancel_failed",
+      };
+    }
     return { success: true };
   }
 

--- a/docs/features/hosting-extension/trial-cancellation.md
+++ b/docs/features/hosting-extension/trial-cancellation.md
@@ -1,0 +1,80 @@
+# Hosting Extension — Trial Cancellation · Implementation
+
+**Status:** Shipped — `submitCancellation` no-card variant live
+**Architecture reference:** [`ARCHITECTURE.md`](./ARCHITECTURE.md)
+
+---
+
+## What changed
+
+`submitCancellation()` in `app/admin/support/plans/actions.ts` previously had a `console.log` stub for the `no-card` variant — the platform endpoint hadn't shipped yet. That stub is now replaced with a live fetch.
+
+**Before:**
+
+```ts
+if (parsed.data.variant === "no-card") {
+  console.info("trial:cancel:no-card", { reason, otherText });
+  return { success: true };
+}
+```
+
+**After:**
+
+```ts
+if (parsed.data.variant === "no-card") {
+  const trialId = process.env.HOSTED_TRIAL_ID;
+  const res = await fetch(
+    `${PLATFORM_API_URL}/api/trial/hosted/${trialId}/cancel`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reason: parsed.data.reason, otherText: parsed.data.otherText }),
+    }
+  );
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    return { success: false, error: (data as { error?: string }).error ?? "cancel_failed" };
+  }
+  return { success: true };
+}
+```
+
+The `card-added` variant is unchanged — it still opens a Stripe Portal session via `/api/billing/portal`.
+
+---
+
+## Endpoint contract
+
+`POST ${PLATFORM_API_URL}/api/trial/hosted/${HOSTED_TRIAL_ID}/cancel`
+
+**Request body:**
+
+```json
+{ "reason": "too-soon" | "missing-features" | "too-expensive" | "switching" | "other", "otherText"?: string }
+```
+
+**Responses:**
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `200` | `{ "cancelled": true }` | Trial cancelled; deprovisioning queued (≤1hr cron) |
+| `400` | `{ "error": "invalid_body" }` | Bad or missing reason |
+| `404` | `{ "error": "not_found" }` | `HOSTED_TRIAL_ID` not found |
+| `409` | `{ "error": "already_cancelled" }` | Trial already cancelled |
+| `409` | `{ "error": "not_cancellable" }` | Trial is CONVERTED or DEPROVISIONED |
+| `409` | `{ "error": "use_stripe_portal" }` | Card on file — must cancel via Stripe Portal |
+
+---
+
+## Env vars
+
+Both vars are injected at provisioning time and already present in `PLATFORM_API_URL` and `HOSTED_TRIAL_ID`. No new env vars.
+
+---
+
+## Customer experience
+
+1. Customer opens the cancel modal, selects a reason, submits
+2. Platform sets `status = CANCELLED`, queues deprovisioning (≤1hr cron cycle)
+3. Customer receives a cancellation confirmation email from the platform
+4. Modal closes with the existing success toast

--- a/docs/features/hosting-extension/trial-cancellation.md
+++ b/docs/features/hosting-extension/trial-cancellation.md
@@ -53,7 +53,7 @@ The `card-added` variant is unchanged — it still opens a Stripe Portal session
 { "reason": "too-soon" | "missing-features" | "too-expensive" | "switching" | "other", "otherText"?: string }
 ```
 
-**Responses:**
+**Responses** (upstream endpoint — the store action wraps these into `CancelTrialResult { success, error? }`):
 
 | Status | Body | Meaning |
 |--------|------|---------|

--- a/docs/features/hosting-extension/trial-ui-plan.md
+++ b/docs/features/hosting-extension/trial-ui-plan.md
@@ -1,9 +1,6 @@
 # Hosting Extension — Trial UI · Plan
 
 **Branch:** `feat/hosted-store-s2`
-**Base:** `main`
-**Worktree:** `c:\Users\yuens\dev\hosted-store-s2`
-**ACs:** [`docs/plans/hosting-extension-trial-ui-ACs.md`](../../plans/hosting-extension-trial-ui-ACs.md)
 **Architecture reference:** [`ARCHITECTURE.md`](./ARCHITECTURE.md)
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.106.1",
+  "version": "0.106.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Wires `submitCancellation` no-card variant to the hosted platform cancel endpoint — replaces the `console.log` stub from the trial UI session
- Adds `PLATFORM_API_URL` + `HOSTED_TRIAL_ID` guards, `AbortSignal.timeout(10_000)`, and `try/catch` consistent with the card-added variant
- Adds `docs/features/hosting-extension/trial-cancellation.md` documenting the change and endpoint contract
- Cleans up stale metadata from `trial-ui-plan.md`

## Test plan

- [ ] Platform dev server running on `:3001` with an ACTIVE trial seeded as `HOSTED_TRIAL_ID`
- [ ] Submit cancel modal with a reason → store returns `{ success: true }`, trial flips to `CANCELLED` in platform DB
- [ ] Verify `PLATFORM_API_URL` missing → returns `{ success: false, error: "Hosting service not configured" }`
- [ ] Verify `HOSTED_TRIAL_ID` missing → returns `{ success: false, error: "Trial ID not configured" }`