### PR TITLE
docs: discovery sweep — align README, static pages, and workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,42 +54,7 @@ Most e-commerce platforms treat coffee like any other product. But your customer
 | One-click subscriptions | Order management & analytics |
 | Stripe checkout (cards, Apple Pay, Google Pay) | Pages CMS with AI content generation |
 
-### Screenshots
-
-<details>
-<summary><strong>Homepage</strong> - Clean, modern storefront</summary>
-
-![Homepage](./docs/assets/screenshots/homepage.png)
-
-</details>
-
-<details>
-<summary><strong>AI Chat Assistant</strong> - Natural language coffee recommendations</summary>
-
-![AI Chat](./docs/assets/screenshots/ai-chat.png)
-
-</details>
-
-<details>
-<summary><strong>Product Page</strong> - Rich product details with variant selection</summary>
-
-![Product Page](./docs/assets/screenshots/product-page.png)
-
-</details>
-
-<details>
-<summary><strong>Admin Dashboard</strong> - Analytics and store overview</summary>
-
-![Admin Dashboard](./docs/assets/screenshots/admin-dashboard.png)
-
-</details>
-
-<details>
-<summary><strong>Menu Builder</strong> - Drag-and-drop catalog organization</summary>
-
-![Menu Builder](./docs/assets/screenshots/menu-builder.png)
-
-</details>
+→ **[Try the live demo at demo.artisanroast.app](https://demo.artisanroast.app/)** — no signup required. Sign in as Admin or Demo Customer to explore every feature.
 
 ---
 
@@ -105,9 +70,8 @@ Setting up Artisan Roast requires a free database (Neon) and a deployment host (
 
 ### For Customers
 
-- **Smart Search** - Find coffee by name, origin, roast level, or tasting notes
-- **AI Recommendations** - Personalized suggestions based on browsing and purchase history
-- **AI Chat Assistant** - Ask questions like "What's good for cold brew?"
+- **Smart Search** - Faceted search by name, origin, roast level, and tasting notes
+- **Product Reviews** - Star ratings, brew method badges, and roaster brew guides
 - **Flexible Subscriptions** - Weekly, bi-weekly, or monthly delivery
 - **Subscription Portal** - Pause, skip, or cancel anytime (Stripe Billing Portal)
 
@@ -162,7 +126,7 @@ Every merge to `main` is verified by two automated pipelines:
 
 | Check | What it guarantees |
 |-------|--------------------|
-| **Build** (every PR + merge) | TypeScript compiles, ESLint passes, 1,000+ unit tests pass, production build succeeds |
+| **Build** (every PR + merge) | TypeScript compiles, ESLint passes, 1,400+ unit tests pass, production build succeeds |
 | **Nightly QA** (nightly cron) | A real fresh install — empty database, deployed to Vercel — passes all 16 acceptance criteria end-to-end |
 
 On merge to `main`, the QA database is reset and the QA deployment is refreshed. The following morning, a Claude Agent SDK + Playwright script walks through the full setup flow, known-value round-trips, and initial app state checks — using the accessibility tree instead of CSS selectors. Any regression opens a GitHub issue automatically.
@@ -175,11 +139,11 @@ On merge to `main`, the QA database is reset and the QA deployment is refreshed.
 
 - [x] Core e-commerce (cart, checkout, orders)
 - [x] Stripe subscriptions
-- [x] AI product recommendations
-- [x] AI chat assistant
 - [x] Menu Builder (drag-and-drop catalog)
 - [x] Pages CMS with AI generation
-- [ ] Voice AI barista (demo only)
+- [x] Product reviews and brew guides
+- [x] Keyword search with faceted filtering
+- [x] Plans page with hosting extension
 - [ ] Inventory management
 - [ ] Multi-store support
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ No signup required. Click **"Sign in as Admin"** or **"Sign in as Demo Customer"
 | Account | What You'll See |
 |---------|-----------------|
 | **Admin** | Full dashboard: products, orders, analytics, Menu Builder, Pages CMS |
-| **Demo Customer** | Order history, active subscription, AI-powered recommendations |
+| **Demo Customer** | Order history, active subscription, smart product recommendations |
 
 > This is a shared demo environment. Please be respectful with the data.
 
@@ -50,7 +50,7 @@ Most e-commerce platforms treat coffee like any other product. But your customer
 | For Your Customers | For You |
 |---|---|
 | Browse by origin, roast, or tasting notes | Beautiful admin dashboard |
-| Search by origin, roast level, or tasting note | Drag-and-drop menu organization |
+| Search by origin, roast level, or tasting notes | Drag-and-drop menu organization |
 | One-click subscriptions | Order management & analytics |
 | Stripe checkout (cards, Apple Pay, Google Pay) | Pages CMS with AI content generation |
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Setting up Artisan Roast requires a free database (Neon) and a deployment host (
 - **Admin Dashboard** - Sales, trending products, top searches, activity trends
 - **Order Management** - Track orders from purchase to delivery
 
+### For Platform Builders
+
+- **Provider-agnostic SDK** - Plans, trials, and à la carte add-ons follow a typed contract. Any developer can implement a managed hosting platform for Artisan Roast stores — the store is a pure consumer of the SDK, not locked to any provider.
+- **Build-time isolation** - Hosted-mode UI is gated on a single env var and dead-code-eliminated from OSS builds. Self-hosted stores ship none of the hosting chrome.
+
 ### Technical
 
 - **Next.js 16** with App Router and React 19
@@ -97,7 +102,7 @@ Setting up Artisan Roast requires a free database (Neon) and a deployment host (
 - **Stripe** payments and subscriptions
 - **OAuth** login (Google, GitHub)
 - **AI** powered by any OpenAI-compatible provider
-- **1,000+ tests** with Jest and Testing Library
+- **1,400+ tests** with Jest and Testing Library
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Most e-commerce platforms treat coffee like any other product. But your customer
 
 **Artisan Roast understands coffee.**
 
-- **AI that speaks coffee** - "I like bright, citrusy flavors" → instant recommendations
+- **Coffee in the schema** - Origin, altitude, tasting notes, roast level — first-class columns, not bolt-on custom fields
 - **Subscriptions that just work** - Set it and forget it, with easy customer self-service
 - **Menu Builder** - Organize your catalog the way *you* think about it (Origins → Ethiopian → Yirgacheffe)
 - **Self-host for free** - MIT licensed, your data stays yours
@@ -50,7 +50,7 @@ Most e-commerce platforms treat coffee like any other product. But your customer
 | For Your Customers | For You |
 |---|---|
 | Browse by origin, roast, or tasting notes | Beautiful admin dashboard |
-| AI chat: "What's similar to Ethiopian Yirgacheffe?" | Drag-and-drop menu organization |
+| Search by origin, roast level, or tasting note | Drag-and-drop menu organization |
 | One-click subscriptions | Order management & analytics |
 | Stripe checkout (cards, Apple Pay, Google Pay) | Pages CMS with AI content generation |
 

--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -271,13 +271,14 @@ export default async function AboutPage() {
                   <Link
                     href="https://github.com/yuens1002/artisan-roast"
                     target="_blank"
+                    rel="noopener noreferrer"
                   >
                     <Github className="h-5 w-5" />
                     View on GitHub
                   </Link>
                 </Button>
                 <Button asChild size="lg" className="gap-2">
-                  <Link href="https://demo.artisanroast.app/" target="_blank">
+                  <Link href="https://demo.artisanroast.app/" target="_blank" rel="noopener noreferrer">
                     <Store className="h-5 w-5" />
                     Try the Demo
                   </Link>

--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -9,13 +9,10 @@ import {
   Package,
   RefreshCw,
   Search,
-  MessageSquare,
-  Mic,
   Sparkles,
   BarChart3,
   Activity,
   Github,
-  Mail,
   LayoutDashboard,
   Settings,
   Boxes,
@@ -144,38 +141,18 @@ export default async function AboutPage() {
               <Card className="h-full transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
-                    <Sparkles className="h-5 w-5 text-purple-600 dark:text-purple-400" />
-                    AI-Powered Personalization
+                    <Search className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+                    Discovery & Reviews
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="flex gap-3">
-                    <MessageSquare className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+                    <Search className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
                     <div>
-                      <h3 className="font-semibold">
-                        Chat AI Assistant{" "}
-                        <span className="text-xs font-normal text-muted-foreground">
-                          (In Progress)
-                        </span>
-                      </h3>
+                      <h3 className="font-semibold">Keyword Search</h3>
                       <p className="text-sm text-muted-foreground">
-                        Text-based conversational interface with full order
-                        history context and brewing expertise.
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex gap-3">
-                    <Mic className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
-                    <div>
-                      <h3 className="font-semibold">
-                        Voice AI Barista{" "}
-                        <span className="text-xs font-normal text-muted-foreground">
-                          (In Progress)
-                        </span>
-                      </h3>
-                      <p className="text-sm text-muted-foreground">
-                        Multilingual voice assistant for hands-free coffee
-                        recommendations and ordering.
+                        Faceted search across name, origin, roast level, and
+                        tasting notes with an animated slide-out drawer.
                       </p>
                     </div>
                   </div>
@@ -184,9 +161,8 @@ export default async function AboutPage() {
                     <div>
                       <h3 className="font-semibold">Smart Recommendations</h3>
                       <p className="text-sm text-muted-foreground">
-                        Behavioral product recommendations based on user
-                        activity, powered by Gemini with a smart scoring
-                        algorithm.
+                        Behavioral product recommendations based on browsing
+                        and purchase history with a smart scoring algorithm.
                       </p>
                     </div>
                   </div>
@@ -293,7 +269,7 @@ export default async function AboutPage() {
               <div className="flex flex-col justify-center gap-6 md:flex-row">
                 <Button asChild size="lg" variant="outline" className="gap-2">
                   <Link
-                    href="https://github.com/yuens1002/ecomm-ai-app"
+                    href="https://github.com/yuens1002/artisan-roast"
                     target="_blank"
                   >
                     <Github className="h-5 w-5" />
@@ -301,17 +277,15 @@ export default async function AboutPage() {
                   </Link>
                 </Button>
                 <Button asChild size="lg" className="gap-2">
-                  <Link href="/contact">
-                    <Mail className="h-5 w-5" />
-                    Contact for Demo
+                  <Link href="https://demo.artisanroast.app/" target="_blank">
+                    <Store className="h-5 w-5" />
+                    Try the Demo
                   </Link>
                 </Button>
               </div>
               <p className="mt-6 text-sm text-muted-foreground">
-                Want to see the AI recommendations in action? Contact me for
-                demo account credentials to experience personalized product
-                recommendations, behavioral analytics, and the full feature
-                set.
+                No signup required — sign in as Admin or Demo Customer to
+                explore the full feature set.
               </p>
             </section>
           </ScrollReveal>

--- a/app/(site)/app-features/page.tsx
+++ b/app/(site)/app-features/page.tsx
@@ -187,7 +187,7 @@ export default async function AppFeaturesPage() {
                   Learn about the CMS architecture and design decisions.
                 </p>
                 <Link
-                  href="https://github.com/yuens1002/ecomm-ai-app/blob/main/docs/pages-cms-architecture.md"
+                  href="https://github.com/yuens1002/artisan-roast/blob/main/docs/pages-cms-architecture.md"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm font-medium text-primary hover:underline"
@@ -202,7 +202,7 @@ export default async function AppFeaturesPage() {
                   Explore the AI-powered About page generator specification.
                 </p>
                 <Link
-                  href="https://github.com/yuens1002/ecomm-ai-app/blob/main/docs/ai-about-page-generator.md"
+                  href="https://github.com/yuens1002/artisan-roast/blob/main/docs/ai-about-page-generator.md"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm font-medium text-primary hover:underline"
@@ -217,7 +217,7 @@ export default async function AppFeaturesPage() {
                   Review the complete implementation plan and checklist.
                 </p>
                 <Link
-                  href="https://github.com/yuens1002/ecomm-ai-app/blob/main/docs/pages-cms-implementation-plan.md"
+                  href="https://github.com/yuens1002/artisan-roast/blob/main/docs/pages-cms-implementation-plan.md"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm font-medium text-primary hover:underline"

--- a/app/(site)/features/page.tsx
+++ b/app/(site)/features/page.tsx
@@ -17,6 +17,7 @@ import {
   Shield,
   Code,
   Rocket,
+  Layers,
   Check,
   X,
   Github,
@@ -79,6 +80,14 @@ const features = [
     description: "OAuth (GitHub/Google), role-based admin access.",
     accent:
       "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400",
+  },
+  {
+    icon: Layers,
+    title: "Provider-Agnostic Plans",
+    description:
+      "Plans, trials, and add-ons follow an open SDK contract. Any developer can build a managed hosting platform — the store is a pure consumer, not locked to any provider.",
+    accent:
+      "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400",
   },
   {
     icon: Code,

--- a/app/(site)/features/page.tsx
+++ b/app/(site)/features/page.tsx
@@ -255,6 +255,7 @@ export default function FeaturesPage() {
                   <Link
                     href="https://github.com/yuens1002/artisan-roast"
                     target="_blank"
+                    rel="noopener noreferrer"
                   >
                     <Github className="h-5 w-5" />
                     View on GitHub
@@ -392,6 +393,7 @@ export default function FeaturesPage() {
                   <Link
                     href="https://github.com/yuens1002/artisan-roast"
                     target="_blank"
+                    rel="noopener noreferrer"
                   >
                     <Github className="h-5 w-5" />
                     View on GitHub

--- a/app/(site)/features/page.tsx
+++ b/app/(site)/features/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/table";
 import {
   Coffee,
-  Sparkles,
+  Search,
   CreditCard,
   LayoutDashboard,
   FileText,
@@ -43,10 +43,10 @@ const features = [
       "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
   },
   {
-    icon: Sparkles,
-    title: "AI Digital Sommelier",
+    icon: Search,
+    title: "Smart Search & Discovery",
     description:
-      "More than generic product suggestions. A digital sommelier that guides customers through complex flavor profiles, roast characteristics, and origins to find their perfect brew.",
+      "Faceted keyword search across name, origin, roast level, and tasting notes — with an animated slide-out drawer and curated category chips.",
     accent:
       "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400",
   },
@@ -149,8 +149,8 @@ const comparisonRows: {
     nextCommerce: false,
   },
   {
-    feature: "AI features",
-    artisan: "Built-in",
+    feature: "AI content generation",
+    artisan: "Built-in (Pages CMS)",
     shopify: "Paid apps",
     medusa: false,
     saleor: false,
@@ -244,7 +244,7 @@ export default function FeaturesPage() {
                 </Button>
                 <Button asChild size="lg" variant="outline" className="gap-2">
                   <Link
-                    href="https://github.com/yuens1002/ecomm-ai-app"
+                    href="https://github.com/yuens1002/artisan-roast"
                     target="_blank"
                   >
                     <Github className="h-5 w-5" />
@@ -381,7 +381,7 @@ export default function FeaturesPage() {
                 </Button>
                 <Button asChild size="lg" variant="outline" className="gap-2">
                   <Link
-                    href="https://github.com/yuens1002/ecomm-ai-app"
+                    href="https://github.com/yuens1002/artisan-roast"
                     target="_blank"
                   >
                     <Github className="h-5 w-5" />

--- a/docs/AGENTIC-WORKFLOW.md
+++ b/docs/AGENTIC-WORKFLOW.md
@@ -344,8 +344,9 @@ Main thread reads both reports when complete                           ─┘
 | `/ac-verify` | 3 | Sub-agent verification template |
 | `/ui-verify` | 3 | Screenshot capture + comparison (used by sub-agent) |
 | `/verify-workflow` | 2-4 | Full orchestration (when running without sub-agents) |
+| `/review` | 4.5 | Holistic cross-artifact check — deliverables ↔ code, ACs ↔ tests, docs drift |
 | `/release` | 6 | Version bump + tag + PR |
-| `/retro` | Post-session | Capture process lessons → update skills, templates, validators |
+| `/retro` | 7 | Capture process lessons → update skills, templates, validators |
 
 ## Learning Loop
 
@@ -355,7 +356,7 @@ When a session reveals a process gap (not a code bug), run `/retro` to capture t
 2. **Classify** which layers need fixing (skill, template, validator, workflow doc)
 3. **Apply** concrete, enforceable changes to each layer
 4. **Test** validator changes, trace skill changes through the failure scenario
-5. **Log** the lesson in `.claude/skills/retro/retro-log.md`
+5. **Log** the lesson in `.claude/retro-log.md`
 
 Future sessions automatically benefit because skills, templates, and validators are loaded at session start. The retro log serves as an audit trail of what was learned and when.
 
@@ -467,6 +468,8 @@ Plans must include a commit schedule section:
 | Session awareness | SessionStart | `session-start-loop-node.js` | Injects process loop context at session start | Context injection (exit 2) |
 | Stop gate | Stop | `verify-before-stop-node.js` | Prevents declaring done without verification | Yes (`pending`/`partial`) |
 | Commit gate | PreToolUse (Bash) | `verify-before-commit-node.js` | Prevents commits in unverified states | Yes (`pending`/`partial`) |
+| PR creation gate | PreToolUse (Bash) | `pre-pr-via-release-node.js` | Blocks `gh pr create` unless latest commit is release fingerprint or `docs-only release` | Yes |
+| Merge gate | PreToolUse (Bash) | `review-before-merge-node.js` | Blocks `gh pr merge` while any review thread is unresolved | Yes |
 
 ### How They Work Together
 
@@ -487,8 +490,11 @@ Plans must include a commit schedule section:
 | `.claude/hooks/verify-before-stop-node.js` | Yes | Stop gate — blocks premature completion |
 | `.claude/hooks/verify-before-commit-node.js` | Yes | Pre-commit verification gate |
 | `.claude/verification-status.json` | No | Per-branch AC tracking |
-| `.claude/skills/ac-verify/SKILL.md` | Yes | Verification sub-agent prompt template |
-| `.claude/skills/verify-workflow/SKILL.md` | Yes | Full workflow orchestration |
-| `.claude/skills/ui-verify/SKILL.md` | Yes | Screenshot capture + comparison |
+| `.claude/hooks/pre-pr-via-release-node.js` | Yes | PR creation gate — requires release fingerprint commit |
+| `.claude/hooks/review-before-merge-node.js` | Yes | Merge gate — blocks while review threads are unresolved |
+| `.claude/commands/ac-verify.md` | Yes | Verification sub-agent prompt template |
+| `.claude/commands/verify-workflow.md` | Yes | Full workflow orchestration |
+| `.claude/commands/ui-verify.md` | Yes | Screenshot capture + comparison |
 | `.claude/skills/release/SKILL.md` | Yes | Release workflow |
+| `.claude/retro-log.md` | No | Running log of process lessons (audit trail) |
 | `docs/AGENTIC-WORKFLOW.md` | Yes | This document |


### PR DESCRIPTION
## Summary

- Replaced all `<details>` screenshot blocks in README with a link to the live demo at `demo.artisanroast.app`
- Removed stale AI feature claims (chat assistant, voice barista, AI recommendations) from README features list, roadmap, "Why Artisan Roast?" section, and "See It In Action" table
- Updated `about/page.tsx`, `features/page.tsx`, and `app-features/page.tsx`: replaced AI cards with current features (keyword search, reviews), fixed GitHub URLs (`ecomm-ai-app` → `artisan-roast`), updated CTAs to demo link
- Added "For Platform Builders" section to README and Provider-Agnostic Plans card to `features/page.tsx`
- Fixed test count (1,000+ → 1,400+) in two README locations
- Fixed `docs/AGENTIC-WORKFLOW.md`: stale `.claude/skills/` paths → `.claude/commands/`, retro log path, added 2 missing enforcement hook rows, added `/review` to skill reference table

## Type

Docs-only — no version bump.