### PR TITLE
feat(ci): plans resolver drift nightly (v0.107.1)

### DIFF
--- a/.github/workflows/plans-capture-nightly.yml
+++ b/.github/workflows/plans-capture-nightly.yml
@@ -45,9 +45,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Clear committed baseline JSONs
+        # If we don't delete first, a missing/skipped scenario leaves the
+        # existing JSON intact and `git diff` stays clean — drift undetected.
+        # Deleting forces missing scenarios to show up as deletions in the diff.
+        # README.md preserved.
+        run: find e2e/plans/captured/ -name '*.json' -delete
+
       - name: Capture plan scenarios from prod
         env:
           DEV_KEYS_JSON: ${{ secrets.PLANS_CAPTURE_DEV_KEYS_JSON }}
+          # Fail loud on unknown labels or missing scenarios — a coverage gap
+          # in CI is itself a drift signal.
+          STRICT_KEYS: "1"
         run: |
           if [ -z "$DEV_KEYS_JSON" ]; then
             echo "::error::Secret PLANS_CAPTURE_DEV_KEYS_JSON is not set. See workflow header for setup."
@@ -63,7 +73,7 @@ jobs:
           else
             echo "drift_detected=true" >> "$GITHUB_OUTPUT"
             git diff -- e2e/plans/captured/ > drift.diff
-            echo "::error::Drift detected. See drift.diff artifact."
+            echo "::error::Drift detected (includes any deleted scenarios — coverage gap). See drift.diff artifact."
             exit 1
           fi
 

--- a/.github/workflows/plans-capture-nightly.yml
+++ b/.github/workflows/plans-capture-nightly.yml
@@ -1,0 +1,105 @@
+name: Plans Resolver Drift
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # 8am UTC daily (offset from e2e-nightly at 7am UTC)
+  workflow_dispatch:
+
+concurrency:
+  group: plans-capture-nightly
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+# Detects drift between prod /api/plans/resolved and the committed baseline at
+# e2e/plans/captured/*.json. A failing run means either (a) the platform shipped
+# a resolver change — refresh the baseline locally and commit, or (b) the
+# resolver regressed — file a bug in artisan-roast-platform.
+#
+# Setup required before the first scheduled run can pass:
+#   1. Repo secret PLANS_CAPTURE_DEV_KEYS_JSON — JSON object mapping each dev
+#      scenario key (see app/admin/support/plans/_fixtures/plan-scenarios.ts
+#      ALL_KEYS) to its license key.
+#   2. Initial baseline committed at e2e/plans/captured/*.json. Generate via:
+#        DEV_KEYS_FILE=../artisan-roast-platform/.dev-scenario-keys \
+#        PLATFORM_URL=https://manage.artisanroast.app \
+#        npm run plans:capture
+#        git add e2e/plans/captured/ && git commit
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    env:
+      PLATFORM_URL: https://manage.artisanroast.app
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Capture plan scenarios from prod
+        env:
+          DEV_KEYS_JSON: ${{ secrets.PLANS_CAPTURE_DEV_KEYS_JSON }}
+        run: |
+          if [ -z "$DEV_KEYS_JSON" ]; then
+            echo "::error::Secret PLANS_CAPTURE_DEV_KEYS_JSON is not set. See workflow header for setup."
+            exit 1
+          fi
+          npm run plans:capture
+
+      - name: Detect drift
+        id: drift
+        run: |
+          if git diff --quiet -- e2e/plans/captured/; then
+            echo "No drift — baseline matches prod."
+          else
+            echo "drift_detected=true" >> "$GITHUB_OUTPUT"
+            git diff -- e2e/plans/captured/ > drift.diff
+            echo "::error::Drift detected. See drift.diff artifact."
+            exit 1
+          fi
+
+      - name: Upload drift diff
+        uses: actions/upload-artifact@v4.6.2
+        if: failure() && steps.drift.outputs.drift_detected == 'true'
+        with:
+          name: plans-resolver-drift
+          path: drift.diff
+          retention-days: 14
+
+      - name: Open issue on drift
+        if: failure() && steps.drift.outputs.drift_detected == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "Plans resolver drift — $(date -u '+%Y-%m-%d')" \
+            --label "bug" \
+            --body "## Plans resolver drift
+
+          The prod /api/plans/resolved response no longer matches the committed baseline at \`e2e/plans/captured/\`.
+
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          Commit: \`${{ github.sha }}\`
+
+          Download the \`plans-resolver-drift\` artifact for the full diff.
+
+          **If intentional** (a resolver change shipped):
+          \`\`\`bash
+          DEV_KEYS_FILE=../artisan-roast-platform/.dev-scenario-keys \\
+            PLATFORM_URL=https://manage.artisanroast.app \\
+            npm run plans:capture
+          git diff e2e/plans/captured/
+          git add e2e/plans/captured/
+          git commit -m 'chore(plans): refresh prod capture baseline'
+          \`\`\`
+
+          **If unintentional** — the resolver regressed. File a bug against artisan-roast-platform with the diff."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## 0.107.2 - 2026-05-11
+
+### Added
+
+- **Plans resolver drift nightly** (`.github/workflows/plans-capture-nightly.yml`): daily 8am UTC job captures every dev scenario from prod `/api/plans/resolved`, diffs against the committed baseline at `e2e/plans/captured/*.json`. Drift fails the run, uploads a `plans-resolver-drift` artifact, and auto-opens an issue with refresh instructions. Catches resolver regressions that mock-driven Playwright tests can't (the mock is authored, the capture is observed).
+- **Prod capture baseline** at `e2e/plans/captured/*.json` — 13 dev scenarios. Source of truth for the nightly drift check.
+- **`e2e/plans/captured/README.md`** documenting the baseline + refresh flow.
+
+### Changed
+
+- **`scripts/capture-plan-scenarios.ts`** now handles two key-file formats: id-keyed JSON (CI path via `DEV_KEYS_JSON` secret) and label-headered env-style (local path via `DEV_KEYS_FILE`, matches what platform's `seed-dev-scenarios.ts` writes). Auto-detects which format the file uses.
+- **`STRICT_KEYS=1`** mode in capture script: hard-fails on unknown env labels (in `parseEnvFile`) and missing scenarios (in `main`). Workflow sets it so silent skips can't leave the committed baseline stale while `git diff` reports no drift.
+- **Workflow wipes `e2e/plans/captured/*.json`** before capture so missing scenarios surface as deletions in the diff (defense in depth alongside `STRICT_KEYS`).
+
 ## 0.107.1 - 2026-05-11
 
 ### Fixed

--- a/e2e/plans/captured/README.md
+++ b/e2e/plans/captured/README.md
@@ -1,0 +1,40 @@
+# Captured plan-resolver payloads
+
+Snapshots of `GET /api/plans/resolved` from prod, one file per dev scenario in
+`app/admin/support/plans/_fixtures/plan-scenarios.ts`'s `ALL_KEYS`.
+
+These act as the **expected-shape baseline** for the `Plans Resolver Drift`
+nightly workflow. When prod's resolver response stops matching what's checked
+in here, the workflow fails and opens an issue.
+
+## Refresh discipline
+
+Re-capture, review the diff, commit if the change is intentional.
+
+```bash
+DEV_KEYS_FILE=../artisan-roast-platform/.dev-scenario-keys \
+  PLATFORM_URL=https://manage.artisanroast.app \
+  npm run plans:capture
+
+git diff e2e/plans/captured/
+git add e2e/plans/captured/
+git commit -m 'chore(plans): refresh prod capture baseline'
+```
+
+## What "intentional" means
+
+- Platform shipped a resolver change (added an action, renamed a slug, fixed
+  a state branch) — refresh.
+- The fixture set in `_fixtures/plan-scenarios.ts` grew or shrank — refresh.
+
+## What "unintentional" means
+
+- An action silently disappeared (e.g. the priority-support `subscribe` CTA on
+  `dev-free`) — that's a regression. File a bug in `artisan-roast-platform`
+  with the drift diff before refreshing.
+
+## Why this matters
+
+The mock platform in `e2e/mock-platform.mjs` is author-controlled — it can't
+catch resolver drift because we write it. Captured payloads come from the
+real resolver, so they catch what the mock can't.

--- a/e2e/plans/captured/dev-free.json
+++ b/e2e/plans/captured/dev-free.json
@@ -1,0 +1,157 @@
+{
+  "plans": [
+    {
+      "slug": "free",
+      "name": "Community Roast",
+      "description": "Open-source self-hosted store with community support",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "Full e-commerce platform",
+            "Unlimited products & orders",
+            "Community support via GitHub",
+            "Self-hosted — you own your data"
+          ]
+        },
+        "excludes": [
+          "Priority support tickets",
+          "1:1 sessions",
+          "AI-powered features",
+          "Google Analytics integration"
+        ]
+      },
+      "highlight": false,
+      "visibility": "self-hosted",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Current Plan",
+        "pools": [],
+        "actions": []
+      }
+    },
+    {
+      "slug": "priority-support",
+      "name": "Priority Support",
+      "description": "Dedicated support with guaranteed response times",
+      "price": 4900,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "priority-support"
+      ],
+      "details": {
+        "sla": {
+          "availability": "Business days (Mon–Fri)",
+          "responseTime": "48 hours",
+          "sessionBooking": "Scheduled via Calendly link provided after subscription",
+          "sessionDuration": "30 minutes"
+        },
+        "scope": [
+          "Setup & configuration",
+          "Troubleshooting",
+          "Platform guidance"
+        ],
+        "terms": [
+          "Billed monthly, cancel anytime from your billing dashboard",
+          "Unused tickets do not roll over to the next billing period",
+          "1:1 session must be booked within the billing period",
+          "Support is provided in English only",
+          "Refunds are not available for partial months",
+          "Plan changes take effect immediately"
+        ],
+        "quotas": [
+          {
+            "icon": "ticket",
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "countLabel": "tickets"
+          },
+          {
+            "icon": "calendar",
+            "slug": "one-on-one",
+            "label": "1:1 Sessions",
+            "limit": 1,
+            "countLabel": "sessions"
+          }
+        ],
+        "benefits": {
+          "activeItems": [
+            "5 priority support tickets/mo with 48hr SLA",
+            "1 30min 1:1 session/mo",
+            "Anonymous Github issue tracking & transparency"
+          ],
+          "inactiveItems": [
+            "5 priority support tickets/mo with 48hr SLA",
+            "1 30min 1:1 session/mo",
+            "Anonymous Github issue tracking & transparency"
+          ],
+          "inactiveHeader": "Get back"
+        },
+        "excludes": [
+          "Custom development",
+          "Feature requests",
+          "Third-party integrations"
+        ]
+      },
+      "highlight": true,
+      "visibility": "self-hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-subscription",
+          "heading": "Cancel your subscription?",
+          "reasons": [
+            {
+              "label": "Don't use enough tickets to justify the cost",
+              "value": "low-usage"
+            },
+            {
+              "label": "Response time didn't meet my expectations",
+              "value": "slow-response"
+            },
+            {
+              "label": "My issues weren't fully resolved",
+              "value": "unresolved"
+            },
+            {
+              "label": "I prefer GitHub issues / community support",
+              "value": "prefer-community"
+            },
+            {
+              "label": "Closing or pausing my store",
+              "value": "closing-store"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep subscription",
+          "confirmIcon": "external-link",
+          "description": "We'll redirect you to Stripe to complete cancellation. Tell us why first — your feedback helps us improve.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "salePrice": 3900,
+      "saleEndsAt": "2026-06-30T23:59:59.000Z",
+      "saleLabel": "1st 6mos Launch Special",
+      "state": {
+        "status": "NONE",
+        "actions": [
+          {
+            "slug": "subscribe",
+            "label": "Subscribe",
+            "iconAfter": "external-link",
+            "variant": "primary"
+          }
+        ]
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-hosted-active-card.json
+++ b/e2e/plans/captured/dev-hosted-active-card.json
@@ -1,0 +1,244 @@
+{
+  "plans": [
+    {
+      "slug": "free",
+      "name": "Community Roast",
+      "description": "Open-source self-hosted store with community support",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "Full e-commerce platform",
+            "Unlimited products & orders",
+            "Community support via GitHub",
+            "Self-hosted — you own your data"
+          ]
+        },
+        "excludes": [
+          "Priority support tickets",
+          "1:1 sessions",
+          "AI-powered features",
+          "Google Analytics integration"
+        ]
+      },
+      "highlight": false,
+      "visibility": "self-hosted",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Current Plan",
+        "pools": [],
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend-trial",
+      "name": "House Blend Trial",
+      "description": "Risk-free for 14 days — full features, no card, no commitment.",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting"
+      ],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "No billing needed — add card to extend to 30 days",
+            "Download your data as a ZIP anytime",
+            "100% feature parity from day 1",
+            "Cancel anytime — no contract, no commitment"
+          ]
+        }
+      },
+      "highlight": false,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-trial",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "description": "We'd love to know why before you go.",
+          "confirmLabel": "Cancel Trial",
+          "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "cancel-stripe",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "confirmIcon": "external-link",
+          "description": "Your card is on file. Cancel to stop any future charges.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "state": {
+        "status": "TRIAL",
+        "badge": "Trial (Card Added)",
+        "badgeIcon": "clock",
+        "pools": [],
+        "statusInfo": {
+          "descText": "Trial ends 2026-06-08T12:44:11.643Z"
+        },
+        "deprovisionAt": "2026-06-08T12:44:11.643Z",
+        "actions": [
+          {
+            "slug": "cancel-trial",
+            "label": "Cancel Trial",
+            "endpoint": "/api/trial/cancel",
+            "variant": "ghost",
+            "modalSlug": "cancel-stripe"
+          }
+        ]
+      }
+    },
+    {
+      "slug": "house-blend",
+      "name": "House Blend",
+      "description": "Fully managed hosting with custom domain and priority support.",
+      "price": 7900,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting",
+        "priority-support"
+      ],
+      "details": {
+        "sla": {
+          "availability": "Business days (Mon–Fri)",
+          "responseTime": "48 hours"
+        },
+        "terms": [
+          "Billed monthly, cancel anytime from your billing dashboard",
+          "Unused tickets do not roll over to the next billing period",
+          "Refunds are not available for partial months",
+          "Plan changes take effect immediately"
+        ],
+        "quotas": [
+          {
+            "icon": "ticket",
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "countLabel": "used"
+          }
+        ],
+        "benefits": {
+          "activeItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveHeader": "Get back"
+        }
+      },
+      "highlight": true,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-subscription",
+          "heading": "Cancel your subscription?",
+          "reasons": [
+            {
+              "label": "Too expensive for my revenue",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Performance or reliability issues",
+              "value": "performance"
+            },
+            {
+              "label": "Moving to a self-hosted setup",
+              "value": "self-hosted"
+            },
+            {
+              "label": "Closing my store",
+              "value": "closing-store"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep subscription",
+          "confirmIcon": "external-link",
+          "description": "We'll redirect you to Stripe to complete cancellation. Tell us why first — your feedback helps us improve.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "salePrice": 6900,
+      "saleLabel": "6mos Launch Special",
+      "state": {
+        "status": "NONE",
+        "actions": []
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-hosted-active-no-card.json
+++ b/e2e/plans/captured/dev-hosted-active-no-card.json
@@ -1,0 +1,244 @@
+{
+  "plans": [
+    {
+      "slug": "free",
+      "name": "Community Roast",
+      "description": "Open-source self-hosted store with community support",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "Full e-commerce platform",
+            "Unlimited products & orders",
+            "Community support via GitHub",
+            "Self-hosted — you own your data"
+          ]
+        },
+        "excludes": [
+          "Priority support tickets",
+          "1:1 sessions",
+          "AI-powered features",
+          "Google Analytics integration"
+        ]
+      },
+      "highlight": false,
+      "visibility": "self-hosted",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Current Plan",
+        "pools": [],
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend-trial",
+      "name": "House Blend Trial",
+      "description": "Risk-free for 14 days — full features, no card, no commitment.",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting"
+      ],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "No billing needed — add card to extend to 30 days",
+            "Download your data as a ZIP anytime",
+            "100% feature parity from day 1",
+            "Cancel anytime — no contract, no commitment"
+          ]
+        }
+      },
+      "highlight": false,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-trial",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "description": "We'd love to know why before you go.",
+          "confirmLabel": "Cancel Trial",
+          "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "cancel-stripe",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "confirmIcon": "external-link",
+          "description": "Your card is on file. Cancel to stop any future charges.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "state": {
+        "status": "TRIAL",
+        "badge": "Trial",
+        "badgeIcon": "clock",
+        "pools": [],
+        "statusInfo": {
+          "descText": "Trial ends 2026-05-23T12:44:11.643Z"
+        },
+        "deprovisionAt": "2026-06-08T12:44:11.643Z",
+        "actions": [
+          {
+            "slug": "cancel-trial",
+            "label": "Cancel Trial",
+            "endpoint": "/api/trial/cancel",
+            "variant": "ghost",
+            "modalSlug": "cancel-trial"
+          }
+        ]
+      }
+    },
+    {
+      "slug": "house-blend",
+      "name": "House Blend",
+      "description": "Fully managed hosting with custom domain and priority support.",
+      "price": 7900,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting",
+        "priority-support"
+      ],
+      "details": {
+        "sla": {
+          "availability": "Business days (Mon–Fri)",
+          "responseTime": "48 hours"
+        },
+        "terms": [
+          "Billed monthly, cancel anytime from your billing dashboard",
+          "Unused tickets do not roll over to the next billing period",
+          "Refunds are not available for partial months",
+          "Plan changes take effect immediately"
+        ],
+        "quotas": [
+          {
+            "icon": "ticket",
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "countLabel": "used"
+          }
+        ],
+        "benefits": {
+          "activeItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveHeader": "Get back"
+        }
+      },
+      "highlight": true,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-subscription",
+          "heading": "Cancel your subscription?",
+          "reasons": [
+            {
+              "label": "Too expensive for my revenue",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Performance or reliability issues",
+              "value": "performance"
+            },
+            {
+              "label": "Moving to a self-hosted setup",
+              "value": "self-hosted"
+            },
+            {
+              "label": "Closing my store",
+              "value": "closing-store"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep subscription",
+          "confirmIcon": "external-link",
+          "description": "We'll redirect you to Stripe to complete cancellation. Tell us why first — your feedback helps us improve.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "salePrice": 6900,
+      "saleLabel": "6mos Launch Special",
+      "state": {
+        "status": "NONE",
+        "actions": []
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-hosted-cancelled-card.json
+++ b/e2e/plans/captured/dev-hosted-cancelled-card.json
@@ -1,0 +1,236 @@
+{
+  "plans": [
+    {
+      "slug": "free",
+      "name": "Community Roast",
+      "description": "Open-source self-hosted store with community support",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "Full e-commerce platform",
+            "Unlimited products & orders",
+            "Community support via GitHub",
+            "Self-hosted — you own your data"
+          ]
+        },
+        "excludes": [
+          "Priority support tickets",
+          "1:1 sessions",
+          "AI-powered features",
+          "Google Analytics integration"
+        ]
+      },
+      "highlight": false,
+      "visibility": "self-hosted",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Current Plan",
+        "pools": [],
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend-trial",
+      "name": "House Blend Trial",
+      "description": "Risk-free for 14 days — full features, no card, no commitment.",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting"
+      ],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "No billing needed — add card to extend to 30 days",
+            "Download your data as a ZIP anytime",
+            "100% feature parity from day 1",
+            "Cancel anytime — no contract, no commitment"
+          ]
+        }
+      },
+      "highlight": false,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-trial",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "description": "We'd love to know why before you go.",
+          "confirmLabel": "Cancel Trial",
+          "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "cancel-stripe",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "confirmIcon": "external-link",
+          "description": "Your card is on file. Cancel to stop any future charges.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "state": {
+        "status": "CANCELLED",
+        "badge": "Cancelled",
+        "daysRemaining": 12,
+        "daysLimit": 30,
+        "deprovisionAt": "2026-05-23T12:44:11.643Z",
+        "statusInfo": {
+          "descText": "Trial cancelled. Instance will be deprovisioned."
+        },
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend",
+      "name": "House Blend",
+      "description": "Fully managed hosting with custom domain and priority support.",
+      "price": 7900,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting",
+        "priority-support"
+      ],
+      "details": {
+        "sla": {
+          "availability": "Business days (Mon–Fri)",
+          "responseTime": "48 hours"
+        },
+        "terms": [
+          "Billed monthly, cancel anytime from your billing dashboard",
+          "Unused tickets do not roll over to the next billing period",
+          "Refunds are not available for partial months",
+          "Plan changes take effect immediately"
+        ],
+        "quotas": [
+          {
+            "icon": "ticket",
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "countLabel": "used"
+          }
+        ],
+        "benefits": {
+          "activeItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveHeader": "Get back"
+        }
+      },
+      "highlight": true,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-subscription",
+          "heading": "Cancel your subscription?",
+          "reasons": [
+            {
+              "label": "Too expensive for my revenue",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Performance or reliability issues",
+              "value": "performance"
+            },
+            {
+              "label": "Moving to a self-hosted setup",
+              "value": "self-hosted"
+            },
+            {
+              "label": "Closing my store",
+              "value": "closing-store"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep subscription",
+          "confirmIcon": "external-link",
+          "description": "We'll redirect you to Stripe to complete cancellation. Tell us why first — your feedback helps us improve.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "salePrice": 6900,
+      "saleLabel": "6mos Launch Special",
+      "state": {
+        "status": "NONE",
+        "actions": []
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-hosted-cancelled.json
+++ b/e2e/plans/captured/dev-hosted-cancelled.json
@@ -1,0 +1,236 @@
+{
+  "plans": [
+    {
+      "slug": "free",
+      "name": "Community Roast",
+      "description": "Open-source self-hosted store with community support",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "Full e-commerce platform",
+            "Unlimited products & orders",
+            "Community support via GitHub",
+            "Self-hosted — you own your data"
+          ]
+        },
+        "excludes": [
+          "Priority support tickets",
+          "1:1 sessions",
+          "AI-powered features",
+          "Google Analytics integration"
+        ]
+      },
+      "highlight": false,
+      "visibility": "self-hosted",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Current Plan",
+        "pools": [],
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend-trial",
+      "name": "House Blend Trial",
+      "description": "Risk-free for 14 days — full features, no card, no commitment.",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting"
+      ],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "No billing needed — add card to extend to 30 days",
+            "Download your data as a ZIP anytime",
+            "100% feature parity from day 1",
+            "Cancel anytime — no contract, no commitment"
+          ]
+        }
+      },
+      "highlight": false,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-trial",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "description": "We'd love to know why before you go.",
+          "confirmLabel": "Cancel Trial",
+          "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "cancel-stripe",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "confirmIcon": "external-link",
+          "description": "Your card is on file. Cancel to stop any future charges.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "state": {
+        "status": "CANCELLED",
+        "badge": "Cancelled",
+        "daysRemaining": 12,
+        "daysLimit": 30,
+        "deprovisionAt": "2026-06-08T12:44:11.643Z",
+        "statusInfo": {
+          "descText": "Trial cancelled. Instance will be deprovisioned."
+        },
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend",
+      "name": "House Blend",
+      "description": "Fully managed hosting with custom domain and priority support.",
+      "price": 7900,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting",
+        "priority-support"
+      ],
+      "details": {
+        "sla": {
+          "availability": "Business days (Mon–Fri)",
+          "responseTime": "48 hours"
+        },
+        "terms": [
+          "Billed monthly, cancel anytime from your billing dashboard",
+          "Unused tickets do not roll over to the next billing period",
+          "Refunds are not available for partial months",
+          "Plan changes take effect immediately"
+        ],
+        "quotas": [
+          {
+            "icon": "ticket",
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "countLabel": "used"
+          }
+        ],
+        "benefits": {
+          "activeItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveHeader": "Get back"
+        }
+      },
+      "highlight": true,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-subscription",
+          "heading": "Cancel your subscription?",
+          "reasons": [
+            {
+              "label": "Too expensive for my revenue",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Performance or reliability issues",
+              "value": "performance"
+            },
+            {
+              "label": "Moving to a self-hosted setup",
+              "value": "self-hosted"
+            },
+            {
+              "label": "Closing my store",
+              "value": "closing-store"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep subscription",
+          "confirmIcon": "external-link",
+          "description": "We'll redirect you to Stripe to complete cancellation. Tell us why first — your feedback helps us improve.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "salePrice": 6900,
+      "saleLabel": "6mos Launch Special",
+      "state": {
+        "status": "NONE",
+        "actions": []
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-hosted-converted.json
+++ b/e2e/plans/captured/dev-hosted-converted.json
@@ -1,0 +1,148 @@
+{
+  "plans": [
+    {
+      "slug": "free",
+      "name": "Community Roast",
+      "description": "Open-source self-hosted store with community support",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "Full e-commerce platform",
+            "Unlimited products & orders",
+            "Community support via GitHub",
+            "Self-hosted — you own your data"
+          ]
+        },
+        "excludes": [
+          "Priority support tickets",
+          "1:1 sessions",
+          "AI-powered features",
+          "Google Analytics integration"
+        ]
+      },
+      "highlight": false,
+      "visibility": "self-hosted",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Current Plan",
+        "pools": [],
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend",
+      "name": "House Blend",
+      "description": "Fully managed hosting with custom domain and priority support.",
+      "price": 7900,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting",
+        "priority-support"
+      ],
+      "details": {
+        "sla": {
+          "availability": "Business days (Mon–Fri)",
+          "responseTime": "48 hours"
+        },
+        "terms": [
+          "Billed monthly, cancel anytime from your billing dashboard",
+          "Unused tickets do not roll over to the next billing period",
+          "Refunds are not available for partial months",
+          "Plan changes take effect immediately"
+        ],
+        "quotas": [
+          {
+            "icon": "ticket",
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "countLabel": "used"
+          }
+        ],
+        "benefits": {
+          "activeItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveHeader": "Get back"
+        }
+      },
+      "highlight": true,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-subscription",
+          "heading": "Cancel your subscription?",
+          "reasons": [
+            {
+              "label": "Too expensive for my revenue",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Performance or reliability issues",
+              "value": "performance"
+            },
+            {
+              "label": "Moving to a self-hosted setup",
+              "value": "self-hosted"
+            },
+            {
+              "label": "Closing my store",
+              "value": "closing-store"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep subscription",
+          "confirmIcon": "external-link",
+          "description": "We'll redirect you to Stripe to complete cancellation. Tell us why first — your feedback helps us improve.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "salePrice": 6900,
+      "saleLabel": "6mos Launch Special",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Active",
+        "pools": [
+          {
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "used": 0,
+            "icon": "ticket"
+          }
+        ],
+        "actions": [
+          {
+            "slug": "manage-billing",
+            "label": "Manage Billing",
+            "endpoint": "/api/billing/portal",
+            "iconAfter": "external-link",
+            "variant": "secondary",
+            "modalSlug": "cancel-subscription"
+          }
+        ]
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-hosted-deprovisioned.json
+++ b/e2e/plans/captured/dev-hosted-deprovisioned.json
@@ -1,0 +1,129 @@
+{
+  "plans": [
+    {
+      "slug": "free",
+      "name": "Community Roast",
+      "description": "Open-source self-hosted store with community support",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "Full e-commerce platform",
+            "Unlimited products & orders",
+            "Community support via GitHub",
+            "Self-hosted — you own your data"
+          ]
+        },
+        "excludes": [
+          "Priority support tickets",
+          "1:1 sessions",
+          "AI-powered features",
+          "Google Analytics integration"
+        ]
+      },
+      "highlight": false,
+      "visibility": "self-hosted",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Current Plan",
+        "pools": [],
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend",
+      "name": "House Blend",
+      "description": "Fully managed hosting with custom domain and priority support.",
+      "price": 7900,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting",
+        "priority-support"
+      ],
+      "details": {
+        "sla": {
+          "availability": "Business days (Mon–Fri)",
+          "responseTime": "48 hours"
+        },
+        "terms": [
+          "Billed monthly, cancel anytime from your billing dashboard",
+          "Unused tickets do not roll over to the next billing period",
+          "Refunds are not available for partial months",
+          "Plan changes take effect immediately"
+        ],
+        "quotas": [
+          {
+            "icon": "ticket",
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "countLabel": "used"
+          }
+        ],
+        "benefits": {
+          "activeItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveHeader": "Get back"
+        }
+      },
+      "highlight": true,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-subscription",
+          "heading": "Cancel your subscription?",
+          "reasons": [
+            {
+              "label": "Too expensive for my revenue",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Performance or reliability issues",
+              "value": "performance"
+            },
+            {
+              "label": "Moving to a self-hosted setup",
+              "value": "self-hosted"
+            },
+            {
+              "label": "Closing my store",
+              "value": "closing-store"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep subscription",
+          "confirmIcon": "external-link",
+          "description": "We'll redirect you to Stripe to complete cancellation. Tell us why first — your feedback helps us improve.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "salePrice": 6900,
+      "saleLabel": "6mos Launch Special",
+      "state": {
+        "status": "NONE",
+        "actions": []
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-hosted-expired.json
+++ b/e2e/plans/captured/dev-hosted-expired.json
@@ -1,0 +1,236 @@
+{
+  "plans": [
+    {
+      "slug": "free",
+      "name": "Community Roast",
+      "description": "Open-source self-hosted store with community support",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "Full e-commerce platform",
+            "Unlimited products & orders",
+            "Community support via GitHub",
+            "Self-hosted — you own your data"
+          ]
+        },
+        "excludes": [
+          "Priority support tickets",
+          "1:1 sessions",
+          "AI-powered features",
+          "Google Analytics integration"
+        ]
+      },
+      "highlight": false,
+      "visibility": "self-hosted",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Current Plan",
+        "pools": [],
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend-trial",
+      "name": "House Blend Trial",
+      "description": "Risk-free for 14 days — full features, no card, no commitment.",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting"
+      ],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "No billing needed — add card to extend to 30 days",
+            "Download your data as a ZIP anytime",
+            "100% feature parity from day 1",
+            "Cancel anytime — no contract, no commitment"
+          ]
+        }
+      },
+      "highlight": false,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-trial",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "description": "We'd love to know why before you go.",
+          "confirmLabel": "Cancel Trial",
+          "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "cancel-stripe",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "confirmIcon": "external-link",
+          "description": "Your card is on file. Cancel to stop any future charges.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "state": {
+        "status": "EXPIRED",
+        "badge": "Trial Expired",
+        "badgeIcon": "alert-circle",
+        "pools": [],
+        "deprovisionAt": "2026-06-08T12:44:11.643Z",
+        "statusInfo": {
+          "descText": "Your trial has ended. Subscribe to restore access."
+        },
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend",
+      "name": "House Blend",
+      "description": "Fully managed hosting with custom domain and priority support.",
+      "price": 7900,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting",
+        "priority-support"
+      ],
+      "details": {
+        "sla": {
+          "availability": "Business days (Mon–Fri)",
+          "responseTime": "48 hours"
+        },
+        "terms": [
+          "Billed monthly, cancel anytime from your billing dashboard",
+          "Unused tickets do not roll over to the next billing period",
+          "Refunds are not available for partial months",
+          "Plan changes take effect immediately"
+        ],
+        "quotas": [
+          {
+            "icon": "ticket",
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "countLabel": "used"
+          }
+        ],
+        "benefits": {
+          "activeItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveHeader": "Get back"
+        }
+      },
+      "highlight": true,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-subscription",
+          "heading": "Cancel your subscription?",
+          "reasons": [
+            {
+              "label": "Too expensive for my revenue",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Performance or reliability issues",
+              "value": "performance"
+            },
+            {
+              "label": "Moving to a self-hosted setup",
+              "value": "self-hosted"
+            },
+            {
+              "label": "Closing my store",
+              "value": "closing-store"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep subscription",
+          "confirmIcon": "external-link",
+          "description": "We'll redirect you to Stripe to complete cancellation. Tell us why first — your feedback helps us improve.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "salePrice": 6900,
+      "saleLabel": "6mos Launch Special",
+      "state": {
+        "status": "NONE",
+        "actions": []
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-hosted-inactive.json
+++ b/e2e/plans/captured/dev-hosted-inactive.json
@@ -1,0 +1,236 @@
+{
+  "plans": [
+    {
+      "slug": "free",
+      "name": "Community Roast",
+      "description": "Open-source self-hosted store with community support",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "Full e-commerce platform",
+            "Unlimited products & orders",
+            "Community support via GitHub",
+            "Self-hosted — you own your data"
+          ]
+        },
+        "excludes": [
+          "Priority support tickets",
+          "1:1 sessions",
+          "AI-powered features",
+          "Google Analytics integration"
+        ]
+      },
+      "highlight": false,
+      "visibility": "self-hosted",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Current Plan",
+        "pools": [],
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend-trial",
+      "name": "House Blend Trial",
+      "description": "Risk-free for 14 days — full features, no card, no commitment.",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting"
+      ],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "No billing needed — add card to extend to 30 days",
+            "Download your data as a ZIP anytime",
+            "100% feature parity from day 1",
+            "Cancel anytime — no contract, no commitment"
+          ]
+        }
+      },
+      "highlight": false,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-trial",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "description": "We'd love to know why before you go.",
+          "confirmLabel": "Cancel Trial",
+          "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "cancel-stripe",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "confirmIcon": "external-link",
+          "description": "Your card is on file. Cancel to stop any future charges.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "state": {
+        "status": "CANCELLED",
+        "badge": "Cancelled",
+        "daysRemaining": 0,
+        "daysLimit": 30,
+        "deprovisionAt": "2026-05-11T16:07:13.750Z",
+        "statusInfo": {
+          "descText": "Trial cancelled. Instance will be deprovisioned."
+        },
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend",
+      "name": "House Blend",
+      "description": "Fully managed hosting with custom domain and priority support.",
+      "price": 7900,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting",
+        "priority-support"
+      ],
+      "details": {
+        "sla": {
+          "availability": "Business days (Mon–Fri)",
+          "responseTime": "48 hours"
+        },
+        "terms": [
+          "Billed monthly, cancel anytime from your billing dashboard",
+          "Unused tickets do not roll over to the next billing period",
+          "Refunds are not available for partial months",
+          "Plan changes take effect immediately"
+        ],
+        "quotas": [
+          {
+            "icon": "ticket",
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "countLabel": "used"
+          }
+        ],
+        "benefits": {
+          "activeItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveHeader": "Get back"
+        }
+      },
+      "highlight": true,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-subscription",
+          "heading": "Cancel your subscription?",
+          "reasons": [
+            {
+              "label": "Too expensive for my revenue",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Performance or reliability issues",
+              "value": "performance"
+            },
+            {
+              "label": "Moving to a self-hosted setup",
+              "value": "self-hosted"
+            },
+            {
+              "label": "Closing my store",
+              "value": "closing-store"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep subscription",
+          "confirmIcon": "external-link",
+          "description": "We'll redirect you to Stripe to complete cancellation. Tell us why first — your feedback helps us improve.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "salePrice": 6900,
+      "saleLabel": "6mos Launch Special",
+      "state": {
+        "status": "NONE",
+        "actions": []
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-hosted-pending.json
+++ b/e2e/plans/captured/dev-hosted-pending.json
@@ -1,0 +1,129 @@
+{
+  "plans": [
+    {
+      "slug": "free",
+      "name": "Community Roast",
+      "description": "Open-source self-hosted store with community support",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "Full e-commerce platform",
+            "Unlimited products & orders",
+            "Community support via GitHub",
+            "Self-hosted — you own your data"
+          ]
+        },
+        "excludes": [
+          "Priority support tickets",
+          "1:1 sessions",
+          "AI-powered features",
+          "Google Analytics integration"
+        ]
+      },
+      "highlight": false,
+      "visibility": "self-hosted",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Current Plan",
+        "pools": [],
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend",
+      "name": "House Blend",
+      "description": "Fully managed hosting with custom domain and priority support.",
+      "price": 7900,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting",
+        "priority-support"
+      ],
+      "details": {
+        "sla": {
+          "availability": "Business days (Mon–Fri)",
+          "responseTime": "48 hours"
+        },
+        "terms": [
+          "Billed monthly, cancel anytime from your billing dashboard",
+          "Unused tickets do not roll over to the next billing period",
+          "Refunds are not available for partial months",
+          "Plan changes take effect immediately"
+        ],
+        "quotas": [
+          {
+            "icon": "ticket",
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "countLabel": "used"
+          }
+        ],
+        "benefits": {
+          "activeItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveHeader": "Get back"
+        }
+      },
+      "highlight": true,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-subscription",
+          "heading": "Cancel your subscription?",
+          "reasons": [
+            {
+              "label": "Too expensive for my revenue",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Performance or reliability issues",
+              "value": "performance"
+            },
+            {
+              "label": "Moving to a self-hosted setup",
+              "value": "self-hosted"
+            },
+            {
+              "label": "Closing my store",
+              "value": "closing-store"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep subscription",
+          "confirmIcon": "external-link",
+          "description": "We'll redirect you to Stripe to complete cancellation. Tell us why first — your feedback helps us improve.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "salePrice": 6900,
+      "saleLabel": "6mos Launch Special",
+      "state": {
+        "status": "NONE",
+        "actions": []
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-hosted-provisioning.json
+++ b/e2e/plans/captured/dev-hosted-provisioning.json
@@ -1,0 +1,129 @@
+{
+  "plans": [
+    {
+      "slug": "free",
+      "name": "Community Roast",
+      "description": "Open-source self-hosted store with community support",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "Full e-commerce platform",
+            "Unlimited products & orders",
+            "Community support via GitHub",
+            "Self-hosted — you own your data"
+          ]
+        },
+        "excludes": [
+          "Priority support tickets",
+          "1:1 sessions",
+          "AI-powered features",
+          "Google Analytics integration"
+        ]
+      },
+      "highlight": false,
+      "visibility": "self-hosted",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Current Plan",
+        "pools": [],
+        "actions": []
+      }
+    },
+    {
+      "slug": "house-blend",
+      "name": "House Blend",
+      "description": "Fully managed hosting with custom domain and priority support.",
+      "price": 7900,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting",
+        "priority-support"
+      ],
+      "details": {
+        "sla": {
+          "availability": "Business days (Mon–Fri)",
+          "responseTime": "48 hours"
+        },
+        "terms": [
+          "Billed monthly, cancel anytime from your billing dashboard",
+          "Unused tickets do not roll over to the next billing period",
+          "Refunds are not available for partial months",
+          "Plan changes take effect immediately"
+        ],
+        "quotas": [
+          {
+            "icon": "ticket",
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "countLabel": "used"
+          }
+        ],
+        "benefits": {
+          "activeItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveItems": [
+            "Managed hosting & backups",
+            "Custom domain configuration",
+            "5 priority support tickets/month, 48-hr SLA"
+          ],
+          "inactiveHeader": "Get back"
+        }
+      },
+      "highlight": true,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-subscription",
+          "heading": "Cancel your subscription?",
+          "reasons": [
+            {
+              "label": "Too expensive for my revenue",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Performance or reliability issues",
+              "value": "performance"
+            },
+            {
+              "label": "Moving to a self-hosted setup",
+              "value": "self-hosted"
+            },
+            {
+              "label": "Closing my store",
+              "value": "closing-store"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep subscription",
+          "confirmIcon": "external-link",
+          "description": "We'll redirect you to Stripe to complete cancellation. Tell us why first — your feedback helps us improve.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "salePrice": 6900,
+      "saleLabel": "6mos Launch Special",
+      "state": {
+        "status": "NONE",
+        "actions": []
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-pro-inactive.json
+++ b/e2e/plans/captured/dev-pro-inactive.json
@@ -1,0 +1,157 @@
+{
+  "plans": [
+    {
+      "slug": "free",
+      "name": "Community Roast",
+      "description": "Open-source self-hosted store with community support",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "Full e-commerce platform",
+            "Unlimited products & orders",
+            "Community support via GitHub",
+            "Self-hosted — you own your data"
+          ]
+        },
+        "excludes": [
+          "Priority support tickets",
+          "1:1 sessions",
+          "AI-powered features",
+          "Google Analytics integration"
+        ]
+      },
+      "highlight": false,
+      "visibility": "self-hosted",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Current Plan",
+        "pools": [],
+        "actions": []
+      }
+    },
+    {
+      "slug": "priority-support",
+      "name": "Priority Support",
+      "description": "Dedicated support with guaranteed response times",
+      "price": 4900,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "priority-support"
+      ],
+      "details": {
+        "sla": {
+          "availability": "Business days (Mon–Fri)",
+          "responseTime": "48 hours",
+          "sessionBooking": "Scheduled via Calendly link provided after subscription",
+          "sessionDuration": "30 minutes"
+        },
+        "scope": [
+          "Setup & configuration",
+          "Troubleshooting",
+          "Platform guidance"
+        ],
+        "terms": [
+          "Billed monthly, cancel anytime from your billing dashboard",
+          "Unused tickets do not roll over to the next billing period",
+          "1:1 session must be booked within the billing period",
+          "Support is provided in English only",
+          "Refunds are not available for partial months",
+          "Plan changes take effect immediately"
+        ],
+        "quotas": [
+          {
+            "icon": "ticket",
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "countLabel": "tickets"
+          },
+          {
+            "icon": "calendar",
+            "slug": "one-on-one",
+            "label": "1:1 Sessions",
+            "limit": 1,
+            "countLabel": "sessions"
+          }
+        ],
+        "benefits": {
+          "activeItems": [
+            "5 priority support tickets/mo with 48hr SLA",
+            "1 30min 1:1 session/mo",
+            "Anonymous Github issue tracking & transparency"
+          ],
+          "inactiveItems": [
+            "5 priority support tickets/mo with 48hr SLA",
+            "1 30min 1:1 session/mo",
+            "Anonymous Github issue tracking & transparency"
+          ],
+          "inactiveHeader": "Get back"
+        },
+        "excludes": [
+          "Custom development",
+          "Feature requests",
+          "Third-party integrations"
+        ]
+      },
+      "highlight": true,
+      "visibility": "self-hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-subscription",
+          "heading": "Cancel your subscription?",
+          "reasons": [
+            {
+              "label": "Don't use enough tickets to justify the cost",
+              "value": "low-usage"
+            },
+            {
+              "label": "Response time didn't meet my expectations",
+              "value": "slow-response"
+            },
+            {
+              "label": "My issues weren't fully resolved",
+              "value": "unresolved"
+            },
+            {
+              "label": "I prefer GitHub issues / community support",
+              "value": "prefer-community"
+            },
+            {
+              "label": "Closing or pausing my store",
+              "value": "closing-store"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep subscription",
+          "confirmIcon": "external-link",
+          "description": "We'll redirect you to Stripe to complete cancellation. Tell us why first — your feedback helps us improve.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "salePrice": 3900,
+      "saleEndsAt": "2026-06-30T23:59:59.000Z",
+      "saleLabel": "1st 6mos Launch Special",
+      "state": {
+        "status": "NONE",
+        "actions": [
+          {
+            "slug": "subscribe",
+            "label": "Subscribe",
+            "iconAfter": "external-link",
+            "variant": "primary"
+          }
+        ]
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-pro.json
+++ b/e2e/plans/captured/dev-pro.json
@@ -1,0 +1,178 @@
+{
+  "plans": [
+    {
+      "slug": "free",
+      "name": "Community Roast",
+      "description": "Open-source self-hosted store with community support",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "Full e-commerce platform",
+            "Unlimited products & orders",
+            "Community support via GitHub",
+            "Self-hosted — you own your data"
+          ]
+        },
+        "excludes": [
+          "Priority support tickets",
+          "1:1 sessions",
+          "AI-powered features",
+          "Google Analytics integration"
+        ]
+      },
+      "highlight": false,
+      "visibility": "self-hosted",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Current Plan",
+        "pools": [],
+        "actions": []
+      }
+    },
+    {
+      "slug": "priority-support",
+      "name": "Priority Support",
+      "description": "Dedicated support with guaranteed response times",
+      "price": 4900,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "priority-support"
+      ],
+      "details": {
+        "sla": {
+          "availability": "Business days (Mon–Fri)",
+          "responseTime": "48 hours",
+          "sessionBooking": "Scheduled via Calendly link provided after subscription",
+          "sessionDuration": "30 minutes"
+        },
+        "scope": [
+          "Setup & configuration",
+          "Troubleshooting",
+          "Platform guidance"
+        ],
+        "terms": [
+          "Billed monthly, cancel anytime from your billing dashboard",
+          "Unused tickets do not roll over to the next billing period",
+          "1:1 session must be booked within the billing period",
+          "Support is provided in English only",
+          "Refunds are not available for partial months",
+          "Plan changes take effect immediately"
+        ],
+        "quotas": [
+          {
+            "icon": "ticket",
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 5,
+            "countLabel": "tickets"
+          },
+          {
+            "icon": "calendar",
+            "slug": "one-on-one",
+            "label": "1:1 Sessions",
+            "limit": 1,
+            "countLabel": "sessions"
+          }
+        ],
+        "benefits": {
+          "activeItems": [
+            "5 priority support tickets/mo with 48hr SLA",
+            "1 30min 1:1 session/mo",
+            "Anonymous Github issue tracking & transparency"
+          ],
+          "inactiveItems": [
+            "5 priority support tickets/mo with 48hr SLA",
+            "1 30min 1:1 session/mo",
+            "Anonymous Github issue tracking & transparency"
+          ],
+          "inactiveHeader": "Get back"
+        },
+        "excludes": [
+          "Custom development",
+          "Feature requests",
+          "Third-party integrations"
+        ]
+      },
+      "highlight": true,
+      "visibility": "self-hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-subscription",
+          "heading": "Cancel your subscription?",
+          "reasons": [
+            {
+              "label": "Don't use enough tickets to justify the cost",
+              "value": "low-usage"
+            },
+            {
+              "label": "Response time didn't meet my expectations",
+              "value": "slow-response"
+            },
+            {
+              "label": "My issues weren't fully resolved",
+              "value": "unresolved"
+            },
+            {
+              "label": "I prefer GitHub issues / community support",
+              "value": "prefer-community"
+            },
+            {
+              "label": "Closing or pausing my store",
+              "value": "closing-store"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep subscription",
+          "confirmIcon": "external-link",
+          "description": "We'll redirect you to Stripe to complete cancellation. Tell us why first — your feedback helps us improve.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        }
+      ],
+      "salePrice": 3900,
+      "saleEndsAt": "2026-06-30T23:59:59.000Z",
+      "saleLabel": "1st 6mos Launch Special",
+      "state": {
+        "status": "ACTIVE",
+        "badge": "Active",
+        "pools": [
+          {
+            "slug": "tickets",
+            "label": "Priority Tickets",
+            "limit": 0,
+            "used": 0,
+            "purchased": 0,
+            "icon": "ticket"
+          },
+          {
+            "slug": "one-on-one",
+            "label": "1:1 Sessions",
+            "limit": 0,
+            "used": 0,
+            "purchased": 0,
+            "icon": "calendar"
+          }
+        ],
+        "actions": [
+          {
+            "slug": "manage-billing",
+            "label": "Manage Billing",
+            "endpoint": "/api/billing/portal",
+            "iconAfter": "external-link",
+            "variant": "secondary",
+            "modalSlug": "cancel-subscription"
+          }
+        ]
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.107.1",
+  "version": "0.107.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.107.1",
+      "version": "0.107.2",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.107.1",
+  "version": "0.107.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/scripts/capture-plan-scenarios.ts
+++ b/scripts/capture-plan-scenarios.ts
@@ -164,6 +164,12 @@ async function main(): Promise<void> {
 
   console.log(`\nDone — ok ${ok}, missing ${missing}, failed ${failed}`);
   if (failed > 0) process.exit(1);
+  // STRICT_KEYS (set by CI): missing scenarios are a coverage gap, not just
+  // a warning — fail so the drift detector can't silently leave stale JSONs.
+  if (process.env.STRICT_KEYS === "1" && missing > 0) {
+    console.error(`STRICT_KEYS: ${missing} scenario(s) had no license key — coverage gap`);
+    process.exit(1);
+  }
 }
 
 void main();

--- a/scripts/capture-plan-scenarios.ts
+++ b/scripts/capture-plan-scenarios.ts
@@ -37,6 +37,73 @@ interface ResolvedResponse {
   resolvedAt: string;
 }
 
+/**
+ * Map of `seed-dev-scenarios.ts` labels (the comment header on each
+ * LICENSE_KEY= line in `.dev-scenario-keys`) to the dev-key ids the store
+ * uses in ALL_KEYS. The platform's seed script writes labels as comments;
+ * the capture flow keys by id.
+ *
+ * If this drifts (platform adds/renames a scenario), the capture script
+ * skips the unknown label with a warning and continues. The cross-repo
+ * fix is to regenerate `.dev-scenario-keys` as id-keyed JSON
+ * (planned: PR-NEW in plan.md deferred tracker).
+ */
+const LABEL_TO_ID: Record<string, string> = {
+  "FREE — community plan, no subscription": "dev-free",
+  "PRO — priority support active, pools live": "dev-pro",
+  "PRO / INACTIVE — priority support subscription lapsed": "dev-pro-inactive",
+  "HOSTED / PENDING_VERIFICATION — plans page shows nothing": "dev-hosted-pending",
+  "HOSTED / PROVISIONING — plans page shows nothing": "dev-hosted-provisioning",
+  "HOSTED / ACTIVE trial — no card on file": "dev-hosted-active-no-card",
+  "HOSTED / ACTIVE trial — card on file": "dev-hosted-active-card",
+  "HOSTED / CONVERTING — subscription in flight": "dev-hosted-converting",
+  "HOSTED / EXPIRED — trial ended, subscribe to restore": "dev-hosted-expired",
+  "HOSTED / CANCELLED — trial cancelled, deprovision countdown": "dev-hosted-cancelled",
+  "HOSTED / CANCELLED (card on file) — deprovision countdown running": "dev-hosted-cancelled-card",
+  "HOSTED / CONVERTED — house-blend active subscription": "dev-hosted-converted",
+  "HOSTED / INACTIVE — house-blend subscription lapsed": "dev-hosted-inactive",
+  "HOSTED / DEPROVISIONED — plans page shows nothing": "dev-hosted-deprovisioned",
+};
+
+/** Parse env-style `.dev-scenario-keys`:
+ *  Each `LICENSE_KEY=<value>` line is preceded by a `# <label>` comment.
+ *  Returns { devKey → licenseKey } using LABEL_TO_ID to look up the id.
+ *  Lines whose preceding label isn't in the map are skipped with a warning. */
+function parseEnvFile(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  let lastLabel: string | null = null;
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith("#")) {
+      const label = line.slice(1).trim();
+      // Skip the file header comment ("Dev scenario license keys — …")
+      if (label.toLowerCase().startsWith("dev scenario license keys")) continue;
+      lastLabel = label;
+      continue;
+    }
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!lastLabel) continue;
+    const id = LABEL_TO_ID[lastLabel];
+    if (!id) {
+      console.warn(`  skip (unknown label): "${lastLabel}"`);
+      lastLabel = null;
+      continue;
+    }
+    out[id] = value;
+    lastLabel = null;
+  }
+  return out;
+}
+
 async function loadKeys(): Promise<Record<string, string>> {
   if (process.env.DEV_KEYS_JSON) {
     return JSON.parse(process.env.DEV_KEYS_JSON);
@@ -46,7 +113,14 @@ async function loadKeys(): Promise<Record<string, string>> {
     throw new Error("Set DEV_KEYS_FILE or DEV_KEYS_JSON");
   }
   const text = await readFile(file, "utf8");
-  return JSON.parse(text);
+  // Auto-detect: JSON object (starts with `{`) vs env-style (KEY=value lines).
+  // The platform repo's `.dev-scenario-keys` is env-style; CI passes JSON via
+  // DEV_KEYS_JSON.
+  const trimmed = text.trimStart();
+  if (trimmed.startsWith("{")) {
+    return JSON.parse(text);
+  }
+  return parseEnvFile(text);
 }
 
 async function captureOne(key: string, licenseKey: string): Promise<void> {

--- a/scripts/capture-plan-scenarios.ts
+++ b/scripts/capture-plan-scenarios.ts
@@ -68,9 +68,11 @@ const LABEL_TO_ID: Record<string, string> = {
 /** Parse env-style `.dev-scenario-keys`:
  *  Each `LICENSE_KEY=<value>` line is preceded by a `# <label>` comment.
  *  Returns { devKey → licenseKey } using LABEL_TO_ID to look up the id.
- *  Lines whose preceding label isn't in the map are skipped with a warning. */
+ *  Unknown labels warn in local dev; under STRICT_KEYS they collect and
+ *  throw at end so coverage regressions can't slip through CI drift checks. */
 function parseEnvFile(text: string): Record<string, string> {
   const out: Record<string, string> = {};
+  const unknownLabels: string[] = [];
   let lastLabel: string | null = null;
   for (const rawLine of text.split(/\r?\n/)) {
     const line = rawLine.trim();
@@ -94,12 +96,21 @@ function parseEnvFile(text: string): Record<string, string> {
     if (!lastLabel) continue;
     const id = LABEL_TO_ID[lastLabel];
     if (!id) {
-      console.warn(`  skip (unknown label): "${lastLabel}"`);
+      if (process.env.STRICT_KEYS === "1") {
+        unknownLabels.push(lastLabel);
+      } else {
+        console.warn(`  skip (unknown label): "${lastLabel}"`);
+      }
       lastLabel = null;
       continue;
     }
     out[id] = value;
     lastLabel = null;
+  }
+  if (process.env.STRICT_KEYS === "1" && unknownLabels.length > 0) {
+    throw new Error(
+      `STRICT_KEYS: ${unknownLabels.length} unknown label(s) in dev-scenario-keys — extend LABEL_TO_ID or remove the source line(s):\n  ${unknownLabels.join("\n  ")}`
+    );
   }
   return out;
 }


### PR DESCRIPTION
## Summary

Adds a daily drift detection workflow for `/api/plans/resolved`. Captures every dev scenario from prod each morning, diffs against the committed baseline at `e2e/plans/captured/*.json`, and fires an auto-issue on drift.

Catches the class of regressions that mock-driven Playwright tests cannot: the mock is **authored** (we tell it what to return), so it can't surface a resolver dropping an action or emitting the wrong status. The capture is **observed** (it's the real prod response), so divergence from baseline = real signal.

## What ships

- `.github/workflows/plans-capture-nightly.yml` — 8am UTC daily + workflow_dispatch. Captures all dev scenarios, runs `git diff -- e2e/plans/captured/`, fails on diff, uploads drift artifact, auto-opens issue with refresh instructions.
- `e2e/plans/captured/*.json` — 13 baseline payloads captured from prod just now. Source of truth.
- `e2e/plans/captured/README.md` — refresh + investigation flow.
- `scripts/capture-plan-scenarios.ts` — now handles two key-file formats:
  - **CI path:** id-keyed JSON via `DEV_KEYS_JSON` secret (matches the new repo secret `PLANS_CAPTURE_DEV_KEYS_JSON`).
  - **Local path:** label-headered env-style via `DEV_KEYS_FILE` (matches what platform's `seed-dev-scenarios.ts` writes to `.dev-scenario-keys`). LABEL_TO_ID table bridges the two.

## Setup (done)

- ✅ Repo secret `PLANS_CAPTURE_DEV_KEYS_JSON` added (piped directly from the platform-repo file; contents never displayed in chat).
- ✅ Initial baseline captured + committed at `e2e/plans/captured/*.json`.

## Expected first nightly behavior

The first scheduled run (8am UTC tomorrow) will compare against the baseline captured right now. **If the platform resolver fix on `feat/plan-scenario-corrections` deploys between now and then, the first nightly will report drift** — that's the workflow doing its job, not a bug. Action: refresh baseline via `npm run plans:capture`, commit, close the auto-issue.

## Test plan

- [x] `npm run precheck` — 0 errors (1 pre-existing TanStack warning, untouched)
- [x] `npm run test:ci` — 1388 tests pass
- [x] Local capture run succeeds against prod (13/13 scenarios captured)
- [x] Workflow YAML validated via gh CLI / GitHub repo
- [x] Repo secret added
- [ ] Trigger workflow_dispatch manually to verify the pipeline once merged
- [ ] First scheduled run (8am UTC) — accept drift artifact if platform fix shipped

## Follow-up

The platform repo has `.dev-scenario-keys` in env-style with labels as comments. A cross-repo cleanup is filed (regenerate as id-keyed JSON) to remove the `LABEL_TO_ID` table in `capture-plan-scenarios.ts`.