### PR TITLE
docs: Session 2 plan — CONVERTING state + ConversionModal

### DIFF
--- a/docs/features/provider-plan-sdk-alignment/plan.md
+++ b/docs/features/provider-plan-sdk-alignment/plan.md
@@ -44,24 +44,33 @@ Sessions 1–5 (now in `archive/`) shipped the foundation: SDK-driven types, pro
 - `npm run plans:capture` runs successfully against the provider for at least the self-hosted dev keys; captured JSONs committed.
 - AC-DRIFT sub-rows verified (each layer demonstrably catches a synthetic regression).
 
-### Session 2 — CONVERTING state + ConversionModal
+### Session 2 — CONVERTING state + ConversionModal + ride-alongs
 
-**Scope:** Add CONVERTING plan state to the SDK + provider + renderer chain, plus a non-dismissable `ConversionModal` component that polls the resolver until the customer's plan converts off CONVERTING.
+**Status:** planned. ACs drafted — see [`session-2/ACs.md`](session-2/ACs.md) (15 ACs).
 
-**Pre-reqs:**
+**Scope:** Add the `CONVERTING` plan state across SDK → provider → store, plus a non-dismissable `ConversionModal` that polls the resolver until the plan converts off CONVERTING. Plus two ride-alongs that close deferred items: **ST-2** (`ConfirmActionDialog` field coverage) and **ST-3** (page-level composition tests).
 
-- Session 1 done — the harness exists before new state variants land, so coverage grows with the type.
-- SDK-RFC-MCP-VER landed (or batched in this session).
+**Locked design decisions (from planning):**
+
+- **SDK bump = minor (v0.5.0).** Adding a union member breaks `switch(state.status)` exhaustiveness in consumers — minor is the honest bump.
+- **MCP version fix bundled in.** SDK-RFC-MCP-VER (wire `serverInfo.version` to the package version) ships in the same SDK PR as CONVERTING — both are SDK changes.
+- **Conversion UX is modal-only — no Card.** `PlanCard` returns `null` for CONVERTING; a full-screen `ConversionModal` owns the UX. The page freezes behind it (scroll lock + `pointer-events-none` + dim) so the customer can't navigate or interact mid-transition. (Card-vs-modal amounts to the same backend work; modal-only is the safer UX during a state transition.)
+- **Ride-alongs ST-2 + ST-3 are in.** We're writing `conversion-modal.test.tsx` anyway; the modal/dialog test patterns transfer to `confirm-action-dialog.test.tsx`. And the modal needs page-level integration tests, so `plan-page-client.test.tsx` lands too.
 
 **Cross-repo deliverables:**
 
 | Repo | Deliverable |
 |------|-------------|
-| SDK | Add `ConvertingState` to `PlanState` discriminated union. Fields: `status: "CONVERTING"`, optional progress / message fields. Add `CONVERTING` to the relevant SCENARIOS. Add to `validate_plan_payload` MCP tool. Bump SDK version. |
-| Provider | Resolver branch emits CONVERTING during the conversion window (after Stripe webhook fires, before plan provisions to ACTIVE). Wire trial-conversion endpoint to emit transient CONVERTING state. Captured-payload dev scenario seeded (`dev-hosted-converting`). |
-| Store | Bump SDK dep. Add `ConvertingCard` (or reuse PlanCard with a CONVERTING branch — TBD). Add `ConversionModal` component triggered by `state.status === "CONVERTING"` on any plan; non-dismissable overlay with polling indicator; polls `/api/plans/resolved` every ~5s; closes + `router.refresh()` when no plan returns CONVERTING. New contract test file `converting-card.test.tsx`. New `conversion-modal.test.tsx`. Add CONVERTING scenario to fixtures. Capture new payload after provider deploy. |
+| `artisan-roast-sdk` | Add `ConvertingState` to `PlanState` union (`status: "CONVERTING"`, `statusInfo?: StatusInfo`, optional `startedAt?`). No `actions[]`/`pools[]` — purely transient. Add CONVERTING scaffold to `SCENARIOS`. Update `validate_plan_payload` Zod schema. **Bundle SDK-RFC-MCP-VER.** Tag **v0.5.0**, push. |
+| platform | Resolver branch emits CONVERTING during the conversion window (post-Stripe-webhook, pre-provision-to-ACTIVE). Wire trial-conversion endpoint. Seed `dev-hosted-converting`. Regenerate `.dev-scenario-keys` as id-keyed JSON (removes the store's `LABEL_TO_ID` table). Bump SDK ref to `#v0.5.0`. Deploy. |
+| `artisan-roast` (store) | Bump SDK ref to `#v0.5.0`. `PlanCard` dispatch handles CONVERTING → returns `null`. New `_components/ConversionModal.tsx` — non-dismissable overlay, spinner + `statusInfo.descText`, polls `router.refresh()` every ~5s, closes when no plan is CONVERTING. Page freeze in `PlanPageClient`. Add `dev-hosted-converting` to `_fixtures/plan-scenarios.ts` + `ALL_KEYS`. New `__tests__/contract/conversion-modal.test.tsx`. Ride-alongs: `confirm-action-dialog.test.tsx` (ST-2), `plan-page-client.test.tsx` (ST-3). Capture `dev-hosted-converting.json` after the provider deploys. |
 
-**Acceptance criteria:** TBD — follows the Session 1 template (presence/absence/placement on every How column). Drafted at session start.
+**Sequencing (enforced by `STRICT_KEYS=1` in the drift nightly):** SDK PR + tag → platform PR + deploy → store PR (last — its AC-CAP-CONVERTING capture would skip the scenario and hard-fail until the provider is live).
+
+**New decisions to add to `architecture.md` when this lands:**
+
+- **D14** — CONVERTING is the first `PlanState` variant with no `actions[]` and no `pools[]`. Purely transient. The renderer shows nothing in the card slot; the modal owns it.
+- **D15** — Conversion UX is modal-only (no Card render) to prevent navigation/interaction during the state transition. The page is frozen behind a non-dismissable overlay.
 
 ### Session 3+ — TBD
 
@@ -123,15 +132,16 @@ Items split out of Session 1 that need to land before, during, or after Session 
 
 | ID | Title | Why deferred | Picks up in |
 |----|-------|--------------|-------------|
-| ST-1 | AC-CT-COMMON restructure | Existing 6 per-state contract files cover the ship-gating surface; consolidation into a common-fields suite + slim per-state files is a polish refactor. | Follow-up branch / Session 2 |
-| ST-2 | AC-CT-MODAL — `confirm-action-dialog.test.tsx` | `ConfirmActionConfig` field coverage isn't gating ship; cancel-trial/cancel-stripe modals only fire from hosted/trial gate which isn't open. | Follow-up branch / Session 2 |
-| ST-3 | AC-CT-PAGE — `plan-page-client.test.tsx` | Page composition, ordering, empty state, warnings banner. Helpful but not gating. | Follow-up branch |
-| ST-4 | AC-CAP — Captured-payload Jest test | Needs dev license keys for capture; replaces existing `e2e/plans/scenarios.spec.ts` Playwright spec with a Jest-driven version. Cross-field consistency assertions (`quotas[].limit === pools[].limit`). MCP-backed `npm run plans:validate` optional cross-check. | Follow-up branch (after captures collected) |
-| ST-5 | AC-PW — Playwright plumbing spec | Smoke test for Next.js wiring: `searchParams` await, `?scenario=` dev-gating in prod, hydration mismatch absence, fetch-timeout → empty-state without console errors. | Follow-up branch |
-| ST-6 | AC-DRIFT — drift-injection ritual | Per-layer manual verification that each test layer can detect a synthetic regression (positional swap, snapshot diff, captured payload edit, removed await). | Verification pass before Session 2 ships |
-| ST-7 | Compatibility-over-time (§12 work) | Boundary validation, version handshake headers, admin version banner, graceful renderer FallbackCard for unknown shapes. Filed in `architecture.md` D13 — deferred until self-hosted customers exist or a real skew incident forces it. | Self-hosted launch |
-| ST-8 | Architecture doc relocation | Move (or copy + adapt) `architecture.md` to a cross-repo location (provider's `appendix/cross-repo/`) for the full picture; keep a store-side excerpt for renderer-only concerns. | After Session 1 ships, before Session 2 starts |
+| ST-1 | AC-CT-COMMON restructure | Existing 6 per-state contract files cover the ship-gating surface; consolidation into a common-fields suite + slim per-state files is a polish refactor. Cheaper to bulk-migrate after a 3rd batch of states accrues. | Future — explicitly NOT Session 2 |
+| ST-2 | AC-CT-MODAL — `confirm-action-dialog.test.tsx` | `ConfirmActionConfig` field coverage. Modal/dialog test patterns transfer from Session 2's `conversion-modal.test.tsx`. | **Session 2 (ride-along)** — see `session-2/ACs.md` AC-CT-MODAL |
+| ST-3 | AC-CT-PAGE — `plan-page-client.test.tsx` | Page composition, ordering, empty state, warnings banner — and the CONVERTING-plan → ConversionModal-mounted integration test, which Session 2 needs anyway. | **Session 2 (ride-along)** — see `session-2/ACs.md` AC-CT-PAGE |
+| ST-4 | AC-CAP — Captured-payload Jest test | Replace `e2e/plans/scenarios.spec.ts` (deleted) with a Jest-driven version that loads `e2e/plans/captured/*.json` (now committed — baseline + nightly drift workflow shipped in v0.107.2). Structural + cross-field assertions. MCP-backed `npm run plans:validate` optional cross-check. | Follow-up branch (captures now exist) |
+| ST-5 | AC-PW — Playwright plumbing spec | Smoke test for Next.js wiring. The `fix/e2e-mock-resolved-plans` work (mock serves `/api/plans/resolved`) unblocks this — the mock infra it needs now exists. | Follow-up branch |
+| ST-6 | AC-DRIFT — drift-injection ritual | Per-layer manual verification that each test layer can detect a synthetic regression. | Verification pass per session (Session 2's ACs include AC-DRIFT) |
+| ST-7 | Compatibility-over-time (§9.4 work) | Boundary validation, version handshake headers, admin version banner, graceful renderer FallbackCard for unknown shapes. `architecture.md` D13 — signal-triggered, not timeline-triggered. Note: CONVERTING (Session 2) adds a union member; the renderer's `switch` gains a CONVERTING case — but a *future* unknown state would still fall through. The FallbackCard is the guard for that. | Self-hosted launch / first skew incident |
+| ST-8 | Architecture doc relocation | Move (or copy + adapt) `architecture.md` to a cross-repo location (provider's `appendix/cross-repo/`). Note: platform PR #74 (`docs: pools-architecture scoping; close out provider-sdk-integration`) is in flight on that side — coordinate so the cross-repo doc home is settled there, then point the store excerpt at it. | After platform PR #74 lands |
 | ST-9 | Currency support beyond USD | Renderer hardcodes `$`; SDK type allows any ISO 4217 code. Multi-currency rendering is a future feature. | Future session |
+| ST-10 | Remove `LABEL_TO_ID` from `capture-plan-scenarios.ts` | The store maps platform's `.dev-scenario-keys` labels → dev-key ids via a hardcoded table because the platform's `seed-dev-scenarios.ts` writes labels as comments. Once the platform regenerates that file as id-keyed JSON (filed as PR-SEED-CONVERTING in Session 2), the table goes away. | Session 2 cleanup (after platform regenerates `.dev-scenario-keys`) |
 
 ### Provider-side (separate repo)
 
@@ -139,23 +149,27 @@ These belong in the provider repo's plan docs. Filed here so cross-repo context 
 
 | ID | Title | Notes |
 |----|-------|-------|
-| PR-1 | Session 2 resolver: emit CONVERTING state | New branch in `PlanState` resolver during conversion window. Pairs with store-side ConversionModal. |
-| PR-2 | Seed `dev-hosted-converting` scenario | Dev license key + HostedTrial row with `status: CONVERTING`. |
+| PR-1 | Session 2 resolver: emit CONVERTING state | New branch in `PlanState` resolver during conversion window. Pairs with store-side ConversionModal. **Session 2 — see `session-2/ACs.md` PR-CONVERTING-RESOLVER.** |
+| PR-2 | Seed `dev-hosted-converting` scenario | Dev license key + HostedTrial row with `status: CONVERTING`. **Session 2 — see `session-2/ACs.md` PR-SEED-CONVERTING. Also: regenerate `.dev-scenario-keys` as id-keyed JSON to retire ST-10.** |
 | PR-3 | PLAT-1 — Plan business spec validation tests | Provider-side test suite asserts each shipped plan's resolver output matches its product spec (Priority Support = 5 tickets / 1 session / $49 / $39 sale label, etc.). |
 | PR-4 | PLAT-2 — Cadence enforcement tests | Time-dependent tests verify pool replenishment fires on month boundary. |
 | PR-5 | Stripe link IDs in dev seed | Seed `stripeExtendLinkId`, `stripeSubscribeLinkId` + delete-trial modal entry for hosted dev scenarios. (Resolves session-5 SKIP findings P4-related in dev only; prod already has real links.) |
 | PR-6 | Version handshake response headers | Echo `X-Provider-SDK-Version` for store-side runtime drift detection. Deferred with §9.4 — signal-triggered, not timeline-triggered. |
 | PR-7 | Document the resolver's branch logic as a spec | Today: `route.ts` source is the only spec. A separate `docs/plans/resolver-spec.md` (or similar) would document each branch's preconditions, output shape, and rationale. Pairs with PLAT-1 (spec validation tests). Not blocking ship; helpful for cross-repo onboarding. |
+| PR-8 | P8 — rename "Everything in Community Roast" → "Everything in Community" | House-blend's `details.benefits.activeItems` still references the old FREE-plan name ("Community Roast" → now "Community"). Content-only DB change. **In progress (platform).** The store baseline correctly captures the current copy; when the DB change ships, the nightly drift detector flags the change, the store re-captures, baseline updates. No store-side code change. |
+
+> **Already landed (platform):** PR #72 (`feat(resolver): plan scenario corrections + free→NONE + buildPoolsFromQuotas fix`) — merged 2026-05-11, deployed. PR #73 (`chore: unblock pre-commit + gitignore session state`) — merged 2026-05-11, handled the `.dev-scenario-keys` / `.claude/` gitignore concern. PR #74 (`docs: pools-architecture scoping`) — open, platform-side doc work.
 
 ### SDK-side (separate repo)
 
 | ID | Title | Status |
 |----|-------|--------|
-| SDK-RFC-MCP-VER | Wire MCP `serverInfo.version` to SDK package version | **Bundle with next SDK touch (during Session 2 likely)** — small fix; prerequisite for any meaningful version-aware MCP workflow |
+| SDK-RFC-MCP-VER | Wire MCP `serverInfo.version` to SDK package version | **Session 2 — bundled into the SDK v0.5.0 PR with SDK-RFC-3** (both are SDK changes; ship together) |
 | SDK-RFC-1 | `quotas[].cadence` field (`"month" \| "year" \| "one-time"`) | Future — enables deterministic cadence rendering |
 | SDK-RFC-2 | `pools?: UsagePool[]` on every state (NoneState / InactiveState / CancelledState) | Future — removes the today-pattern hack of putting FREE in ACTIVE state just to attach addon pools |
-| SDK-RFC-3 | Add CONVERTING state to `PlanState` union | **Session 2 prereq** |
+| SDK-RFC-3 | Add CONVERTING state to `PlanState` union | **Session 2 — bundled with SDK-RFC-MCP-VER → tag v0.5.0** (minor: union member breaks consumer `switch` exhaustiveness). See `session-2/ACs.md` SDK-RFC-CONVERTING. |
 | SDK-RFC-4 | SDK semver + deprecation policy + migration docs | Deferred — wait for self-hosted launch when version skew becomes a real customer problem |
+| SDK-RFC-5 | MCP changelog/diff tool (`mcp__artisan-roast-sdk__diff_versions`) | Future — useful during SDK upgrades but not blocking |
 | SDK-RFC-5 | MCP changelog/diff tool (`mcp__artisan-roast-sdk__diff_versions`) | Future — useful during SDK upgrades but not blocking |
 
 ## Review gates

--- a/docs/features/provider-plan-sdk-alignment/plan.md
+++ b/docs/features/provider-plan-sdk-alignment/plan.md
@@ -139,7 +139,7 @@ Items split out of Session 1 that need to land before, during, or after Session 
 | ST-5 | AC-PW — Playwright plumbing spec | Smoke test for Next.js wiring. The `fix/e2e-mock-resolved-plans` work (mock serves `/api/plans/resolved`) unblocks this — the mock infra it needs now exists. | Follow-up branch |
 | ST-6 | AC-DRIFT — drift-injection ritual | Per-layer manual verification that each test layer can detect a synthetic regression. | Verification pass per session (Session 2's ACs include AC-DRIFT) |
 | ST-7 | Compatibility-over-time (§9.4 work) | Boundary validation, version handshake headers, admin version banner, graceful renderer FallbackCard for unknown shapes. `architecture.md` D13 — signal-triggered, not timeline-triggered. Note: CONVERTING (Session 2) adds a union member; the renderer's `switch` gains a CONVERTING case — but a *future* unknown state would still fall through. The FallbackCard is the guard for that. | Self-hosted launch / first skew incident |
-| ST-8 | Architecture doc relocation | Move (or copy + adapt) `architecture.md` to a cross-repo location (provider's `appendix/cross-repo/`). Note: platform PR #74 (`docs: pools-architecture scoping; close out provider-sdk-integration`) is in flight on that side — coordinate so the cross-repo doc home is settled there, then point the store excerpt at it. | After platform PR #74 lands |
+| ST-8 | Architecture doc relocation | Move (or copy + adapt) `architecture.md` to a cross-repo location (provider's `appendix/cross-repo/`). Note: `yuens1002/artisan-roast-platform#74` (`docs: pools-architecture scoping; close out provider-sdk-integration`) is in flight on that side — coordinate so the cross-repo doc home is settled there, then point the store excerpt at it. | After `yuens1002/artisan-roast-platform#74` lands |
 | ST-9 | Currency support beyond USD | Renderer hardcodes `$`; SDK type allows any ISO 4217 code. Multi-currency rendering is a future feature. | Future session |
 | ST-10 | Remove `LABEL_TO_ID` from `capture-plan-scenarios.ts` | The store maps platform's `.dev-scenario-keys` labels → dev-key ids via a hardcoded table because the platform's `seed-dev-scenarios.ts` writes labels as comments. Once the platform regenerates that file as id-keyed JSON (filed as PR-SEED-CONVERTING in Session 2), the table goes away. | Session 2 cleanup (after platform regenerates `.dev-scenario-keys`) |
 
@@ -158,7 +158,7 @@ These belong in the provider repo's plan docs. Filed here so cross-repo context 
 | PR-7 | Document the resolver's branch logic as a spec | Today: `route.ts` source is the only spec. A separate `docs/plans/resolver-spec.md` (or similar) would document each branch's preconditions, output shape, and rationale. Pairs with PLAT-1 (spec validation tests). Not blocking ship; helpful for cross-repo onboarding. |
 | PR-8 | P8 — rename "Everything in Community Roast" → "Everything in Community" | House-blend's `details.benefits.activeItems` still references the old FREE-plan name ("Community Roast" → now "Community"). Content-only DB change. **In progress (platform).** The store baseline correctly captures the current copy; when the DB change ships, the nightly drift detector flags the change, the store re-captures, baseline updates. No store-side code change. |
 
-> **Already landed (platform):** PR #72 (`feat(resolver): plan scenario corrections + free→NONE + buildPoolsFromQuotas fix`) — merged 2026-05-11, deployed. PR #73 (`chore: unblock pre-commit + gitignore session state`) — merged 2026-05-11, handled the `.dev-scenario-keys` / `.claude/` gitignore concern. PR #74 (`docs: pools-architecture scoping`) — open, platform-side doc work.
+> **Already landed (platform):** `yuens1002/artisan-roast-platform#72` (`feat(resolver): plan scenario corrections + free→NONE + buildPoolsFromQuotas fix`) — merged 2026-05-11, deployed. `yuens1002/artisan-roast-platform#73` (`chore: unblock pre-commit + gitignore session state`) — merged 2026-05-11, handled the `.dev-scenario-keys` / `.claude/` gitignore concern. `yuens1002/artisan-roast-platform#74` (`docs: pools-architecture scoping`) — open, platform-side doc work.
 
 ### SDK-side (separate repo)
 
@@ -169,7 +169,6 @@ These belong in the provider repo's plan docs. Filed here so cross-repo context 
 | SDK-RFC-2 | `pools?: UsagePool[]` on every state (NoneState / InactiveState / CancelledState) | Future — removes the today-pattern hack of putting FREE in ACTIVE state just to attach addon pools |
 | SDK-RFC-3 | Add CONVERTING state to `PlanState` union | **Session 2 — bundled with SDK-RFC-MCP-VER → tag v0.5.0** (minor: union member breaks consumer `switch` exhaustiveness). See `session-2/ACs.md` SDK-RFC-CONVERTING. |
 | SDK-RFC-4 | SDK semver + deprecation policy + migration docs | Deferred — wait for self-hosted launch when version skew becomes a real customer problem |
-| SDK-RFC-5 | MCP changelog/diff tool (`mcp__artisan-roast-sdk__diff_versions`) | Future — useful during SDK upgrades but not blocking |
 | SDK-RFC-5 | MCP changelog/diff tool (`mcp__artisan-roast-sdk__diff_versions`) | Future — useful during SDK upgrades but not blocking |
 
 ## Review gates

--- a/docs/features/provider-plan-sdk-alignment/session-2/ACs.md
+++ b/docs/features/provider-plan-sdk-alignment/session-2/ACs.md
@@ -54,7 +54,7 @@ Three PRs, must land in order. The drift nightly + `STRICT_KEYS=1` make the orde
 
 1. **SDK PR** (`feat/converting-state-and-mcp-ver`) — CONVERTING in the union + MCP version fix → tag v0.5.0 → push.
 2. **Platform PR** (`feat/converting-resolver`) — resolver emits CONVERTING + seed `dev-hosted-converting` → deploy. Bumps SDK ref to `#v0.5.0`.
-3. **Store PR** (`feat/converting-state`) — bump SDK ref, `ConvertingCard` dispatch (returns null), `ConversionModal`, page freeze, fixture entry, contract tests, ride-along ST-2/ST-3 tests, capture `dev-hosted-converting.json` after the provider deploys.
+3. **Store PR** (`feat/converting-state`) — bump SDK ref, `PlanCard`'s `case "CONVERTING"` returning `null` (no separate ConvertingCard component), `ConversionModal`, page freeze, fixture entry, contract tests, ride-along ST-2/ST-3 tests, capture `dev-hosted-converting.json` after the provider deploys.
 
 The store PR's AC-CAP-CONVERTING can't pass until the provider is live (capture would skip the scenario; `STRICT_KEYS` fails). So the store PR is the last thing to merge, after a provider deploy.
 
@@ -68,6 +68,6 @@ The store PR's AC-CAP-CONVERTING can't pass until the provider is live (capture 
 
 ---
 
-## Total: 15 ACs
+## Total: 15 rows
 
-13 substantive + AC-CT-COMMON-DEFER (traceability note) + AC-DRIFT (ritual) + AC-REG (gate). Two of the 13 (AC-CT-MODAL, AC-CT-PAGE) close deferred items ST-2 and ST-3.
+12 substantive ACs + AC-CT-COMMON-DEFER (traceability note, not an AC) + AC-DRIFT (verification ritual) + AC-REG (gate) = 15 rows. Two of the 12 substantive ACs (AC-CT-MODAL, AC-CT-PAGE) close deferred items ST-2 and ST-3.

--- a/docs/features/provider-plan-sdk-alignment/session-2/ACs.md
+++ b/docs/features/provider-plan-sdk-alignment/session-2/ACs.md
@@ -1,0 +1,73 @@
+# Session 2 — Acceptance Criteria
+
+**Branch:** `feat/converting-state` (proposed)
+**Plan:** [`../plan.md`](../plan.md) (Session 2 section)
+**Architecture:** [`../architecture.md`](../architecture.md)
+
+> **Scope:** Add the `CONVERTING` plan state across SDK → provider → store, plus a non-dismissable `ConversionModal` that polls the resolver until the customer's plan converts off CONVERTING. Plus two ride-along ACs that close deferred items ST-2 (ConfirmActionDialog coverage) and ST-3 (page-level composition).
+>
+> **Pre-reqs:** SDK v0.5.0 tagged + pushed (CONVERTING in `PlanState` union + `validate_plan_payload` + bundled SDK-RFC-MCP-VER). Provider resolver emits CONVERTING + seeds `dev-hosted-converting`. Both must land before the store PR.
+>
+> **How column convention:** Presence / Absence / Placement on every row — what should appear, what should NOT appear where it shouldn't, what structural slot it occupies. Same format as Session 1.
+>
+> **Ship-gating vs. coverage:** the hosted/trial gate is still not open to customers, so CONVERTING isn't user-facing yet. All ACs are coverage-building; none gate a customer-facing ship. They gate the *next* time the hosted gate opens.
+
+---
+
+## Cross-repo prerequisites (tracked, not store ACs)
+
+| ID | Repo | Deliverable | Status |
+|----|------|-------------|:------:|
+| SDK-RFC-CONVERTING | `artisan-roast-sdk` | Add `ConvertingState` to `PlanState` union: `status: "CONVERTING"`, `statusInfo?: StatusInfo` (resolver-supplied progress copy), optional `startedAt?: string` (stuck-state detection). No `actions[]`, no `pools[]` — purely transient. Add a CONVERTING scaffold to `SCENARIOS`. Update `validate_plan_payload` Zod schema. | ☐ |
+| SDK-RFC-MCP-VER | `artisan-roast-sdk` | Wire MCP `serverInfo.version` to the SDK package version (read at build). Bundle into the SDK-RFC-CONVERTING PR — both are SDK changes, ship together as v0.5.0. | ☐ |
+| SDK-v0.5.0 | `artisan-roast-sdk` | Tag v0.5.0 (minor — adding a union member breaks `switch(state.status)` exhaustiveness in consumers; minor bump is honest). Push tag. | ☐ |
+| PR-CONVERTING-RESOLVER | platform | Resolver branch emits CONVERTING during the conversion window (after Stripe webhook fires, before plan provisions to ACTIVE). Wire trial-conversion endpoint to push HostedTrial through CONVERTING → ACTIVE. Bump SDK ref to `#v0.5.0`. | ☐ |
+| PR-SEED-CONVERTING | platform | Seed `dev-hosted-converting` — license key + HostedTrial row stuck in conversion. Regenerate `.dev-scenario-keys` (now id-keyed JSON, removes the store's `LABEL_TO_ID` table). | ☐ |
+
+---
+
+## Store-side ACs
+
+| # | AC | Layer | What | How (Presence / Absence / Placement) | Pass | Agent | QC | Reviewer |
+|---|----|:-----:|------|---------------------------------------|------|-------|----|----------|
+| 1 | **AC-DEPS** | — | SDK dep bumped to `#v0.5.0` | **Presence:** `package.json` `artisan-roast-sdk` ref is `github:yuens1002/artisan-roast-sdk#v0.5.0`; `npm install` resolves; SDK package version is 0.5.0. **Absence:** no `file:` ref. **Placement:** dependency line in `package.json`. | After bump, TypeScript flags `PlanCard`'s `switch(state.status)` as non-exhaustive — that's the forcing function for AC-CT-CONVERTING. | | | |
+| 2 | **AC-CT-CONVERTING** | 2 | `PlanCard` dispatch handles CONVERTING | **Presence:** `switch(state.status)` has a `case "CONVERTING":` that returns `null` (the card slot renders nothing — the modal owns the UX). TypeScript exhaustive switch passes. **Absence:** no card border, badge, pricing, pools, or actions render for a CONVERTING plan in the cards grid. **Placement:** the CONVERTING case sits in the same switch as the other 6 states. | New tests in `__tests__/contract/converting-card.test.tsx` (or extend an existing file). Inline-constructed CONVERTING plan → assert nothing renders in the card position. | | | |
+| 3 | **AC-CT-CONVERSION-MODAL** | 2 | `ConversionModal` component contract | **Presence:** `_components/ConversionModal.tsx`. Renders when at least one plan in `plans[]` has `state.status === "CONVERTING"`. Shows a spinner/loader. Shows `state.statusInfo.descText` when present (resolver-supplied "Processing payment…" / "Brewing your store…"). **Absence:** not rendered when no plan is CONVERTING; no close button, no Escape-key handler, no overlay-click-to-close — non-dismissable by design. **Placement:** full-screen overlay (fixed, z-top), above the cards grid. | New `__tests__/contract/conversion-modal.test.tsx`. Construct a plans array with/without a CONVERTING plan; assert modal presence/absence; assert spinner + descText projection; assert no dismiss affordances. | | | |
+| 4 | **AC-CT-CONVERSION-MODAL-POLL** | 2 | Polling behavior | **Presence:** modal invokes `router.refresh()` on a configured interval (~5s; mockable timer in tests); polling continues while the modal is open. **Absence:** polling stops when the modal closes (no plan is CONVERTING anymore); no overlapping `router.refresh()` calls if a refresh is slow. **Placement:** poll logic inside `ConversionModal` (a `useEffect` with `setInterval` cleared on unmount / state-clear). | `conversion-modal.test.tsx` with fake timers — advance time, assert `router.refresh` call count; unmount, assert no further calls. | | | |
+| 5 | **AC-CT-FREEZE** | 2 | Page freeze while modal is open | **Presence:** when `ConversionModal` is open, `<body>` (or the page root) gets `overflow-hidden` (scroll lock); the cards grid behind gets `pointer-events-none` + a visual dim (`opacity-50` or a backdrop). **Absence:** when the modal closes, scroll lock + pointer-events + dim are removed; no clickable element behind the modal is reachable (focus trap or `inert`/`aria-hidden` on the background). **Placement:** the freeze styling is applied by `PlanPageClient` (which renders the modal) to the cards-grid container and the body, not by individual cards. | `plan-page-client.test.tsx` (see AC-CT-PAGE) — render with a CONVERTING plan, assert background container has the freeze classes + that a background button is not reachable via tab order. | | | |
+| 6 | **AC-CT-PAGE** *(ride-along ST-3)* | 2 | Page-level composition | **Presence:** `__tests__/contract/plan-page-client.test.tsx`. Asserts: `plans: []` → empty-state copy; N≥1 plans → one card per plan in payload order; `license.warnings` non-empty → warnings banner with each entry; `?checkout=success` searchParam → `refreshLicense` action fired; `?demo=success` → demo toast; **a CONVERTING plan in `plans[]` → ConversionModal mounted + page frozen**. **Absence:** N=0 → no card containers; warnings empty → no banner; missing query params → no side effects; no CONVERTING plan → no modal. **Placement:** cards in `.grid-cols-2` parent; warnings banner above the grid; modal above everything. | New file; closes deferred ST-3. | | | |
+| 7 | **AC-CT-MODAL** *(ride-along ST-2)* | 2 | `ConfirmActionDialog` field coverage | **Presence:** `__tests__/contract/confirm-action-dialog.test.tsx`. Every `ConfirmActionConfig` field projects: `heading` as title, `description` as body, `reasonsLabel` above the reasons select, each `reasons[]` entry as an option, `keepLabel` + `confirmLabel` as buttons, `confirmIcon` on the confirm button, `other.label`+`placeholder`+`maxLength` reveal the free-text field with a character counter when "Other" is selected. **Absence:** without `confirmIcon`, no icon on confirm; without `other`, no free-text field; when `open=false`, none of the above in DOM. **Placement:** dialog in a Radix portal; reasons select above the optional free-text input; keep button left of confirm. | New file; closes deferred ST-2. (We're writing `conversion-modal.test.tsx` anyway — the modal/dialog test patterns transfer.) | | | |
+| 8 | **AC-PIN** | 3 | SDK SCAFFOLD pin updated for CONVERTING | **Presence:** `sdk-scaffold-pins.test.ts` snapshot includes the CONVERTING scaffold; the "all SCENARIOS keys we depend on are exported" assertion lists it. **Absence:** snapshot still date-stable (the bare-`YYYY-MM-DD` normalizer from v0.107.3 covers any renewal-date copy). **Placement:** snapshot in `__snapshots__/`. | Snapshot regenerated against SDK v0.5.0. | | | |
+| 9 | **AC-CT-COMMON-DEFER** | — | (not in scope) | The common-fields restructure (ST-1) stays deferred. Note here for traceability — Session 2 adds files, doesn't consolidate them. Bulk migration is cheaper later when a 3rd batch of states accrues. | n/a | | | |
+| 10 | **AC-FMT** | Pure | No new formatters expected | **Presence:** if CONVERTING's `statusInfo.descText` needs any computed formatting (progress %, elapsed time from `startedAt`), add a pure formatter to `formatters.ts` + a unit test. **Absence:** if the resolver supplies fully-formed copy (likely), no new formatter — `formatters.test.ts` unchanged. **Placement:** `formatters.ts` if added. | Likely a no-op; documented so the implementer checks. | | | |
+| 11 | **AC-DEV** | Page | `?scenario=dev-hosted-converting` in dev | **Presence:** `_fixtures/plan-scenarios.ts` gains a `dev-hosted-converting` entry (HB_TRIAL_CONVERTING + HB_NONE). `ALL_KEYS` includes it. Visiting `/admin/support/plans?scenario=dev-hosted-converting` in dev mounts the modal + freezes the page. **Absence:** the entry isn't in `ALL_KEYS` only if the SDK scaffold isn't available yet (then it's a TODO). **Placement:** fixture in `_fixtures/` (outside `__tests__/` — Vercel build excludes the latter). | Manual dev verification + the fixture entry exists. | | | |
+| 12 | **AC-CAP-CONVERTING** | 4 | Captured baseline for CONVERTING | **Presence:** after the provider deploys, `npm run plans:capture` writes `e2e/plans/captured/dev-hosted-converting.json`; `state.status === "CONVERTING"`; committed. The nightly drift workflow's `LABEL_TO_ID` (or the new id-keyed JSON) includes the converting scenario. **Absence:** if the provider hasn't deployed yet, the capture skips it — and with `STRICT_KEYS=1` in CI that's a hard fail, so the store PR can't merge until the provider side is live. **Placement:** `e2e/plans/captured/`. | Sequencing dependency: provider must deploy before the store PR merges. | | | |
+| 13 | **AC-VIS** | 6 | Screenshot for the converting scenario | **Presence:** `scripts/screenshot-plan-scenarios.ts` captures `dev-hosted-converting` (it loops `ALL_KEYS`, so this is automatic once the fixture entry exists). The PNG shows the modal overlaying a dimmed cards grid. **Absence:** n/a. **Placement:** `.screenshots/plan-scenarios/dev-hosted-converting.png`. | One screenshot, viewport-only (per CLAUDE.md — no `fullPage`). | | | |
+| 14 | **AC-DRIFT** | 2/3/4 | Drift-injection ritual | One injection per testable layer, run once before AC closes, documented in QC, then reverted. **Layer 2:** remove the `case "CONVERTING":` from the dispatch → TypeScript fails (non-exhaustive switch) — that's the test catching it; revert. Also: break the modal's "render when any plan is CONVERTING" condition → AC-CT-CONVERSION-MODAL fails; revert. **Layer 3:** patch a local SCAFFOLD value → snapshot diff; revert. **Layer 4:** edit `dev-hosted-converting.json` to set `status` to something outside the union → AC-CAP structural assertion fails; revert. | Same ritual as Session 1. | | | |
+| 15 | **AC-REG** | All | Regression + bookkeeping | **Presence:** `npm run typecheck` 0 errors; `npm run test:ci` 0 failures; `npm run test:e2e` 0 failures; `npm run precheck` 0 errors; `.claude/verification-status.json` updated for the branch with the right `acs_total`; CHANGELOG entry; version bump (minor — adds a user-visible-eventually feature, even if gated). **Absence:** no leftover TODO comments referencing missing SDK scaffolds once v0.5.0 is in; no `LABEL_TO_ID` drift if the platform regenerated `.dev-scenario-keys`. **Placement:** verification-status.json references this ACs doc. | Final gate. | | | |
+
+---
+
+## Sequencing
+
+Three PRs, must land in order. The drift nightly + `STRICT_KEYS=1` make the order enforced rather than just recommended:
+
+1. **SDK PR** (`feat/converting-state-and-mcp-ver`) — CONVERTING in the union + MCP version fix → tag v0.5.0 → push.
+2. **Platform PR** (`feat/converting-resolver`) — resolver emits CONVERTING + seed `dev-hosted-converting` → deploy. Bumps SDK ref to `#v0.5.0`.
+3. **Store PR** (`feat/converting-state`) — bump SDK ref, `ConvertingCard` dispatch (returns null), `ConversionModal`, page freeze, fixture entry, contract tests, ride-along ST-2/ST-3 tests, capture `dev-hosted-converting.json` after the provider deploys.
+
+The store PR's AC-CAP-CONVERTING can't pass until the provider is live (capture would skip the scenario; `STRICT_KEYS` fails). So the store PR is the last thing to merge, after a provider deploy.
+
+---
+
+## Updates to root docs after Session 2 lands
+
+- `plan.md` — mark SDK-RFC-CONVERTING, SDK-RFC-MCP-VER, SDK-v0.5.0, PR-CONVERTING-RESOLVER, PR-SEED-CONVERTING, ST-2, ST-3 as ✅ done. Remove the `LABEL_TO_ID` follow-up if the platform regenerated `.dev-scenario-keys` as id-keyed JSON.
+- `architecture.md` — new `ConvertingState` row in the per-field ownership table; D14 + D15 in the decisions log (see plan.md for proposed wording).
+- `session-1/ACs.md` — no change (Session 1 is closed).
+
+---
+
+## Total: 15 ACs
+
+13 substantive + AC-CT-COMMON-DEFER (traceability note) + AC-DRIFT (ritual) + AC-REG (gate). Two of the 13 (AC-CT-MODAL, AC-CT-PAGE) close deferred items ST-2 and ST-3.


### PR DESCRIPTION
## Summary

Docs-only — materializes the Session 2 plan from the planning discussion. No code.

- **`docs/features/provider-plan-sdk-alignment/session-2/ACs.md`** — 15 acceptance criteria. Covers: `CONVERTING` dispatch in `PlanCard` (returns `null` — modal owns the UX); `ConversionModal` contract (non-dismissable, polls `router.refresh()` ~5s, shows `statusInfo.descText`, closes when no plan is CONVERTING); page-freeze behind the modal (scroll lock + `pointer-events-none` + dim); ride-along ST-2 (`ConfirmActionDialog` field coverage) + ST-3 (page-level composition); SCAFFOLD pin update; `?scenario=dev-hosted-converting` dev override; captured baseline; screenshot; drift-injection ritual; regression gate. Plus a cross-repo prereqs table and the enforced SDK → platform → store sequencing.
- **`docs/features/provider-plan-sdk-alignment/plan.md`** — Session 2 section rewritten with the locked design decisions (SDK minor bump v0.5.0; bundle SDK-RFC-MCP-VER into that PR; conversion UX is modal-only — no Card; ride-alongs ST-2/ST-3 in). Deferred tracker refreshed (ST-2/ST-3 → Session 2; ST-1 → explicitly future; ST-4/ST-5 → unblocked by shipped infra; ST-8 → coordinate with platform PR #74; new ST-10 = retire `LABEL_TO_ID` once platform regenerates `.dev-scenario-keys` as id-keyed JSON; new PR-8 = P8, in progress on platform). Marked platform PRs #72/#73 landed.

## Locked decisions (recorded in plan.md)

| Q | Decision |
|---|---|
| SDK version bump for adding CONVERTING | **Minor (v0.5.0)** — union member breaks consumer `switch` exhaustiveness |
| MCP version-handshake fix (SDK-RFC-MCP-VER) | **Bundle into the v0.5.0 SDK PR** — both are SDK changes |
| ConvertingCard vs modal-only | **Modal-only.** `PlanCard` returns `null`; full-screen `ConversionModal` owns it; page frozen behind it so the customer can't navigate mid-transition. Card-vs-modal is the same backend work; modal-only is the safer UX. |
| Ride-along ST-2 (ConfirmActionDialog) + ST-3 (page composition) | **In.** Modal/dialog test patterns transfer; the modal needs page-level integration tests anyway. |

## Test plan

- [x] `npm run precheck` — passes (docs-only)
- [x] Markdown lint clean on both files
- [ ] Human review of the AC structure + sequencing before Session 2 implementation kicks off

## Note

`docs-only release` marker commit included so the PR-creation gate accepts a docs-only branch (no version bump, no CHANGELOG). Phase B (tagging) is skipped for docs-only.