### PR TITLE
feat: bump artisan-roast-sdk to v0.5.1 with PendingCard stub

### DIFF
--- a/app/admin/support/plans/PlanPageClient.tsx
+++ b/app/admin/support/plans/PlanPageClient.tsx
@@ -28,7 +28,8 @@ import type {
   HydratedPlan,
   PlanAction,
   UsagePool as SdkUsagePool,
-  ConfirmActionConfig,
+  FeedbackFormModal,
+  PendingState,
 } from "artisan-roast-sdk/plans";
 import {
   computePoolTotal,
@@ -102,7 +103,7 @@ export function PlanPageClient({ license, plans }: PlanPageClientProps) {
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
   const [activeModal, setActiveModal] = useState<{
-    config: ConfirmActionConfig;
+    config: FeedbackFormModal;
     slug: string;
   } | null>(null);
 
@@ -142,7 +143,11 @@ export function PlanPageClient({ license, plans }: PlanPageClientProps) {
   function handleAction(action: PlanAction, plan: HydratedPlan) {
     if (action.modalSlug) {
       const config = plan.actionModals?.find((m) => m.slug === action.modalSlug);
-      if (config) setActiveModal({ config, slug: action.modalSlug });
+      // Only the feedbackForm kind opens ConfirmActionDialog. The paymentConfirm
+      // modal kind ships with the next provider-plan-sdk-alignment session.
+      if (config?.type === "feedbackForm") {
+        setActiveModal({ config, slug: action.modalSlug });
+      }
       return;
     }
     if (action.url) {
@@ -303,6 +308,16 @@ function PlanCard({ plan, isPending, onAction }: PlanCardBaseProps) {
         <InactiveCard
           plan={plan}
           state={state}
+          onAction={onAction}
+          onCardClick={onCardClick}
+        />
+      );
+    case "PENDING":
+      return (
+        <PendingCard
+          plan={plan}
+          state={state}
+          isPending={isPending}
           onAction={onAction}
           onCardClick={onCardClick}
         />
@@ -943,6 +958,80 @@ function InactiveCard({
                 onAction(action, plan);
               }}
             >
+              {IconBefore && <IconBefore className="mr-1.5 h-3.5 w-3.5" />}
+              {action.label}
+              {Icon && <Icon className="ml-1.5 h-3.5 w-3.5" />}
+            </Button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PendingCard — provisional NONE-shaped card during post-conversion
+// provisioning (SDK PlanState "PENDING", added in v0.5.0).
+//
+// Minimal renderer: name + description + statusInfo (with a spinning icon)
+// + actions. The polished version with a polling-driven Check-Status flow
+// and the paymentConfirm launchpad ships with the next provider-plan-sdk-
+// alignment session — see docs/features/provider-plan-sdk-alignment/session-2
+// (CONVERTING→PENDING reframe).
+// ---------------------------------------------------------------------------
+
+function PendingCard({
+  plan,
+  state,
+  isPending,
+  onAction,
+  onCardClick,
+}: {
+  plan: HydratedPlan;
+  state: PendingState;
+  isPending: boolean;
+  onAction: (action: PlanAction, plan: HydratedPlan) => void;
+  onCardClick: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <div
+      className="flex flex-col rounded-lg border p-6 space-y-5 transition-shadow hover:shadow-lg cursor-pointer"
+      onClick={onCardClick}
+    >
+      <div>
+        <h3 className="text-lg font-semibold">{plan.name}</h3>
+        <p className="text-sm text-muted-foreground mt-1">{plan.description}</p>
+      </div>
+
+      {state.statusInfo?.descText && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          {/* descIcon is ignored for now — PENDING uses Loader2 by convention.
+              A polished version that dispatches on state.statusInfo.descIcon
+              ships with the next provider-plan-sdk-alignment session. */}
+          <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+          <span>{state.statusInfo.descText}</span>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 mt-auto pt-0">
+        <div className="flex-1" />
+        {state.actions.map((action) => {
+          const Icon = action.iconAfter ? resolveIcon(action.iconAfter) : null;
+          const IconBefore = action.iconBefore ? resolveIcon(action.iconBefore) : null;
+          return (
+            <Button
+              key={action.slug}
+              variant={actionVariant(action.variant)}
+              size="sm"
+              disabled={isPending || action.disabled}
+              onClick={(e) => {
+                e.stopPropagation();
+                onAction(action, plan);
+              }}
+            >
+              {isPending && action.variant === "primary" && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
               {IconBefore && <IconBefore className="mr-1.5 h-3.5 w-3.5" />}
               {action.label}
               {Icon && <Icon className="ml-1.5 h-3.5 w-3.5" />}

--- a/app/admin/support/plans/__tests__/__snapshots__/sdk-scaffold-pins.test.ts.snap
+++ b/app/admin/support/plans/__tests__/__snapshots__/sdk-scaffold-pins.test.ts.snap
@@ -170,6 +170,63 @@ exports[`SDK SCAFFOLD pins SCAFFOLDS shape is pinned 1`] = `
     },
     "visibility": "hosted",
   },
+  "PENDING": {
+    "actionModals": [
+      {
+        "confirmLabel": "Confirm and pay",
+        "description": "You'll be charged $79.00/month. Cancel anytime.",
+        "heading": "Completing your subscription",
+        "processingMessages": [
+          "Processing payment…",
+          "Almost there…",
+        ],
+        "slug": "convert-payment",
+        "type": "paymentConfirm",
+      },
+    ],
+    "currency": "USD",
+    "description": "Fully managed hosting with custom domain and priority support.",
+    "details": {
+      "benefits": {
+        "activeItems": [
+          "Everything in Community Roast",
+          "Managed hosting & backups",
+          "Custom domain configuration",
+          "5 priority support tickets/month, 48-hr SLA",
+        ],
+      },
+      "sla": {
+        "responseTime": "48 hours",
+      },
+    },
+    "features": [
+      "hosting",
+      "custom-domain",
+      "priority-support",
+      "tickets",
+    ],
+    "highlight": true,
+    "interval": "month",
+    "name": "House Blend",
+    "price": 7900,
+    "slug": "house-blend",
+    "state": {
+      "actions": [
+        {
+          "endpoint": "/api/plans/status",
+          "label": "Check Status",
+          "slug": "check-status",
+          "variant": "primary",
+        },
+      ],
+      "status": "PENDING",
+      "statusInfo": {
+        "descIcon": "loader-2",
+        "descText": "Setting up your store — this can take a few minutes.",
+      },
+    },
+    "visibility": "hosted",
+  },
   "PRIORITY_SUPPORT_ACTIVE": {
     "actionModals": [
       {
@@ -201,6 +258,7 @@ exports[`SDK SCAFFOLD pins SCAFFOLDS shape is pinned 1`] = `
         ],
         "reasonsLabel": "Reason for cancelling",
         "slug": "cancel-subscription",
+        "type": "feedbackForm",
       },
     ],
     "currency": "USD",
@@ -567,6 +625,7 @@ exports[`SDK SCAFFOLD pins SCAFFOLDS shape is pinned 1`] = `
         ],
         "reasonsLabel": "Reason for cancelling",
         "slug": "cancel-trial",
+        "type": "feedbackForm",
       },
       {
         "confirmIcon": "external-link",
@@ -603,6 +662,7 @@ exports[`SDK SCAFFOLD pins SCAFFOLDS shape is pinned 1`] = `
         ],
         "reasonsLabel": "Reason for cancelling",
         "slug": "cancel-stripe",
+        "type": "feedbackForm",
       },
     ],
     "currency": "USD",
@@ -688,6 +748,7 @@ exports[`SDK SCAFFOLD pins SCAFFOLDS shape is pinned 1`] = `
         ],
         "reasonsLabel": "Reason for cancelling",
         "slug": "cancel-trial",
+        "type": "feedbackForm",
       },
       {
         "confirmIcon": "external-link",
@@ -724,6 +785,7 @@ exports[`SDK SCAFFOLD pins SCAFFOLDS shape is pinned 1`] = `
         ],
         "reasonsLabel": "Reason for cancelling",
         "slug": "cancel-stripe",
+        "type": "feedbackForm",
       },
     ],
     "currency": "USD",

--- a/app/admin/support/plans/__tests__/sdk-scaffold-pins.test.ts
+++ b/app/admin/support/plans/__tests__/sdk-scaffold-pins.test.ts
@@ -55,6 +55,7 @@ describe("SDK SCAFFOLD pins", () => {
       "TRIAL_ACTIVE_NO_CARD",
       "TRIAL_ACTIVE_CARD_ADDED",
       "TRIAL_EXPIRED",
+      "PENDING",
       "CONVERTED",
       "DIRECT_SUBSCRIBE",
       "INACTIVE",

--- a/app/admin/support/plans/_components/ConfirmActionDialog.tsx
+++ b/app/admin/support/plans/_components/ConfirmActionDialog.tsx
@@ -25,7 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 
 import { submitCancellation } from "../actions";
-import type { ConfirmActionConfig } from "artisan-roast-sdk/plans";
+import type { FeedbackFormModal } from "artisan-roast-sdk/plans";
 
 const OTHER_TEXT_MAX = 500;
 
@@ -39,8 +39,12 @@ interface ConfirmActionDialogProps {
   /** When true, the customer has billing on file — flow redirects to
    *  Stripe Portal. When false, a UI-mock cancel is captured client-side. */
   cardAdded: boolean;
-  /** Modal copy + reason list from the plan payload. */
-  config?: ConfirmActionConfig;
+  /**
+   * Modal copy + reason list from the plan payload. Restricted to
+   * `FeedbackFormModal` — the `paymentConfirm` modal kind is a separate
+   * component (deferred to the next provider-plan-sdk-alignment session).
+   */
+  config?: FeedbackFormModal;
 }
 
 // ---------------------------------------------------------------------------

--- a/app/admin/support/plans/_fixtures/plan-scenarios.ts
+++ b/app/admin/support/plans/_fixtures/plan-scenarios.ts
@@ -85,9 +85,11 @@ export const SCENARIO_FIXTURES = {
   "dev-hosted-cancelled-card": [TRIAL_CANCELLED_WITH_CARD],
   "dev-hosted-inactive":       [SCENARIOS.INACTIVE],
 
+  // ── Hosted: PENDING (post-conversion provisioning, SDK v0.5.0) ─────────
+  "dev-hosted-pending":        [SCENARIOS.PENDING],
+
   // ── Empty (resolver returns no cards) ──────────────────────────────────
   "dev-hosted-cancelled":      [],
-  "dev-hosted-pending":        [],
   "dev-hosted-provisioning":   [],
   "dev-hosted-deprovisioned":  [],
 } satisfies Record<string, HydratedPlan[]>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "@vercel/blob": "^2.3.0",
         "@vercel/speed-insights": "^1.3.1",
         "archiver": "^7.0.1",
-        "artisan-roast-sdk": "github:yuens1002/artisan-roast-sdk#v0.4.1",
+        "artisan-roast-sdk": "github:yuens1002/artisan-roast-sdk#v0.5.1",
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -7723,8 +7723,8 @@
       }
     },
     "node_modules/artisan-roast-sdk": {
-      "version": "0.4.1",
-      "resolved": "git+ssh://git@github.com/yuens1002/artisan-roast-sdk.git#1d26c7088a90638bc72927894c8eb96e7ed00f8d",
+      "version": "0.5.1",
+      "resolved": "git+ssh://git@github.com/yuens1002/artisan-roast-sdk.git#bdb83a3353b4805b221bb9593faffc10ccd0cb54",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@vercel/blob": "^2.3.0",
     "@vercel/speed-insights": "^1.3.1",
     "archiver": "^7.0.1",
-    "artisan-roast-sdk": "github:yuens1002/artisan-roast-sdk#v0.4.1",
+    "artisan-roast-sdk": "github:yuens1002/artisan-roast-sdk#v0.5.1",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
Step 12 follow-up to the [artisan-roast-sdk v0.5.0 + v0.5.1 release](https://github.com/yuens1002/artisan-roast-sdk/pull/5).

## Why

`artisan-roast-sdk` v0.5.0 introduced two breaking type changes:

1. `Plan.actionModals[]` is now a **discriminated union** on `type` — `FeedbackFormModal` (`type: "feedbackForm"`) and `PaymentConfirmModal` (`type: "paymentConfirm"`). `ConfirmActionConfig` is gone.
2. A new `PlanState.status === "PENDING"` variant for post-paid-conversion provisioning. The dispatch `switch` on `state.status` is no longer exhaustive without a `PENDING` branch.

v0.5.1 was a patch (TS/schema alignment, spec examples) — runtime API unchanged from 0.5.0.

This PR brings the store onto v0.5.1 so it compiles cleanly against the new types and renders `PENDING` plans with something sensible rather than blowing up. The polished `PendingCard` (polling-driven Check-Status spinner + `paymentConfirm` modal launchpad) is **deferred** to the next provider-plan-sdk-alignment session — see `docs/features/provider-plan-sdk-alignment/session-2` (CONVERTING→PENDING reframe), which `main` already flags.

## What changed

| File | Change |
|------|--------|
| `package.json` / `package-lock.json` | `artisan-roast-sdk` pinned to `github:yuens1002/artisan-roast-sdk#v0.5.1` (was `#v0.4.1`) |
| `app/admin/support/plans/_components/ConfirmActionDialog.tsx` | `ConfirmActionConfig` import → `FeedbackFormModal`; prop type narrowed (the dialog renders the reasons-dropdown flow exclusively — the `paymentConfirm` modal kind is a separate future component) |
| `app/admin/support/plans/PlanPageClient.tsx` | `ConfirmActionConfig` import → `FeedbackFormModal` + `PendingState`; `activeModal` state typed `FeedbackFormModal`; `handleAction` narrows `m.type === "feedbackForm"` before opening the dialog (paymentConfirm intentionally ignored for now); new `case "PENDING": return <PendingCard … />` makes the switch exhaustive; new `PendingCard` component (minimal renderer — name + description + statusInfo with spinner + actions) |
| `app/admin/support/plans/_fixtures/plan-scenarios.ts` | `"dev-hosted-pending"` scenario populated with `SCENARIOS.PENDING` (was the empty-array placeholder) |
| `app/admin/support/plans/__tests__/__snapshots__/sdk-scaffold-pins.test.ts.snap` | SDK scaffold pins snapshot updated for the new `type: "feedbackForm"` discriminator added across existing scaffolds + the new `SCENARIOS.PENDING` entry. Test was designed to catch exactly this drift; reviewer-accepted via `--ci -u` |

## What's NOT in this PR (deferred, intentional)

- **Polished `PendingCard`** — polling-driven Check-Status flow (poll `/api/plans/status`, refresh state until `ACTIVE`), proper layout, accessible status-region semantics. The stub here renders the contract; the next provider-plan-sdk-alignment session adds the behaviour.
- **`PaymentConfirmModal` rendering.** `handleAction` currently ignores `modalSlug` references that resolve to a `paymentConfirm` entry. The companion `paymentConfirm` dialog (confirm-the-charge → non-dismissable spinner → `processingMessages` cycle, then plan flips to `PENDING`) ships alongside the polished `PendingCard`.
- **`descIcon` dispatch on `statusInfo`.** Stub `PendingCard` uses `Loader2` directly (matches the SDK scaffold's `descIcon: "loader-2"`). A general Lucide-name → component lookup will land with the polished card.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (1 pre-existing warning in `useReviewsTable.tsx` re: TanStack Table, unrelated)
- [x] `npx jest app/admin/support/plans --ci` — 84/84 pass, 1 snapshot updated and re-verified
- [x] Existing scaffold-pins test surfaced the `type: "feedbackForm"` additions on every modal as designed → updated and re-verified

## Linked

- SDK: https://github.com/yuens1002/artisan-roast-sdk/pull/5 (v0.5.0), https://github.com/yuens1002/artisan-roast-sdk/pull/6 (v0.5.1)
- Platform: https://github.com/dev-yuen-agency/artisan-roast-platform/pull/79