### PR TITLE
chore: bump version to 0.108.1

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,8 @@ const eslintConfig = defineConfig([
       ".scratchpad/**",
       ".screenshots/**",
       "scratchpad/**",
+      // Claude Code worktrees (git worktrees used for parallel development)
+      ".claude/**",
     ],
   },
   ...nextVitals,

--- a/jest.config.js
+++ b/jest.config.js
@@ -34,6 +34,7 @@ const config = {
     "/__tests__/fixtures([/\\\\]|\\.ts$)", // Fixture files and directories are not test suites
     "/__tests__/integration/", // Integration tests require a live dev server — run with test:integration
     "/__tests__/.*/_[^/]+$", // Underscore-prefixed files in __tests__/ subdirs are helpers, not suites
+    "/.claude/", // Claude Code worktrees and hooks (not app code)
   ],
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.108.0",
+  "version": "0.108.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.108.0",
+      "version": "0.108.1",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.108.0",
+  "version": "0.108.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Version bump to `0.108.1` for Vercel build (patch for #389 baseline refresh)
- Fix ESLint and Jest configs to ignore `.claude/` worktrees — were previously being scanned and causing false errors/failures

## Test plan

- [x] `npm run precheck` — 0 errors
- [x] `npm run test:ci` — 1431 tests pass