### PR TITLE
chore(e2e): refresh plans baseline post-platform-v0.26.0 (v0.108.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- Refreshed `e2e/plans/captured/*.json` baselines against platform v0.26.0 (S2b resolver rewrite). All 9 changed scenarios map to documented AC-EXP-1..10 or additional expected changes.
+- Refreshed `e2e/plans/captured/*.json` baselines against platform v0.26.0 (S2b resolver rewrite). All changed scenarios map to documented AC-EXP-1..10 or additional expected changes.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 0.108.2 - 2026-05-26
+
+### Changed
+
+- Refreshed `e2e/plans/captured/*.json` baselines against platform v0.26.0 (S2b resolver rewrite). All 9 changed scenarios map to documented AC-EXP-1..10 or additional expected changes.
+
+### Fixed
+
+- `scripts/capture-plan-scenarios.ts` `loadKeys()` now correctly extracts `.licenseKey` from the nested `{ licenseKey, label, tier }` format in `dev-scenario-keys.public.json`.
+
 ## 0.108.0 - 2026-05-13
 
 ### Added

--- a/e2e/plans/captured/dev-free.json
+++ b/e2e/plans/captured/dev-free.json
@@ -2,7 +2,7 @@
   "plans": [
     {
       "slug": "free",
-      "name": "Community",
+      "name": "Community Roast",
       "description": "Open-source self-hosted store with community support",
       "price": 0,
       "currency": "usd",
@@ -36,8 +36,8 @@
           {
             "slug": "view-terms",
             "label": "View Terms",
-            "url": "/admin/terms/terms-of-service",
-            "variant": "ghost"
+            "variant": "ghost",
+            "url": "/admin/terms/terms-of-service"
           }
         ]
       }
@@ -106,8 +106,8 @@
       "visibility": "self-hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-subscription",
+          "type": "feedbackForm",
           "heading": "Cancel your subscription?",
           "reasons": [
             {
@@ -149,16 +149,17 @@
         "status": "NONE",
         "actions": [
           {
-            "slug": "view-details",
-            "label": "View Details",
-            "url": "/admin/support/plans/priority-support",
-            "variant": "ghost"
-          },
-          {
             "slug": "subscribe",
             "label": "Subscribe",
             "iconAfter": "external-link",
-            "variant": "primary"
+            "variant": "primary",
+            "endpoint": "/api/checkout?planSlug=priority-support"
+          },
+          {
+            "slug": "view-details",
+            "label": "View Details",
+            "variant": "ghost",
+            "url": "/admin/support/plans/priority-support"
           }
         ]
       }

--- a/e2e/plans/captured/dev-hosted-active-card.json
+++ b/e2e/plans/captured/dev-hosted-active-card.json
@@ -24,8 +24,8 @@
       "visibility": "hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-trial",
+          "type": "feedbackForm",
           "other": {
             "label": "Tell us a bit more",
             "maxLength": 500,
@@ -60,8 +60,8 @@
           "reasonsLabel": "Reason for cancelling"
         },
         {
-          "type": "feedbackForm",
           "slug": "cancel-stripe",
+          "type": "feedbackForm",
           "other": {
             "label": "Tell us a bit more",
             "maxLength": 500,
@@ -95,32 +95,51 @@
           "description": "Your card is on file. Cancel to stop any future charges.",
           "confirmLabel": "Continue to Stripe",
           "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "paymentConfirm",
+          "type": "paymentConfirm",
+          "heading": "Completing your subscription",
+          "description": "We'll redirect you to Stripe to confirm payment.",
+          "confirmLabel": "Continue to Stripe",
+          "processingMessages": [
+            "Talking to Stripe…",
+            "Confirming your payment…",
+            "Almost there — setting up your store…"
+          ]
         }
       ],
       "state": {
         "status": "TRIAL",
         "badge": "Extended",
-        "badgeIcon": "clock",
+        "badgeIcon": "CircleCheckBig",
         "pools": [
           {
             "slug": "trial-days",
             "label": "Trial days",
-            "icon": "calendar",
-            "countLabel": "passed",
             "limit": 30,
-            "used": 0
+            "used": 7,
+            "icon": "clock",
+            "countLabel": "passed"
           }
         ],
+        "deprovisionAt": "2026-06-18T01:22:45.615Z",
         "statusInfo": {
           "descText": "Trial ends June 18, 2026"
         },
-        "deprovisionAt": "2026-06-18T01:22:45.615Z",
         "actions": [
+          {
+            "slug": "convert-now",
+            "label": "Subscribe Now",
+            "iconAfter": "external-link",
+            "variant": "primary",
+            "endpoint": "/api/trial/hosted/cmox7sxd4000jl4obt4qry06v/convert-now"
+          },
           {
             "slug": "cancel-trial",
             "label": "Cancel Trial",
-            "endpoint": "/api/trial/cancel",
             "variant": "ghost",
+            "endpoint": "/api/trial/cancel",
             "modalSlug": "cancel-stripe"
           }
         ]
@@ -170,8 +189,8 @@
       "visibility": "hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-subscription",
+          "type": "feedbackForm",
           "heading": "Cancel your subscription?",
           "reasons": [
             {
@@ -214,8 +233,8 @@
           {
             "slug": "view-details",
             "label": "View Details",
-            "url": "/admin/support/plans/house-blend",
-            "variant": "ghost"
+            "variant": "ghost",
+            "url": "/admin/support/plans/house-blend"
           }
         ]
       }

--- a/e2e/plans/captured/dev-hosted-active-no-card.json
+++ b/e2e/plans/captured/dev-hosted-active-no-card.json
@@ -24,8 +24,8 @@
       "visibility": "hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-trial",
+          "type": "feedbackForm",
           "other": {
             "label": "Tell us a bit more",
             "maxLength": 500,
@@ -60,8 +60,8 @@
           "reasonsLabel": "Reason for cancelling"
         },
         {
-          "type": "feedbackForm",
           "slug": "cancel-stripe",
+          "type": "feedbackForm",
           "other": {
             "label": "Tell us a bit more",
             "maxLength": 500,
@@ -95,32 +95,44 @@
           "description": "Your card is on file. Cancel to stop any future charges.",
           "confirmLabel": "Continue to Stripe",
           "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "paymentConfirm",
+          "type": "paymentConfirm",
+          "heading": "Completing your subscription",
+          "description": "We'll redirect you to Stripe to confirm payment.",
+          "confirmLabel": "Continue to Stripe",
+          "processingMessages": [
+            "Talking to Stripe…",
+            "Confirming your payment…",
+            "Almost there — setting up your store…"
+          ]
         }
       ],
       "state": {
         "status": "TRIAL",
         "badge": "Active",
-        "badgeIcon": "clock",
+        "badgeIcon": "CircleCheckBig",
         "pools": [
           {
             "slug": "trial-days",
             "label": "Trial days",
-            "icon": "calendar",
-            "countLabel": "passed",
             "limit": 14,
-            "used": 0
+            "used": 7,
+            "icon": "clock",
+            "countLabel": "passed"
           }
         ],
+        "deprovisionAt": "2026-06-18T01:22:45.615Z",
         "statusInfo": {
           "descText": "Trial ends June 2, 2026"
         },
-        "deprovisionAt": "2026-06-18T01:22:45.615Z",
         "actions": [
           {
             "slug": "cancel-trial",
             "label": "Cancel Trial",
-            "endpoint": "/api/trial/cancel",
             "variant": "ghost",
+            "endpoint": "/api/trial/cancel",
             "modalSlug": "cancel-trial"
           }
         ]
@@ -170,8 +182,8 @@
       "visibility": "hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-subscription",
+          "type": "feedbackForm",
           "heading": "Cancel your subscription?",
           "reasons": [
             {
@@ -214,8 +226,8 @@
           {
             "slug": "view-details",
             "label": "View Details",
-            "url": "/admin/support/plans/house-blend",
-            "variant": "ghost"
+            "variant": "ghost",
+            "url": "/admin/support/plans/house-blend"
           }
         ]
       }

--- a/e2e/plans/captured/dev-hosted-cancelled-card.json
+++ b/e2e/plans/captured/dev-hosted-cancelled-card.json
@@ -24,8 +24,8 @@
       "visibility": "hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-trial",
+          "type": "feedbackForm",
           "other": {
             "label": "Tell us a bit more",
             "maxLength": 500,
@@ -60,8 +60,8 @@
           "reasonsLabel": "Reason for cancelling"
         },
         {
-          "type": "feedbackForm",
           "slug": "cancel-stripe",
+          "type": "feedbackForm",
           "other": {
             "label": "Tell us a bit more",
             "maxLength": 500,
@@ -95,12 +95,24 @@
           "description": "Your card is on file. Cancel to stop any future charges.",
           "confirmLabel": "Continue to Stripe",
           "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "paymentConfirm",
+          "type": "paymentConfirm",
+          "heading": "Completing your subscription",
+          "description": "We'll redirect you to Stripe to confirm payment.",
+          "confirmLabel": "Continue to Stripe",
+          "processingMessages": [
+            "Talking to Stripe…",
+            "Confirming your payment…",
+            "Almost there — setting up your store…"
+          ]
         }
       ],
       "state": {
         "status": "CANCELLED",
         "badge": "Cancelled",
-        "daysRemaining": 14,
+        "daysRemaining": 7,
         "daysLimit": 30,
         "deprovisionAt": "2026-06-02T01:22:45.615Z",
         "statusInfo": {

--- a/e2e/plans/captured/dev-hosted-converted.json
+++ b/e2e/plans/captured/dev-hosted-converted.json
@@ -44,8 +44,8 @@
       "visibility": "hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-subscription",
+          "type": "feedbackForm",
           "heading": "Cancel your subscription?",
           "reasons": [
             {
@@ -85,30 +85,38 @@
       "state": {
         "status": "ACTIVE",
         "badge": "Active",
+        "badgeIcon": "CircleCheckBig",
         "pools": [
           {
             "slug": "tickets",
             "label": "Priority tickets",
+            "limit": 5,
+            "used": 0,
             "icon": "ticket",
             "countLabel": "used",
-            "limit": 5,
-            "used": 0
+            "purchased": 0,
+            "cta": {
+              "link": "https://artisanroast.app/support/ticket",
+              "slug": "submit-ticket",
+              "label": "Submit Ticket",
+              "iconAfter": "external-link"
+            }
           }
         ],
         "actions": [
           {
-            "slug": "view-details",
-            "label": "View Details",
-            "url": "/admin/support/plans/house-blend",
-            "variant": "ghost"
-          },
-          {
             "slug": "manage-billing",
             "label": "Manage Billing",
-            "endpoint": "/api/billing/portal",
             "iconAfter": "external-link",
             "variant": "secondary",
+            "endpoint": "/api/billing/portal",
             "modalSlug": "cancel-subscription"
+          },
+          {
+            "slug": "view-details",
+            "label": "View Details",
+            "variant": "ghost",
+            "url": "/admin/support/plans/house-blend"
           }
         ]
       }

--- a/e2e/plans/captured/dev-hosted-expired.json
+++ b/e2e/plans/captured/dev-hosted-expired.json
@@ -24,8 +24,8 @@
       "visibility": "hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-trial",
+          "type": "feedbackForm",
           "other": {
             "label": "Tell us a bit more",
             "maxLength": 500,
@@ -60,8 +60,8 @@
           "reasonsLabel": "Reason for cancelling"
         },
         {
-          "type": "feedbackForm",
           "slug": "cancel-stripe",
+          "type": "feedbackForm",
           "other": {
             "label": "Tell us a bit more",
             "maxLength": 500,
@@ -95,27 +95,45 @@
           "description": "Your card is on file. Cancel to stop any future charges.",
           "confirmLabel": "Continue to Stripe",
           "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "paymentConfirm",
+          "type": "paymentConfirm",
+          "heading": "Completing your subscription",
+          "description": "We'll redirect you to Stripe to confirm payment.",
+          "confirmLabel": "Continue to Stripe",
+          "processingMessages": [
+            "Talking to Stripe…",
+            "Confirming your payment…",
+            "Almost there — setting up your store…"
+          ]
         }
       ],
       "state": {
         "status": "EXPIRED",
         "badge": "Expired",
-        "badgeIcon": "alert-circle",
         "pools": [
           {
             "slug": "trial-days",
             "label": "Trial days",
-            "icon": "calendar",
-            "countLabel": "passed",
             "limit": 14,
-            "used": 14
+            "used": 14,
+            "icon": "clock",
+            "countLabel": "passed"
           }
         ],
         "deprovisionAt": "2026-06-18T01:22:45.615Z",
         "statusInfo": {
           "descText": "Your 14 day trial ended. Add billing to extend up to 30 days."
         },
-        "actions": []
+        "actions": [
+          {
+            "slug": "delete-trial",
+            "label": "Delete Trial",
+            "variant": "ghost",
+            "endpoint": "/api/trial/delete"
+          }
+        ]
       }
     },
     {
@@ -162,8 +180,8 @@
       "visibility": "hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-subscription",
+          "type": "feedbackForm",
           "heading": "Cancel your subscription?",
           "reasons": [
             {
@@ -206,8 +224,8 @@
           {
             "slug": "view-details",
             "label": "View Details",
-            "url": "/admin/support/plans/house-blend",
-            "variant": "ghost"
+            "variant": "ghost",
+            "url": "/admin/support/plans/house-blend"
           }
         ]
       }

--- a/e2e/plans/captured/dev-hosted-inactive.json
+++ b/e2e/plans/captured/dev-hosted-inactive.json
@@ -44,8 +44,8 @@
       "visibility": "hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-subscription",
+          "type": "feedbackForm",
           "heading": "Cancel your subscription?",
           "reasons": [
             {
@@ -85,14 +85,13 @@
       "state": {
         "status": "INACTIVE",
         "badge": "Inactive",
-        "badgeIcon": "circle-slash",
         "deactivatedAt": "2026-05-12T01:22:45.615Z",
         "actions": [
           {
             "slug": "view-details",
             "label": "View Details",
-            "url": "/admin/support/plans/house-blend",
-            "variant": "ghost"
+            "variant": "ghost",
+            "url": "/admin/support/plans/house-blend"
           }
         ]
       }

--- a/e2e/plans/captured/dev-hosted-pending.json
+++ b/e2e/plans/captured/dev-hosted-pending.json
@@ -24,8 +24,8 @@
       "visibility": "hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-trial",
+          "type": "feedbackForm",
           "other": {
             "label": "Tell us a bit more",
             "maxLength": 500,
@@ -60,8 +60,8 @@
           "reasonsLabel": "Reason for cancelling"
         },
         {
-          "type": "feedbackForm",
           "slug": "cancel-stripe",
+          "type": "feedbackForm",
           "other": {
             "label": "Tell us a bit more",
             "maxLength": 500,
@@ -95,6 +95,18 @@
           "description": "Your card is on file. Cancel to stop any future charges.",
           "confirmLabel": "Continue to Stripe",
           "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "paymentConfirm",
+          "type": "paymentConfirm",
+          "heading": "Completing your subscription",
+          "description": "We'll redirect you to Stripe to confirm payment.",
+          "confirmLabel": "Continue to Stripe",
+          "processingMessages": [
+            "Talking to Stripe…",
+            "Confirming your payment…",
+            "Almost there — setting up your store…"
+          ]
         }
       ],
       "state": {

--- a/e2e/plans/captured/dev-hosted-provisioning.json
+++ b/e2e/plans/captured/dev-hosted-provisioning.json
@@ -24,8 +24,8 @@
       "visibility": "hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-trial",
+          "type": "feedbackForm",
           "other": {
             "label": "Tell us a bit more",
             "maxLength": 500,
@@ -60,8 +60,8 @@
           "reasonsLabel": "Reason for cancelling"
         },
         {
-          "type": "feedbackForm",
           "slug": "cancel-stripe",
+          "type": "feedbackForm",
           "other": {
             "label": "Tell us a bit more",
             "maxLength": 500,
@@ -95,6 +95,18 @@
           "description": "Your card is on file. Cancel to stop any future charges.",
           "confirmLabel": "Continue to Stripe",
           "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "paymentConfirm",
+          "type": "paymentConfirm",
+          "heading": "Completing your subscription",
+          "description": "We'll redirect you to Stripe to confirm payment.",
+          "confirmLabel": "Continue to Stripe",
+          "processingMessages": [
+            "Talking to Stripe…",
+            "Confirming your payment…",
+            "Almost there — setting up your store…"
+          ]
         }
       ],
       "state": {

--- a/e2e/plans/captured/dev-pro-inactive.json
+++ b/e2e/plans/captured/dev-pro-inactive.json
@@ -2,7 +2,7 @@
   "plans": [
     {
       "slug": "free",
-      "name": "Community",
+      "name": "Community Roast",
       "description": "Open-source self-hosted store with community support",
       "price": 0,
       "currency": "usd",
@@ -36,8 +36,8 @@
           {
             "slug": "view-terms",
             "label": "View Terms",
-            "url": "/admin/terms/terms-of-service",
-            "variant": "ghost"
+            "variant": "ghost",
+            "url": "/admin/terms/terms-of-service"
           }
         ]
       }
@@ -106,8 +106,8 @@
       "visibility": "self-hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-subscription",
+          "type": "feedbackForm",
           "heading": "Cancel your subscription?",
           "reasons": [
             {
@@ -148,20 +148,20 @@
       "state": {
         "status": "INACTIVE",
         "badge": "Inactive",
-        "badgeIcon": "circle-slash",
         "deactivatedAt": "2026-04-19T01:22:45.615Z",
         "actions": [
-          {
-            "slug": "view-details",
-            "label": "View Details",
-            "url": "/admin/support/plans/priority-support",
-            "variant": "ghost"
-          },
           {
             "slug": "renew",
             "label": "Renew",
             "iconAfter": "external-link",
-            "variant": "primary"
+            "variant": "primary",
+            "endpoint": "/api/checkout?planSlug=priority-support"
+          },
+          {
+            "slug": "view-details",
+            "label": "View Details",
+            "variant": "ghost",
+            "url": "/admin/support/plans/priority-support"
           }
         ]
       }

--- a/e2e/plans/captured/dev-pro.json
+++ b/e2e/plans/captured/dev-pro.json
@@ -2,7 +2,7 @@
   "plans": [
     {
       "slug": "free",
-      "name": "Community",
+      "name": "Community Roast",
       "description": "Open-source self-hosted store with community support",
       "price": 0,
       "currency": "usd",
@@ -33,8 +33,8 @@
           {
             "slug": "view-terms",
             "label": "View Terms",
-            "url": "/admin/terms/terms-of-service",
-            "variant": "ghost"
+            "variant": "ghost",
+            "url": "/admin/terms/terms-of-service"
           }
         ]
       }
@@ -103,8 +103,8 @@
       "visibility": "self-hosted",
       "actionModals": [
         {
-          "type": "feedbackForm",
           "slug": "cancel-subscription",
+          "type": "feedbackForm",
           "heading": "Cancel your subscription?",
           "reasons": [
             {
@@ -145,55 +145,54 @@
       "state": {
         "status": "ACTIVE",
         "badge": "Active",
+        "badgeIcon": "CircleCheckBig",
         "pools": [
           {
             "slug": "tickets",
             "label": "Priority tickets",
-            "icon": "ticket",
-            "countLabel": "used",
             "limit": 5,
             "used": 0,
+            "icon": "ticket",
+            "countLabel": "used",
             "purchased": 0,
             "cta": {
+              "link": "https://artisanroast.app/support/ticket",
               "slug": "submit-ticket",
               "label": "Submit Ticket",
-              "url": "https://artisanroast.app/support/ticket",
-              "iconAfter": "external-link",
-              "variant": "primary"
+              "iconAfter": "external-link"
             }
           },
           {
             "slug": "one-on-one",
             "label": "1:1 sessions",
-            "icon": "calendar",
-            "countLabel": "used",
             "limit": 1,
             "used": 0,
+            "icon": "calendar",
+            "countLabel": "used",
             "purchased": 0,
             "cta": {
+              "link": "https://calendly.com/syuen-sbgrp/get_to_know_you",
               "slug": "book-session",
               "label": "Book Session",
-              "url": "Scheduled via Calendly link provided after subscription",
-              "iconBefore": "calendar",
               "iconAfter": "external-link",
-              "variant": "secondary"
+              "iconBefore": "calendar"
             }
           }
         ],
         "actions": [
           {
-            "slug": "view-details",
-            "label": "View Details",
-            "url": "/admin/support/plans/priority-support",
-            "variant": "ghost"
-          },
-          {
             "slug": "manage-billing",
             "label": "Manage Billing",
-            "endpoint": "/api/billing/portal",
             "iconAfter": "external-link",
             "variant": "secondary",
+            "endpoint": "/api/billing/portal",
             "modalSlug": "cancel-subscription"
+          },
+          {
+            "slug": "view-details",
+            "label": "View Details",
+            "variant": "ghost",
+            "url": "/admin/support/plans/priority-support"
           }
         ]
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.108.1",
+  "version": "0.108.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.108.1",
+      "version": "0.108.2",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.108.1",
+  "version": "0.108.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/scripts/capture-plan-scenarios.ts
+++ b/scripts/capture-plan-scenarios.ts
@@ -115,9 +115,19 @@ function parseEnvFile(text: string): Record<string, string> {
   return out;
 }
 
+function normalizeKeyMap(raw: Record<string, string | { licenseKey: string }>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(raw).map(([k, v]) => {
+      if (typeof v === "string") return [k, v];
+      if (v && typeof v === "object" && typeof v.licenseKey === "string") return [k, v.licenseKey];
+      throw new Error(`loadKeys: value for key "${k}" is neither a string nor { licenseKey: string }`);
+    })
+  );
+}
+
 async function loadKeys(): Promise<Record<string, string>> {
   if (process.env.DEV_KEYS_JSON) {
-    return JSON.parse(process.env.DEV_KEYS_JSON);
+    return normalizeKeyMap(JSON.parse(process.env.DEV_KEYS_JSON));
   }
   const file = process.env.DEV_KEYS_FILE;
   if (!file) {
@@ -129,10 +139,7 @@ async function loadKeys(): Promise<Record<string, string>> {
   // DEV_KEYS_JSON.
   const trimmed = text.trimStart();
   if (trimmed.startsWith("{")) {
-    const parsed = JSON.parse(text) as Record<string, string | { licenseKey: string }>;
-    return Object.fromEntries(
-      Object.entries(parsed).map(([k, v]) => [k, typeof v === "string" ? v : v.licenseKey])
-    );
+    return normalizeKeyMap(JSON.parse(text));
   }
   return parseEnvFile(text);
 }

--- a/scripts/capture-plan-scenarios.ts
+++ b/scripts/capture-plan-scenarios.ts
@@ -129,7 +129,10 @@ async function loadKeys(): Promise<Record<string, string>> {
   // DEV_KEYS_JSON.
   const trimmed = text.trimStart();
   if (trimmed.startsWith("{")) {
-    return JSON.parse(text);
+    const parsed = JSON.parse(text) as Record<string, string | { licenseKey: string }>;
+    return Object.fromEntries(
+      Object.entries(parsed).map(([k, v]) => [k, typeof v === "string" ? v : v.licenseKey])
+    );
   }
   return parseEnvFile(text);
 }


### PR DESCRIPTION
## Summary

- Refreshes all 13 `e2e/plans/captured/*.json` dev-scenario baselines against platform v0.26.0 (S2b resolver rewrite, PR #92 merged 2026-05-26)
- Every diff maps to a documented change in the platform handoff — AC-EXP-1..10, additional expected changes table, or post-handoff fixes
- Fixes `loadKeys()` in `scripts/capture-plan-scenarios.ts` to handle the nested `{ licenseKey, label, tier }` format in `dev-scenario-keys.public.json` (was producing `Bearer [object Object]` → 401)

## Diff mapping

| Category | Coverage |
|----------|----------|
| AC-EXP-1..10 | icon/badgeIcon/convert-now slug/CTA full-JSON/no-card action drop |
| Additional expected | quotas drop (AC-FN-3/4), delete-trial in EXPIRED, action ordering (primary first) |
| Post-handoff fixes | subscribe+renew endpoints (checkoutUrl seeded), EXPIRED statusInfo (poolLimitForStatusCopy fallback) |
| Seed/DB catch-up | paymentConfirm modal (v0.23.0 feature, dev DB had drift), Community→Community Roast name |
| Cosmetic / live data | JSON key ordering (schema-parse-order-independent), daysRemaining drift |

## Test plan

- [x] `npm run plans:capture` — 13/13 ok, 0 failed
- [x] All diffs mapped to documented expected changes before committing
- [x] `npm run precheck` — 0 errors
- [x] `npm run test:ci` — 1431 passed