### PR TITLE
fix(plans): close plan-state baseline gaps — 16 scenario keys + nightly drift CI (v0.109.1)

### DIFF
--- a/.claude/verification-status.json
+++ b/.claude/verification-status.json
@@ -420,11 +420,12 @@
       "notes": "SHIP-GATING SUBSET (10/10 PASS): AC-FMT (21 unit tests), AC-CT-NONE/ACTIVE/TRIAL/EXPIRED/CANCELLED/INACTIVE (96 contract tests across 6 files), AC-PIN (sdk-scaffold-pin snapshot), AC-DEV (?scenario= override on page.tsx), AC-REG (typecheck 0 errors, test:ci 122 suites/1388 tests/0 failures, precheck 0 errors, observability logs in lib/plans.ts, 7 throwaway scripts deleted). Architecture in docs/features/provider-plan-sdk-alignment/architecture.md. Session 1 ships: formatters.ts (pure), _components/PoolCtaMenu.tsx (closes Trial/Expired pool.cta gap; respects action.disabled+disabledReason), PlanPageClient.tsx (consumes formatters), page.tsx (?scenario= dev override), lib/plans.ts (structured boundary logging). DEFERRED to follow-up: AC-CT-COMMON restructure, AC-CT-MODAL, AC-CT-PAGE, AC-CAP captured-payload, AC-PW Playwright plumbing, AC-DRIFT injection, AC-SDK cross-repo MCP version fix. Old session-5 commits left on branch for squash-at-PR-time."
     },
     "fix/plan-state-baseline-gaps": {
-      "status": "planning",
-      "acs_passed": 0,
-      "acs_total": 0,
+      "status": "verified",
+      "acs_passed": 10,
+      "acs_total": 10,
+      "acs_doc": "docs/plans/plan-state-baseline-gaps-plan.md",
       "tasks": [],
-      "notes": "Closing GAP-1 (partial) and GAP-2 from docs/appendix/cross-repo/plan-state-testing.md. Adding 2 missing scenario keys to plan-scenarios.ts, fixing LABEL_TO_ID mappings in capture script, capturing 3 missing baseline JSONs."
+      "notes": "Closing GAP-2 from docs/appendix/cross-repo/plan-state-testing.md. 4 FN + 4 CAP + 2 REG ACs."
     },
     "feat/admin-stripe-payments": {
       "status": "verified",

--- a/.claude/verification-status.json
+++ b/.claude/verification-status.json
@@ -419,6 +419,13 @@
       "acs_doc": "docs/features/provider-plan-sdk-alignment/session-1/ACs.md",
       "notes": "SHIP-GATING SUBSET (10/10 PASS): AC-FMT (21 unit tests), AC-CT-NONE/ACTIVE/TRIAL/EXPIRED/CANCELLED/INACTIVE (96 contract tests across 6 files), AC-PIN (sdk-scaffold-pin snapshot), AC-DEV (?scenario= override on page.tsx), AC-REG (typecheck 0 errors, test:ci 122 suites/1388 tests/0 failures, precheck 0 errors, observability logs in lib/plans.ts, 7 throwaway scripts deleted). Architecture in docs/features/provider-plan-sdk-alignment/architecture.md. Session 1 ships: formatters.ts (pure), _components/PoolCtaMenu.tsx (closes Trial/Expired pool.cta gap; respects action.disabled+disabledReason), PlanPageClient.tsx (consumes formatters), page.tsx (?scenario= dev override), lib/plans.ts (structured boundary logging). DEFERRED to follow-up: AC-CT-COMMON restructure, AC-CT-MODAL, AC-CT-PAGE, AC-CAP captured-payload, AC-PW Playwright plumbing, AC-DRIFT injection, AC-SDK cross-repo MCP version fix. Old session-5 commits left on branch for squash-at-PR-time."
     },
+    "fix/plan-state-baseline-gaps": {
+      "status": "planning",
+      "acs_passed": 0,
+      "acs_total": 0,
+      "tasks": [],
+      "notes": "Closing GAP-1 (partial) and GAP-2 from docs/appendix/cross-repo/plan-state-testing.md. Adding 2 missing scenario keys to plan-scenarios.ts, fixing LABEL_TO_ID mappings in capture script, capturing 3 missing baseline JSONs."
+    },
     "feat/admin-stripe-payments": {
       "status": "verified",
       "acs_passed": 25,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 0.109.1 - 2026-06-12
+
+### Fixed
+
+- **Plan scenario fixture coverage** — added `dev-hosted-converting` and `dev-hosted-pending-verification` to `SCENARIO_FIXTURES` and `ALL_KEYS` in `plan-scenarios.ts`, closing the gap to all 16 platform dev scenarios.
+- **`LABEL_TO_ID` label-to-key mappings** in `scripts/capture-plan-scenarios.ts` — corrected wrong mapping for `PENDING_VERIFICATION`, added three missing entries (`dev-hosted-pending`, `dev-hosted-initial-provisioning`, `dev-hosted-provisioning`).
+- **Capture README refresh command** updated to reference the committed `scripts/dev-scenario-keys.public.json` instead of the gitignored env-style file.
+
+### Added
+
+- **Three missing prod baseline snapshots** — `dev-hosted-converting.json`, `dev-hosted-initial-provisioning.json`, `dev-hosted-pending-verification.json` captured from prod and committed to `e2e/plans/captured/`. All 16 scenario keys now have baselines.
+- **`PLANS_CAPTURE_DEV_KEYS_JSON`** GitHub Actions secret set — enables the nightly `Plans Resolver Drift` workflow to run without manual intervention.
+
 ## 0.109.0 - 2026-06-12
 
 ### Added

--- a/app/admin/support/plans/_fixtures/plan-scenarios.ts
+++ b/app/admin/support/plans/_fixtures/plan-scenarios.ts
@@ -86,13 +86,18 @@ export const SCENARIO_FIXTURES = {
   "dev-hosted-inactive":       [SCENARIOS.INACTIVE],
 
   // ── Hosted: PENDING (post-conversion provisioning, SDK v0.5.0) ─────────
+  // Both CONVERTING substates (cardAdded false/true) map to the same lifecycle
+  // key "CONVERTING" → SDK PENDING. The DB distinction exists for the platform's
+  // Layer 1 e2e suite; the store sees identical output from both.
   "dev-hosted-pending":        [SCENARIOS.PENDING],
+  "dev-hosted-converting":     [SCENARIOS.PENDING],
 
   // ── Empty (resolver returns no cards) ──────────────────────────────────
-  "dev-hosted-initial-provisioning": [],
-  "dev-hosted-cancelled":      [],
-  "dev-hosted-provisioning":   [],
-  "dev-hosted-deprovisioned":  [],
+  "dev-hosted-initial-provisioning":   [],
+  "dev-hosted-pending-verification":   [],
+  "dev-hosted-cancelled":              [],
+  "dev-hosted-provisioning":           [],
+  "dev-hosted-deprovisioned":          [],
 } satisfies Record<string, HydratedPlan[]>;
 
 export type ScenarioKey = keyof typeof SCENARIO_FIXTURES;
@@ -112,7 +117,9 @@ export const HOSTED_KEYS: ScenarioKey[] = [
   "dev-hosted-inactive",
   "dev-hosted-cancelled",
   "dev-hosted-pending",
+  "dev-hosted-converting",
   "dev-hosted-initial-provisioning",
+  "dev-hosted-pending-verification",
   "dev-hosted-provisioning",
   "dev-hosted-deprovisioned",
 ];

--- a/docs/plans/plan-state-baseline-gaps-plan.md
+++ b/docs/plans/plan-state-baseline-gaps-plan.md
@@ -113,7 +113,7 @@ correct for both.
 Run locally using the platform's public JSON (no secret needed):
 
 ```bash
-DEV_KEYS_FILE=c:/Users/yuens/dev/artisan-roast-platform/scripts/dev-scenario-keys.public.json \
+DEV_KEYS_FILE=../artisan-roast-platform/scripts/dev-scenario-keys.public.json \
 npm run plans:capture
 ```
 

--- a/docs/plans/plan-state-baseline-gaps-plan.md
+++ b/docs/plans/plan-state-baseline-gaps-plan.md
@@ -1,0 +1,140 @@
+# Plan State Baseline Gaps — Plan
+
+**Branch:** `fix/plan-state-baseline-gaps`
+**Base:** `main`
+
+---
+
+## Context
+
+The platform's dev seed has 16 scenario keys (`scripts/dev-scenario-keys.public.json` in
+`artisan-roast-platform`). The store's `plan-scenarios.ts` has only 14 — two keys are missing
+from `SCENARIO_FIXTURES` and `ALL_KEYS`. Of the 14 that exist, only 13 have been captured in
+`e2e/plans/captured/`. Three baseline JSON files are absent.
+
+These gaps are tracked in `docs/appendix/cross-repo/plan-state-testing.md` (platform repo) as
+GAP-1 (nightly CI secret — ops step) and GAP-2 (3 missing baselines + 2 missing fixture entries).
+
+A secondary bug: `capture-plan-scenarios.ts`'s `LABEL_TO_ID` (used for env-style
+`.dev-scenario-keys` file parsing) has wrong/missing entries. This doesn't affect CI (which uses
+`DEV_KEYS_JSON` directly) or the JSON-format local path, but should be corrected.
+
+### Why dev-hosted-converting and dev-hosted-pending are both PENDING at the store level
+
+Both scenarios have DB status `CONVERTING`. `dispatch.ts` line 90 maps all `CONVERTING` records
+to lifecycle key `"CONVERTING"` regardless of `cardAdded` — so both produce SDK `status: "PENDING"`.
+
+The DB distinction is `cardAdded`:
+- `dev-hosted-pending` (`cardAdded: false`): Stripe Checkout opened, customer hasn't submitted yet
+- `dev-hosted-converting` (`cardAdded: true`): Card submitted, Stripe confirmed, platform
+  provisioning in flight
+
+Both are valid DB permutations covered by the platform's Layer 1 e2e suite. From the store's
+view they're identical — the store only sees `PENDING`. The fixture `[SCENARIOS.PENDING]` is
+correct for both.
+
+---
+
+## Commit Schedule
+
+| # | Message | Deliverables | Risk |
+|---|---|---|---|
+| 0 | `docs: add plan for plan-state-baseline-gaps` | plan doc | — |
+| 1 | `fix(plans): add dev-hosted-converting and dev-hosted-pending-verification scenario keys` | D1 | Low |
+| 2 | `fix(plans): correct LABEL_TO_ID label-to-key mappings in capture script` | D2 | Low |
+| 3 | `chore(plans): capture baselines for 3 missing scenario keys` | D3 | Low — hits prod API |
+
+---
+
+## Acceptance Criteria
+
+**Plan:** `docs/plans/plan-state-baseline-gaps-plan.md`
+
+### Functional (verified by code review)
+
+| AC | What | How | Pass |
+|----|------|-----|------|
+| AC-FN-1 | All 16 scenario keys present in `SCENARIO_FIXTURES` and `ALL_KEYS` | Code review: compare keys vs `dev-scenario-keys.public.json` | All 16 keys match; none missing |
+| AC-FN-2 | `dev-hosted-converting` maps to `[SCENARIOS.PENDING]` | Code review: `plan-scenarios.ts` entry | `"dev-hosted-converting": [SCENARIOS.PENDING]` |
+| AC-FN-3 | `dev-hosted-pending-verification` maps to `[]` | Code review: `plan-scenarios.ts` entry | `"dev-hosted-pending-verification": []` |
+| AC-FN-4 | All LABEL_TO_ID entries map to correct dev keys, no missing platform labels | Code review: cross-ref with `dev-scenario-keys.public.json` label fields | No wrong target keys; all 16 platform labels have a correct mapping |
+
+### Capture / data (verified by code review)
+
+| AC | What | How | Pass |
+|----|------|-----|------|
+| AC-CAP-1 | `e2e/plans/captured/` contains 16 JSON files | Code review: `ls e2e/plans/captured/*.json \| wc -l` | 16 |
+| AC-CAP-2 | `dev-hosted-initial-provisioning.json` matches expected shape | Code review: read file | `{ plans: [] }` |
+| AC-CAP-3 | `dev-hosted-converting.json` matches expected shape | Code review: read file | `{ plans: [{ state: { status: "PENDING" } }] }` |
+| AC-CAP-4 | `dev-hosted-pending-verification.json` matches expected shape | Code review: read file | `{ plans: [] }` |
+
+### Regression (verified by test suite)
+
+| AC | What | How | Pass |
+|----|------|-----|------|
+| AC-REG-1 | Test suite unaffected | Test run: `npm run test:ci` | All tests pass |
+| AC-REG-2 | TypeScript + ESLint clean | Test run: `npm run precheck` | 0 errors |
+
+---
+
+## Deliverables
+
+| # | What | File |
+|---|---|---|
+| D1 | Add `dev-hosted-converting` + `dev-hosted-pending-verification` to `SCENARIO_FIXTURES` + `HOSTED_KEYS` | `app/admin/support/plans/_fixtures/plan-scenarios.ts` |
+| D2 | Fix 4 LABEL_TO_ID bugs: wrong key for PENDING_VERIFICATION; missing entries for `dev-hosted-pending`, `dev-hosted-initial-provisioning`, and wrong label for `dev-hosted-provisioning` | `scripts/capture-plan-scenarios.ts` |
+| D3 | Run `plans:capture` → commit 3 new baseline JSON files | `e2e/plans/captured/*.json` |
+
+---
+
+## Implementation Details
+
+### Commit 1: Add missing scenario keys (D1)
+
+**Files:**
+
+- `app/admin/support/plans/_fixtures/plan-scenarios.ts` — add to `SCENARIO_FIXTURES`:
+  - `"dev-hosted-converting": [SCENARIOS.PENDING]` — both CONVERTING substates map to PENDING
+  - `"dev-hosted-pending-verification": []` — PENDING_VERIFICATION returns no plans
+  - Add both to `HOSTED_KEYS`
+
+### Commit 2: Fix LABEL_TO_ID (D2)
+
+**Files:**
+
+- `scripts/capture-plan-scenarios.ts` — fix `LABEL_TO_ID`:
+  - `"HOSTED / PENDING_VERIFICATION — plans page shows nothing"` → was `"dev-hosted-pending"`, correct to `"dev-hosted-pending-verification"`
+  - Add `"HOSTED / CONVERTING — PENDING 'Confirming your payment…'"` → `"dev-hosted-pending"`
+  - Add `"HOSTED / initial-signup PROVISIONING — plans page shows nothing"` → `"dev-hosted-initial-provisioning"`
+  - Fix `"HOSTED / PROVISIONING — plans page shows nothing"` → `"HOSTED / post-payment PROVISIONING — PENDING 'Setting up your store…'"` → `"dev-hosted-provisioning"`
+
+### Commit 3: Capture baselines (D3)
+
+Run locally using the platform's public JSON (no secret needed):
+
+```bash
+DEV_KEYS_FILE=c:/Users/yuens/dev/artisan-roast-platform/scripts/dev-scenario-keys.public.json \
+npm run plans:capture
+```
+
+Review `git diff e2e/plans/captured/` — confirm 3 new files and no unexpected changes to existing
+baselines. Commit.
+
+---
+
+## Verification & Workflow Loop
+
+After plan approval:
+
+1. **Commit plan to branch** — `git commit --no-verify -m "docs: add plan for plan-state-baseline-gaps"`
+2. Register `verification-status.json`: `{ status: "planned", acs_total: 10 }`
+3. Transition to `"implementing"` when coding begins
+
+After implementation:
+
+1. Transition to `"pending"`
+2. Run `npm run precheck`
+3. Spawn `/ac-verify` sub-agent — sub-agent fills the **Agent** column
+4. Main thread reads report, fills **QC** column
+5. If any fail → fix → re-verify ALL ACs
+6. When all pass → hand off ACs doc to human → human fills **Reviewer** column

--- a/docs/plans/plan-state-baseline-gaps-plan.md
+++ b/docs/plans/plan-state-baseline-gaps-plan.md
@@ -52,28 +52,28 @@ correct for both.
 
 ### Functional (verified by code review)
 
-| AC | What | How | Pass |
-|----|------|-----|------|
-| AC-FN-1 | All 16 scenario keys present in `SCENARIO_FIXTURES` and `ALL_KEYS` | Code review: compare keys vs `dev-scenario-keys.public.json` | All 16 keys match; none missing |
-| AC-FN-2 | `dev-hosted-converting` maps to `[SCENARIOS.PENDING]` | Code review: `plan-scenarios.ts` entry | `"dev-hosted-converting": [SCENARIOS.PENDING]` |
-| AC-FN-3 | `dev-hosted-pending-verification` maps to `[]` | Code review: `plan-scenarios.ts` entry | `"dev-hosted-pending-verification": []` |
-| AC-FN-4 | All LABEL_TO_ID entries map to correct dev keys, no missing platform labels | Code review: cross-ref with `dev-scenario-keys.public.json` label fields | No wrong target keys; all 16 platform labels have a correct mapping |
+| AC | What | How | Agent | Pass |
+|----|------|-----|-------|------|
+| AC-FN-1 | All 16 scenario keys present in `SCENARIO_FIXTURES` and `ALL_KEYS` | Code review: compare keys vs `dev-scenario-keys.public.json` | PASS — `plan-scenarios.ts` lines 74–101 has all 16 keys; `ALL_KEYS` = `SELF_HOSTED_KEYS` (3) + `HOSTED_KEYS` (13) = 16; all match `dev-scenario-keys.public.json` exactly | All 16 keys match; none missing |
+| AC-FN-2 | `dev-hosted-converting` maps to `[SCENARIOS.PENDING]` | Code review: `plan-scenarios.ts` entry | PASS — `plan-scenarios.ts` line 93: `"dev-hosted-converting": [SCENARIOS.PENDING]` | `"dev-hosted-converting": [SCENARIOS.PENDING]` |
+| AC-FN-3 | `dev-hosted-pending-verification` maps to `[]` | Code review: `plan-scenarios.ts` entry | PASS — `plan-scenarios.ts` line 97: `"dev-hosted-pending-verification": []` | `"dev-hosted-pending-verification": []` |
+| AC-FN-4 | All LABEL_TO_ID entries map to correct dev keys, no missing platform labels | Code review: cross-ref with `dev-scenario-keys.public.json` label fields | PASS — `capture-plan-scenarios.ts` lines 51–72: all 16 platform labels present; each maps to the correct dev-key id; no wrong targets found | No wrong target keys; all 16 platform labels have a correct mapping |
 
 ### Capture / data (verified by code review)
 
-| AC | What | How | Pass |
-|----|------|-----|------|
-| AC-CAP-1 | `e2e/plans/captured/` contains 16 JSON files | Code review: `ls e2e/plans/captured/*.json \| wc -l` | 16 |
-| AC-CAP-2 | `dev-hosted-initial-provisioning.json` matches expected shape | Code review: read file | `{ plans: [] }` |
-| AC-CAP-3 | `dev-hosted-converting.json` matches expected shape | Code review: read file | `{ plans: [{ state: { status: "PENDING" } }] }` |
-| AC-CAP-4 | `dev-hosted-pending-verification.json` matches expected shape | Code review: read file | `{ plans: [] }` |
+| AC | What | How | Agent | Pass |
+|----|------|-----|-------|------|
+| AC-CAP-1 | `e2e/plans/captured/` contains 16 JSON files | Code review: `ls e2e/plans/captured/*.json \| wc -l` | PASS — Glob returned 16 files: `dev-free`, `dev-pro`, `dev-pro-inactive`, `dev-hosted-active-no-card`, `dev-hosted-active-card`, `dev-hosted-expired`, `dev-hosted-converted`, `dev-hosted-cancelled-card`, `dev-hosted-inactive`, `dev-hosted-cancelled`, `dev-hosted-pending`, `dev-hosted-converting`, `dev-hosted-initial-provisioning`, `dev-hosted-pending-verification`, `dev-hosted-provisioning`, `dev-hosted-deprovisioned` | 16 |
+| AC-CAP-2 | `dev-hosted-initial-provisioning.json` matches expected shape | Code review: read file | PASS — file contains `{ "plans": [], "resolvedAt": "<NORMALISED_AT_CAPTURE>" }` | `{ plans: [] }` |
+| AC-CAP-3 | `dev-hosted-converting.json` matches expected shape | Code review: read file | PASS — file contains `plans[0].state.status === "PENDING"` with `statusInfo.descText: "Confirming your payment…"` and `actions: []` | `{ plans: [{ state: { status: "PENDING" } }] }` |
+| AC-CAP-4 | `dev-hosted-pending-verification.json` matches expected shape | Code review: read file | PASS — file contains `{ "plans": [], "resolvedAt": "<NORMALISED_AT_CAPTURE>" }` | `{ plans: [] }` |
 
 ### Regression (verified by test suite)
 
-| AC | What | How | Pass |
-|----|------|-----|------|
-| AC-REG-1 | Test suite unaffected | Test run: `npm run test:ci` | All tests pass |
-| AC-REG-2 | TypeScript + ESLint clean | Test run: `npm run precheck` | 0 errors |
+| AC | What | How | Agent | Pass |
+|----|------|-----|-------|------|
+| AC-REG-1 | Test suite unaffected | Test run: `npm run test:ci` | PASS — recorded from main thread: 127 suites / 1435 tests pass | All tests pass |
+| AC-REG-2 | TypeScript + ESLint clean | Test run: `npm run precheck` | PASS — recorded from main thread: 0 errors, 2 pre-existing warnings | 0 errors |
 
 ---
 

--- a/docs/plans/plan-state-baseline-gaps-review.md
+++ b/docs/plans/plan-state-baseline-gaps-review.md
@@ -6,7 +6,7 @@
 
 ## Verdict
 
-Minor — one in-repo docs drift (README.md refresh command references the deprecated env-style format after D2 switched the canonical approach to the public JSON); fix before merge.
+Clear — all deliverables shipped, all ACs verified. The in-repo README docs drift (refresh command using deprecated env-style path) was fixed inline during this review before the PR was opened.
 
 ## Deliverables ↔ Code
 
@@ -28,19 +28,9 @@ No `AC-TST-*` ACs in this plan — all ACs are FN/CAP/REG categories. REG ACs us
 
 ## Docs drift
 
-**In-repo — Minor:**
+**In-repo — Resolved (fixed before PR opened):**
 
-`e2e/plans/captured/README.md` — the "Refresh discipline" example still uses the old env-style path:
-
-```bash
-DEV_KEYS_FILE=../artisan-roast-platform/.dev-scenario-keys \
-```
-
-D2 fixes `LABEL_TO_ID` (the env-style parser) and the capture script's own header already documents both formats. The README should reference the public JSON path instead — it's committed, cross-platform, and doesn't require a gitignored local file:
-
-```bash
-DEV_KEYS_FILE=../artisan-roast-platform/scripts/dev-scenario-keys.public.json \
-```
+`e2e/plans/captured/README.md` — the "Refresh discipline" example previously used the deprecated env-style path. Updated inline to `scripts/dev-scenario-keys.public.json` before the PR was opened; the committed version is correct.
 
 **Out-of-scope — needs companion PR in platform repo:**
 
@@ -48,8 +38,7 @@ DEV_KEYS_FILE=../artisan-roast-platform/scripts/dev-scenario-keys.public.json \
 
 ## Recommendations
 
-1. **Fix `e2e/plans/captured/README.md`** — update the refresh command to use `scripts/dev-scenario-keys.public.json` instead of the gitignored `.dev-scenario-keys` env-style file. One-line change; commit as `docs: update capture README refresh command to use public JSON`.
-2. **Platform companion PR** — after merge, update `docs/appendix/cross-repo/plan-state-testing.md` in `artisan-roast-platform` to mark GAP-2 closed and note that the public JSON format is the canonical local capture path.
+1. **Platform companion PR** — after merge, update `docs/appendix/cross-repo/plan-state-testing.md` in `artisan-roast-platform` to mark GAP-2 closed and note that the public JSON format is the canonical local capture path.
 
 ## Inputs for /retro
 

--- a/docs/plans/plan-state-baseline-gaps-review.md
+++ b/docs/plans/plan-state-baseline-gaps-review.md
@@ -1,0 +1,62 @@
+# /review report — plan-state-baseline-gaps
+
+**Branch:** `fix/plan-state-baseline-gaps`
+**Generated:** 2026-06-12
+**Iterations to reach verified:** 1
+
+## Verdict
+
+Minor — one in-repo docs drift (README.md refresh command references the deprecated env-style format after D2 switched the canonical approach to the public JSON); fix before merge.
+
+## Deliverables ↔ Code
+
+| Deliverable | Implementation | Status |
+|-------------|----------------|--------|
+| D1 — add 2 missing keys to `plan-scenarios.ts` | `app/admin/support/plans/_fixtures/plan-scenarios.ts`: SCENARIO_FIXTURES lines 93+97, HOSTED_KEYS lines 111-112 | ✓ shipped |
+| D2 — fix 4 LABEL_TO_ID bugs in capture script | `scripts/capture-plan-scenarios.ts` lines 51–72: 4 corrections + 3 additions | ✓ shipped |
+| D3 — capture 3 missing baselines | `e2e/plans/captured/`: 3 new JSON files; `dev-pro-inactive.json` legitimately refreshed (deactivatedAt advances each re-seed) | ✓ shipped |
+
+### Code changes not tied to any deliverable
+
+- `.claude/verification-status.json` — workflow state tracking, expected overhead
+- `docs/plans/plan-state-baseline-gaps-plan.md` — plan doc, expected
+- `e2e/plans/captured/dev-pro-inactive.json` one-line diff — expected side effect of running `plans:capture` (deactivatedAt = `now - 30d`, advances on every re-seed); not a regression
+
+## ACs ↔ Tests (Gate 3 spot-check)
+
+No `AC-TST-*` ACs in this plan — all ACs are FN/CAP/REG categories. REG ACs use the existing test suite unchanged. Step 2 is N/A.
+
+## Docs drift
+
+**In-repo — Minor:**
+
+`e2e/plans/captured/README.md` — the "Refresh discipline" example still uses the old env-style path:
+
+```bash
+DEV_KEYS_FILE=../artisan-roast-platform/.dev-scenario-keys \
+```
+
+D2 fixes `LABEL_TO_ID` (the env-style parser) and the capture script's own header already documents both formats. The README should reference the public JSON path instead — it's committed, cross-platform, and doesn't require a gitignored local file:
+
+```bash
+DEV_KEYS_FILE=../artisan-roast-platform/scripts/dev-scenario-keys.public.json \
+```
+
+**Out-of-scope — needs companion PR in platform repo:**
+
+`docs/appendix/cross-repo/plan-state-testing.md` (in `artisan-roast-platform`) still lists GAP-2 as open. GAP-2 is now closed by this branch. Platform-repo companion update needed after merge.
+
+## Recommendations
+
+1. **Fix `e2e/plans/captured/README.md`** — update the refresh command to use `scripts/dev-scenario-keys.public.json` instead of the gitignored `.dev-scenario-keys` env-style file. One-line change; commit as `docs: update capture README refresh command to use public JSON`.
+2. **Platform companion PR** — after merge, update `docs/appendix/cross-repo/plan-state-testing.md` in `artisan-roast-platform` to mark GAP-2 closed and note that the public JSON format is the canonical local capture path.
+
+## Inputs for /retro
+
+**Structural exception — no existing role skill files found:**
+Neither `~/.claude/commands/devops.md` nor `~/.claude/commands/test-engineer.md` exist. If this review surfaces a lesson worth persisting, it would need a new skill file. Both de-facto roles are named here so `/retro` knows the routing intent.
+
+- **De-facto owning role:** `/devops` — owns capture scripts, CI workflows, and baseline data files
+- **De-facto supporting role:** `/test-engineer` — owns `plan-scenarios.ts` (fixture map consumed by the screenshot harness and the `?scenario=` dev override)
+
+**No lessons surfaced that warrant a new skill file.** The README drift is a one-off maintenance gap, not a pattern that would recur across features. The LABEL_TO_ID bug was pre-existing and is now fixed structurally (public JSON format is documented as canonical). No principle addition would have prevented it; the fix is the documentation update.

--- a/e2e/plans/captured/README.md
+++ b/e2e/plans/captured/README.md
@@ -12,7 +12,7 @@ in here, the workflow fails and opens an issue.
 Re-capture, review the diff, commit if the change is intentional.
 
 ```bash
-DEV_KEYS_FILE=../artisan-roast-platform/.dev-scenario-keys \
+DEV_KEYS_FILE=../artisan-roast-platform/scripts/dev-scenario-keys.public.json \
   PLATFORM_URL=https://manage.artisanroast.app \
   npm run plans:capture
 

--- a/e2e/plans/captured/dev-hosted-converting.json
+++ b/e2e/plans/captured/dev-hosted-converting.json
@@ -1,0 +1,122 @@
+{
+  "plans": [
+    {
+      "slug": "house-blend-trial",
+      "name": "House Blend Trial",
+      "description": "Risk-free for 14 days — full features, no card, no commitment.",
+      "price": 0,
+      "currency": "usd",
+      "interval": "month",
+      "features": [
+        "hosting"
+      ],
+      "details": {
+        "benefits": {
+          "activeItems": [
+            "No billing needed — add card to extend to 30 days",
+            "Download your data as a ZIP anytime",
+            "100% feature parity from day 1",
+            "Cancel anytime — no contract, no commitment"
+          ]
+        }
+      },
+      "highlight": false,
+      "visibility": "hosted",
+      "actionModals": [
+        {
+          "slug": "cancel-trial",
+          "type": "feedbackForm",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "description": "We'd love to know why before you go.",
+          "confirmLabel": "Cancel Trial",
+          "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "cancel-stripe",
+          "type": "feedbackForm",
+          "other": {
+            "label": "Tell us a bit more",
+            "maxLength": 500,
+            "placeholder": "What are we missing?"
+          },
+          "heading": "Cancel your trial?",
+          "reasons": [
+            {
+              "label": "Still evaluating — need more time",
+              "value": "too-soon"
+            },
+            {
+              "label": "Missing features I need",
+              "value": "missing-features"
+            },
+            {
+              "label": "Plan too expensive",
+              "value": "too-expensive"
+            },
+            {
+              "label": "Switching to another platform",
+              "value": "switching"
+            },
+            {
+              "label": "Other",
+              "value": "other"
+            }
+          ],
+          "keepLabel": "Keep trial",
+          "confirmIcon": "external-link",
+          "description": "Your card is on file. Cancel to stop any future charges.",
+          "confirmLabel": "Continue to Stripe",
+          "reasonsLabel": "Reason for cancelling"
+        },
+        {
+          "slug": "paymentConfirm",
+          "type": "paymentConfirm",
+          "heading": "Completing your subscription",
+          "description": "We'll redirect you to Stripe to confirm payment.",
+          "confirmLabel": "Continue to Stripe",
+          "processingMessages": [
+            "Talking to Stripe…",
+            "Confirming your payment…",
+            "Almost there — setting up your store…"
+          ]
+        }
+      ],
+      "state": {
+        "status": "PENDING",
+        "statusInfo": {
+          "descText": "Confirming your payment…"
+        },
+        "actions": []
+      }
+    }
+  ],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-hosted-initial-provisioning.json
+++ b/e2e/plans/captured/dev-hosted-initial-provisioning.json
@@ -1,0 +1,4 @@
+{
+  "plans": [],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-hosted-pending-verification.json
+++ b/e2e/plans/captured/dev-hosted-pending-verification.json
@@ -1,0 +1,4 @@
+{
+  "plans": [],
+  "resolvedAt": "<NORMALISED_AT_CAPTURE>"
+}

--- a/e2e/plans/captured/dev-pro-inactive.json
+++ b/e2e/plans/captured/dev-pro-inactive.json
@@ -148,7 +148,7 @@
       "state": {
         "status": "INACTIVE",
         "badge": "Inactive",
-        "deactivatedAt": "2026-04-09T12:44:11.643Z",
+        "deactivatedAt": "2026-04-19T01:22:45.615Z",
         "actions": [
           {
             "slug": "renew",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.109.0",
+  "version": "0.109.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.109.0",
+      "version": "0.109.1",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.109.0",
+  "version": "0.109.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/scripts/capture-plan-scenarios.ts
+++ b/scripts/capture-plan-scenarios.ts
@@ -52,11 +52,17 @@ const LABEL_TO_ID: Record<string, string> = {
   "FREE — community plan, no subscription": "dev-free",
   "PRO — priority support active, pools live": "dev-pro",
   "PRO / INACTIVE — priority support subscription lapsed": "dev-pro-inactive",
-  "HOSTED / PENDING_VERIFICATION — plans page shows nothing": "dev-hosted-pending",
-  "HOSTED / PROVISIONING — plans page shows nothing": "dev-hosted-provisioning",
+  // PENDING_VERIFICATION → dev-hosted-pending-verification (empty plans page)
+  "HOSTED / PENDING_VERIFICATION — plans page shows nothing": "dev-hosted-pending-verification",
+  // initial-signup PROVISIONING → dev-hosted-initial-provisioning (empty plans page)
+  "HOSTED / initial-signup PROVISIONING — plans page shows nothing": "dev-hosted-initial-provisioning",
+  // CONVERTING substates: both map to PENDING at the store level
+  "HOSTED / CONVERTING — PENDING 'Confirming your payment…'": "dev-hosted-pending",
+  "HOSTED / CONVERTING — subscription in flight": "dev-hosted-converting",
+  // post-payment PROVISIONING (stripeSubscriptionId set, convertedAt null)
+  "HOSTED / post-payment PROVISIONING — PENDING 'Setting up your store…'": "dev-hosted-provisioning",
   "HOSTED / ACTIVE trial — no card on file": "dev-hosted-active-no-card",
   "HOSTED / ACTIVE trial — card on file": "dev-hosted-active-card",
-  "HOSTED / CONVERTING — subscription in flight": "dev-hosted-converting",
   "HOSTED / EXPIRED — trial ended, subscribe to restore": "dev-hosted-expired",
   "HOSTED / CANCELLED — trial cancelled, deprovision countdown": "dev-hosted-cancelled",
   "HOSTED / CANCELLED (card on file) — deprovision countdown running": "dev-hosted-cancelled-card",


### PR DESCRIPTION
## Summary

- **16 scenario keys** now in `plan-scenarios.ts` (was 14) — added `dev-hosted-converting` and `dev-hosted-pending-verification` to `SCENARIO_FIXTURES` + `HOSTED_KEYS`
- **16 captured baselines** in `e2e/plans/captured/` (was 13) — three new JSON files captured from prod: `dev-hosted-converting.json` (PENDING), `dev-hosted-initial-provisioning.json` (empty), `dev-hosted-pending-verification.json` (empty)
- **`LABEL_TO_ID` corrected** in `capture-plan-scenarios.ts` — fixed wrong mapping for `PENDING_VERIFICATION`, added 3 missing platform label entries, fixed `PROVISIONING` label
- **Capture README** updated to reference `scripts/dev-scenario-keys.public.json` instead of the gitignored env-style file
- **`PLANS_CAPTURE_DEV_KEYS_JSON`** GitHub Actions secret set — nightly drift workflow is now fully operational

Closes GAP-1 and GAP-2 from `docs/appendix/cross-repo/plan-state-testing.md` (platform repo).

**Note on `dev-hosted-converting`:** both CONVERTING substates (`cardAdded: false` and `cardAdded: true`) map to the same lifecycle key → SDK `PENDING`. The DB distinction exists for the platform's Layer 1 e2e suite; the store sees identical output from both. See plan doc Context section for full analysis.

**Companion action after merge:** update `plan-state-testing.md` in `artisan-roast-platform` to mark both gaps closed.

## Test plan

- [x] `npm run test:ci` — 127 suites / 1435 tests pass
- [x] `npm run precheck` — 0 errors
- [x] 10/10 ACs verified (4 FN + 4 CAP + 2 REG)
- [x] `e2e/plans/captured/*.json` — 16 files, shapes match expected (2× `{plans:[]}`, 1× `{plans:[{state:{status:"PENDING"}}]}`)