### PR TITLE
chore(ci): bump actions/checkout to v4.3.1 and actions/setup-node to v6.4.0

### DIFF
--- a/.github/workflows/build-safe-main.yml
+++ b/.github/workflows/build-safe-main.yml
@@ -26,7 +26,7 @@ jobs:
       RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL != '' && secrets.RESEND_FROM_EMAIL || 'orders@example.com' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.3.1
 
       # Check if code files changed (vs docs-only)
       - name: Check for code changes
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup Node
         if: steps.filter.outputs.code == 'true'
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -23,10 +23,10 @@ jobs:
       AUTH_SECRET: ${{ secrets.AUTH_SECRET != '' && secrets.AUTH_SECRET || 'e2e-ci-placeholder-secret-min32chars!!' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -96,10 +96,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.3.1
         with:
           ref: main
 
       - name: Setup Node
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
 

--- a/.github/workflows/plans-capture-nightly.yml
+++ b/.github/workflows/plans-capture-nightly.yml
@@ -34,10 +34,10 @@ jobs:
       PLATFORM_URL: https://manage.artisanroast.app
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/qa-nightly.yml
+++ b/.github/workflows/qa-nightly.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
 
@@ -156,10 +156,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
 

--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.3.1
 
       - name: Detect changed files
         id: filter


### PR DESCRIPTION
## Summary
- Bumps \`actions/checkout\` from \`v4.2.2\` → \`v4.3.1\` across all 7 workflow files
- Bumps \`actions/setup-node\` from \`v4.4.0\` → \`v6.4.0\` across all 6 workflow files that use it
- Also pins \`install-matrix.yml\`'s previously unpinned \`@v4\` references to exact versions

**Why:** GitHub Actions will force JavaScript actions to run on Node.js 24 by default starting June 16, 2026; Node.js 20 will be removed from runners September 16, 2026. \`v4.3.1\`/\`v6.4.0\` are the node24-compatible versions.

## Test plan
- [ ] \`build-safe\` CI passes on this PR
- [ ] No functional change — only action runner versions updated