### PR TITLE
fix(ci): unblock nightly playwright hang + Node.js 20 deprecation (v0.109.3)

### DIFF
--- a/.github/workflows/build-safe-main.yml
+++ b/.github/workflows/build-safe-main.yml
@@ -15,6 +15,9 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-safe:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -9,6 +9,9 @@ concurrency:
   group: e2e-nightly
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   issues: write
@@ -16,6 +19,7 @@ permissions:
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
@@ -34,8 +38,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright Chromium
-        run: npx playwright install chromium --with-deps
+      - name: Install Playwright system deps
+        run: npx playwright install-deps chromium
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
+      - name: Install Playwright Chromium browser
+        run: npx playwright install chromium
 
       - name: Seed demo admin for e2e tests
         run: npm run create-admin -- "--email=$E2E_ADMIN_EMAIL" "--password=$E2E_ADMIN_PASSWORD" "--name=Admin"

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -23,6 +23,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   matrix-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -21,6 +21,9 @@ permissions:
   contents: read
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   install-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/plans-capture-nightly.yml
+++ b/.github/workflows/plans-capture-nightly.yml
@@ -13,6 +13,9 @@ permissions:
   contents: read
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 # Detects drift between prod /api/plans/resolved and the committed baseline at
 # e2e/plans/captured/*.json. A failing run means either (a) the platform shipped
 # a resolver change — refresh the baseline locally and commit, or (b) the

--- a/.github/workflows/qa-nightly.yml
+++ b/.github/workflows/qa-nightly.yml
@@ -158,6 +158,7 @@ jobs:
     needs: [qa]
     if: failure() && needs.qa.result == 'failure'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/qa-nightly.yml
+++ b/.github/workflows/qa-nightly.yml
@@ -19,6 +19,9 @@ concurrency:
   group: qa-nightly
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
   issues: write
@@ -27,6 +30,7 @@ permissions:
 jobs:
   qa:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4.3.1
@@ -39,8 +43,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browser
-        run: npx playwright install chromium --with-deps
+      - name: Install Playwright system deps
+        run: npx playwright install-deps chromium
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
+      - name: Install Playwright Chromium browser
+        run: npx playwright install chromium
 
       - name: Inject fixture results (fixture mode)
         if: ${{ inputs.fixture_results != '' }}
@@ -198,9 +207,15 @@ jobs:
           echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
           echo "ℹ️  Open issue: ${ISSUE_NUMBER:-none}"
 
-      - name: Install Playwright browser (Category A)
+      - name: Install Playwright system deps (Category A)
         if: env.CATEGORY == 'A'
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install-deps chromium
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
+      - name: Install Playwright Chromium browser (Category A)
+        if: env.CATEGORY == 'A'
+        run: npx playwright install chromium
 
       - name: Repair (Category A)
         if: env.CATEGORY == 'A'

--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -8,6 +8,9 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   spec-drift:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.109.3 - 2026-06-14
+
+### Fixed
+
+- **Nightly CI playwright hang** — split `playwright install chromium --with-deps` into two steps (`install-deps` with `DEBIAN_FRONTEND=noninteractive` + `install chromium`) in `e2e-nightly.yml` and `qa-nightly.yml`. The apt post-install hook was silently freezing after Chrome downloaded, causing every nightly run to hang for 6 hours before GitHub cancelled it.
+- **Node.js 20 action deprecation** — added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at workflow level to all 7 affected workflows ahead of the mandatory June 16 migration. Added `timeout-minutes: 30` to `e2e` and `qa` jobs so future hangs fail fast.
+
 ## 0.109.2 - 2026-06-13
 
 ### Fixed

--- a/docs/plans/ci-nightly-playwright-node24-review.md
+++ b/docs/plans/ci-nightly-playwright-node24-review.md
@@ -1,0 +1,38 @@
+# /review report — ci-nightly-playwright-node24
+
+**Branch:** `fix/ci-nightly-playwright-node24`
+**Generated:** 2026-06-14
+**Iterations to reach verified:** 1
+
+## Verdict
+
+Clear — pure CI infrastructure fix, no product code touched. Two root causes diagnosed from live run logs, both patched in the same commit.
+
+## Deliverables ↔ Code
+
+| Deliverable | Implementation | Status |
+|-------------|----------------|--------|
+| Fix playwright hang in `e2e-nightly.yml` | Split `playwright install chromium --with-deps` into `install-deps` (DEBIAN_FRONTEND=noninteractive) + `install chromium`; added `timeout-minutes: 30` | ✓ shipped |
+| Fix playwright hang in `qa-nightly.yml` | Same split applied to both `qa` job and `self-heal` job | ✓ shipped |
+| Node.js 20 deprecation — all 7 workflows | `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` added at workflow level to `e2e-nightly.yml`, `qa-nightly.yml`, `plans-capture-nightly.yml`, `build-safe-main.yml`, `spec-drift.yml`, `install-test.yml`, `install-matrix.yml` | ✓ shipped |
+
+### Code changes not tied to any deliverable
+
+- `package.json` / `package-lock.json` / `CHANGELOG.md` — version bump, expected release overhead
+
+## ACs ↔ Tests
+
+No plan doc or ACs — this is an infrastructure patch. Verification is observational: the two stuck nightly runs (27493188747, 27492014808) were cancelled manually; next scheduled runs will confirm the fix.
+
+## Docs drift
+
+None — no architecture or feature docs affected by CI workflow changes.
+
+## Recommendations
+
+None. The fix is structural (separate the install steps) and the timeout is a safety net for any future regressions of the same class.
+
+## Inputs for /retro
+
+- **Owning role:** `/devops`
+- **Lesson:** `playwright install chromium --with-deps` is a footgun on GitHub-hosted Ubuntu runners — the apt post-install hook for Chrome can freeze with no output, no timeout, and no signal. The safe pattern is always to split: `install-deps` first (with `DEBIAN_FRONTEND=noninteractive`), then `install chromium`. Add a job-level `timeout-minutes` as a backstop.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.109.2",
+  "version": "0.109.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.109.2",
+      "version": "0.109.3",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.109.2",
+  "version": "0.109.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Split `playwright install chromium --with-deps` into two steps (`install-deps` with `DEBIAN_FRONTEND=noninteractive` + `install chromium`) in `e2e-nightly.yml` and `qa-nightly.yml` — apt post-install hook was silently freezing after Chrome downloaded, causing every nightly run to hang for 6 hours before GitHub cancelled it (10+ days of broken nightlies)
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at workflow level to all 7 affected workflows ahead of mandatory June 16 Node.js 24 migration
- Added `timeout-minutes: 30` to `e2e` and `qa` jobs so future hangs fail fast instead of consuming the 6h GitHub default

## Test plan

- [ ] Verify `e2e-nightly.yml` completes past the playwright install step
- [ ] Verify `qa-nightly.yml` completes past the playwright install step
- [ ] No Node.js 20 deprecation warnings in any workflow logs after June 16