### PR TITLE
chore(hooks): add cross-repo skip to PR create/merge gates

### DIFF
--- a/.claude/hooks/pre-pr-precheck-node.js
+++ b/.claude/hooks/pre-pr-precheck-node.js
@@ -36,6 +36,9 @@ function isFreshStamp(stampFile) {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { execSync } = require("child_process");
+
 function main(input) {
   let command = "";
   try {
@@ -49,6 +52,26 @@ function main(input) {
   // Anchored to start-of-string or after && / ; to avoid heredoc false positives
   if (!/(?:^|&&\s*|;\s*)gh\s+pr\s+create/i.test(command)) {
     allow();
+  }
+
+  // Cross-repo skip: precheck stamps are ecomm-specific. If `--repo owner/name`
+  // targets a different repo, the gate does not apply — each repo enforces its
+  // own quality gates via its own hooks. Fail open if we can't verify.
+  const repoFlagMatch = command.match(/--repo\s+([\w.-]+\/[\w.-]+)/);
+  if (repoFlagMatch) {
+    const targetRepo = repoFlagMatch[1].toLowerCase();
+    try {
+      const projectDir = path.resolve(__dirname, "..", "..");
+      const currentRepo = execSync(
+        "gh repo view --json nameWithOwner -q .nameWithOwner",
+        { cwd: projectDir, encoding: "utf8" }
+      ).trim().toLowerCase();
+      if (targetRepo !== currentRepo) {
+        allow(); // cross-repo PR — gate does not apply
+      }
+    } catch {
+      allow(); // can't verify current repo — allow
+    }
   }
 
   const precheckOk = isFreshStamp(PRECHECK_STAMP);

--- a/.claude/hooks/pre-pr-precheck-node.js
+++ b/.claude/hooks/pre-pr-precheck-node.js
@@ -57,7 +57,11 @@ function main(input) {
   // Cross-repo skip: precheck stamps are ecomm-specific. If `--repo owner/name`
   // targets a different repo, the gate does not apply — each repo enforces its
   // own quality gates via its own hooks. Fail open if we can't verify.
-  const repoFlagMatch = command.match(/--repo\s+([\w.-]+\/[\w.-]+)/);
+  // Scope to the gh pr create invocation to avoid false matches from --repo
+  // flags belonging to other commands in the same compound line.
+  const prCreateIdx = command.search(/(?:^|&&\s*|;\s*)gh\s+pr\s+create/i);
+  const commandAfterCreate = prCreateIdx >= 0 ? command.slice(prCreateIdx) : command;
+  const repoFlagMatch = commandAfterCreate.match(/--repo[\s=]+([\w.-]+\/[\w.-]+)/);
   if (repoFlagMatch) {
     const targetRepo = repoFlagMatch[1].toLowerCase();
     try {

--- a/.claude/hooks/pre-pr-via-release-node.js
+++ b/.claude/hooks/pre-pr-via-release-node.js
@@ -69,11 +69,17 @@ function main(input) {
 
   const projectDir = path.resolve(__dirname, "..", "..");
 
+  // Scope all flag parsing to the `gh pr create` invocation — a `--repo` or
+  // `--head` belonging to an earlier/other command in a compound line should
+  // not influence this gate.
+  const prCreateIdx = command.search(/(?:^|[\n;&|(])\s*gh\s+pr\s+create\b/i);
+  const commandAfterCreate = prCreateIdx >= 0 ? command.slice(prCreateIdx) : command;
+
   // Cross-repo skip: if `--repo owner/name` targets a different repo than the
   // ecomm primary project, the fingerprint gate doesn't apply here. Each repo
   // enforces its own release gate via its own hooks. Fail open — if we can't
   // determine the current repo, allow rather than block with a misleading message.
-  const repoFlagMatch = command.match(/--repo\s+([\w.-]+\/[\w.-]+)/);
+  const repoFlagMatch = commandAfterCreate.match(/--repo[\s=]+([\w.-]+\/[\w.-]+)/);
   if (repoFlagMatch) {
     const targetRepo = repoFlagMatch[1].toLowerCase();
     try {
@@ -118,15 +124,9 @@ function main(input) {
   // Worktree support: if `--head <branch>` is specified (worktree PR), check
   // that branch's latest commit instead. The project dir is always the main
   // checkout but the PR branch may live in a worktree with its own HEAD.
-  //
-  // Match `--head` only within the `gh pr create` invocation — find the index
-  // of `gh pr create` in the command and search for `--head` only after it, so
-  // an unrelated `--head` flag in an earlier compound command can't bypass the gate.
-  //
+  // commandAfterCreate is already scoped to the gh pr create invocation above.
   // Use execFileSync (not string interpolation) to avoid command injection from
   // a crafted branch name containing shell metacharacters.
-  const prCreateIndex = command.search(/(?:^|[\n;&|(])\s*gh\s+pr\s+create\b/i);
-  const commandAfterCreate = prCreateIndex >= 0 ? command.slice(prCreateIndex) : "";
   const headMatch = commandAfterCreate.match(/--head\s+(\S+)/);
   if (headMatch) {
     const headRef = headMatch[1];

--- a/.claude/hooks/pre-pr-via-release-node.js
+++ b/.claude/hooks/pre-pr-via-release-node.js
@@ -69,6 +69,26 @@ function main(input) {
 
   const projectDir = path.resolve(__dirname, "..", "..");
 
+  // Cross-repo skip: if `--repo owner/name` targets a different repo than the
+  // ecomm primary project, the fingerprint gate doesn't apply here. Each repo
+  // enforces its own release gate via its own hooks. Fail open — if we can't
+  // determine the current repo, allow rather than block with a misleading message.
+  const repoFlagMatch = command.match(/--repo\s+([\w.-]+\/[\w.-]+)/);
+  if (repoFlagMatch) {
+    const targetRepo = repoFlagMatch[1].toLowerCase();
+    try {
+      const currentRepo = exec(
+        "gh repo view --json nameWithOwner -q .nameWithOwner",
+        projectDir
+      ).toLowerCase();
+      if (targetRepo !== currentRepo) {
+        process.exit(0); // cross-repo PR — gate does not apply
+      }
+    } catch {
+      process.exit(0); // can't verify current repo — allow
+    }
+  }
+
   // Read the latest commit subject on the current HEAD. Fail closed if git
   // state can't be verified — letting PR creation proceed in exactly the
   // scenarios where enforcement is most needed (misconfigured repo,

--- a/.claude/hooks/review-before-merge-node.js
+++ b/.claude/hooks/review-before-merge-node.js
@@ -92,6 +92,27 @@ function main(input) {
   const projectDir = path.resolve(__dirname, "..", "..");
   const claudeDir = path.resolve(__dirname, "..");
 
+  // Cross-repo skip: review policy is repo-specific. If `--repo owner/name`
+  // targets a different repo than this ecomm checkout, the gate does not apply
+  // here — each repo enforces its own review gate via its own hooks.
+  // Fail open: if we can't determine the current repo, allow rather than
+  // blocking with a misleading message.
+  const repoFlagMatch = command.match(/--repo\s+([\w.-]+\/[\w.-]+)/);
+  if (repoFlagMatch) {
+    const targetRepo = repoFlagMatch[1].toLowerCase();
+    try {
+      const currentRepo = exec(
+        "gh repo view --json nameWithOwner -q .nameWithOwner",
+        projectDir
+      ).toLowerCase();
+      if (targetRepo !== currentRepo) {
+        process.exit(0); // cross-repo merge — gate does not apply
+      }
+    } catch {
+      process.exit(0); // can't verify current repo — allow
+    }
+  }
+
   // Extract PR number from command args, URL, or current branch
   let prNumber = "";
   const numMatch = command.match(/gh\s+pr\s+merge\s+(\d+)/);
@@ -113,18 +134,24 @@ function main(input) {
     process.exit(0);
   }
 
-  // Get repo name for API calls
+  // Get repo name for API calls.
+  // Prefer an explicit --repo owner/name in the command (cross-repo merges);
+  // fall back to the current project's remote when absent.
   let repo = "";
-  try {
-    repo = exec(
-      "gh repo view --json nameWithOwner -q .nameWithOwner",
-      projectDir
-    );
-  } catch {
-    deny(
-      `BLOCKED: Could not determine repository for PR #${prNumber}.\n` +
-        "Check your network connection and gh auth status, then retry.\n"
-    );
+  if (repoFlagMatch) {
+    repo = repoFlagMatch[1];
+  } else {
+    try {
+      repo = exec(
+        "gh repo view --json nameWithOwner -q .nameWithOwner",
+        projectDir
+      );
+    } catch {
+      deny(
+        `BLOCKED: Could not determine repository for PR #${prNumber}.\n` +
+          "Check your network connection and gh auth status, then retry.\n"
+      );
+    }
   }
 
   // ── Gate 1: Wait for Copilot review on code PRs ──────────────────────

--- a/.claude/hooks/review-before-merge-node.js
+++ b/.claude/hooks/review-before-merge-node.js
@@ -97,7 +97,11 @@ function main(input) {
   // here — each repo enforces its own review gate via its own hooks.
   // Fail open: if we can't determine the current repo, allow rather than
   // blocking with a misleading message.
-  const repoFlagMatch = command.match(/--repo\s+([\w.-]+\/[\w.-]+)/);
+  // Scope to the gh pr merge invocation to avoid false matches from --repo
+  // flags belonging to other commands in the same compound line.
+  const prMergeIdx = command.search(/(?:^|[\n;&|(])\s*gh\s+pr\s+merge\b/i);
+  const commandAfterMerge = prMergeIdx >= 0 ? command.slice(prMergeIdx) : command;
+  const repoFlagMatch = commandAfterMerge.match(/--repo[\s=]+([\w.-]+\/[\w.-]+)/);
   if (repoFlagMatch) {
     const targetRepo = repoFlagMatch[1].toLowerCase();
     try {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -134,7 +134,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "ECOMM_HOOKS=\"$(git -C \"$(dirname \"$(git -C \"$CLAUDE_PROJECT_DIR\" rev-parse --git-dir 2>/dev/null)\" 2>/dev/null)\" rev-parse --show-toplevel 2>/dev/null)\"; HOOK=\"$CLAUDE_PROJECT_DIR/.claude/hooks/review-before-merge-node.js\"; if [ -f \"$HOOK\" ]; then node \"$HOOK\"; else exit 0; fi",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/.claude/hooks/review-before-merge-node.js\"; if [ -f \"$HOOK\" ]; then node \"$HOOK\"; else exit 0; fi",
             "timeout": 30
           },
           {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -134,22 +134,22 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -f .claude/hooks/review-before-merge-node.js ]; then node .claude/hooks/review-before-merge-node.js; else exit 0; fi",
+            "command": "ECOMM_HOOKS=\"$(git -C \"$(dirname \"$(git -C \"$CLAUDE_PROJECT_DIR\" rev-parse --git-dir 2>/dev/null)\" 2>/dev/null)\" rev-parse --show-toplevel 2>/dev/null)\"; HOOK=\"$CLAUDE_PROJECT_DIR/.claude/hooks/review-before-merge-node.js\"; if [ -f \"$HOOK\" ]; then node \"$HOOK\"; else exit 0; fi",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "if [ -f .claude/hooks/pre-pr-precheck-node.js ]; then node .claude/hooks/pre-pr-precheck-node.js; else exit 0; fi",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-pr-precheck-node.js\"; if [ -f \"$HOOK\" ]; then node \"$HOOK\"; else exit 0; fi",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "if [ -f .claude/hooks/pre-pr-via-release-node.js ]; then node .claude/hooks/pre-pr-via-release-node.js; else exit 0; fi",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-pr-via-release-node.js\"; if [ -f \"$HOOK\" ]; then node \"$HOOK\"; else exit 0; fi",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "if [ -f .claude/hooks/pre-migrate-backup-node.js ]; then node .claude/hooks/pre-migrate-backup-node.js; else exit 0; fi",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-migrate-backup-node.js\"; if [ -f \"$HOOK\" ]; then node \"$HOOK\"; else exit 0; fi",
             "timeout": 10
           }
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Cross-repo hook fixes**: `pre-pr-via-release-node.js`, `pre-pr-precheck-node.js`, and `review-before-merge-node.js` now skip their gates when `gh pr create`/`gh pr merge` targets a different repository via `--repo owner/name` — each repo enforces its own gates via its own hooks; ecomm hooks no longer block platform PRs opened from the same Claude session
+
 ## 0.106.2 - 2026-05-07
 
 ### Changed


### PR DESCRIPTION
## Summary

- All three PR-gating hooks now exit 0 when `--repo owner/name` targets a different repository — each repo enforces its own gates via its own hooks
- Prevents ecomm hooks from blocking platform PRs opened from the same Claude session
- `review-before-merge-node.js` also gains `--repo` flag support for API calls (consistent with the platform version)

**Hooks updated:** `pre-pr-via-release-node.js` · `pre-pr-precheck-node.js` · `review-before-merge-node.js`

## Test plan

- [ ] `gh pr create --repo dev-yuen-agency/artisan-roast-platform ...` no longer blocked by ecomm release fingerprint gate
- [ ] `gh pr merge N --repo dev-yuen-agency/artisan-roast-platform` no longer blocked by ecomm Copilot review gate
- [ ] Same-repo `gh pr create` / `gh pr merge` still blocked as expected (no regression)