### PR TITLE
fix(ci): pre-install chromium-headless-shell — devices[Desktop Chrome] needs it (v0.109.8)

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -56,8 +56,9 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: |
           # playwright's yauzl (JS zip library) hangs on Node.js 24 for ALL zips.
-          # Bypass for both chromium and ffmpeg: curl download + system unzip + INSTALLATION_COMPLETE marker.
-          # playwright install then finds both markers and completes in < 1s.
+          # Bypass all three artifacts (chromium, chromium-headless-shell, ffmpeg):
+          # curl download + system unzip + INSTALLATION_COMPLETE marker each.
+          # playwright install then finds all markers and completes in < 1s.
           install_browser() {
             local NAME="$1"
             local INFO=$(node -e "
@@ -79,8 +80,9 @@ jobs:
             echo "[$NAME] pre-installed"
           }
           install_browser chromium
+          install_browser chromium-headless-shell
           install_browser ffmpeg
-          npx playwright install --no-shell chromium
+          npx playwright install chromium
         timeout-minutes: 5
         env:
           DEBUG: "pw:install"

--- a/.github/workflows/qa-nightly.yml
+++ b/.github/workflows/qa-nightly.yml
@@ -80,8 +80,9 @@ jobs:
             touch "$DIR/INSTALLATION_COMPLETE"
           }
           install_browser chromium
+          install_browser chromium-headless-shell
           install_browser ffmpeg
-          npx playwright install --no-shell chromium
+          npx playwright install chromium
         timeout-minutes: 5
         env:
           DEBUG: "pw:install"
@@ -289,8 +290,9 @@ jobs:
             touch "$DIR/INSTALLATION_COMPLETE"
           }
           install_browser chromium
+          install_browser chromium-headless-shell
           install_browser ffmpeg
-          npx playwright install --no-shell chromium
+          npx playwright install chromium
         timeout-minutes: 5
         env:
           DEBUG: "pw:install"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.109.8 - 2026-06-16
+
+### Fixed
+
+- **Nightly CI — E2E tests need chromium-headless-shell** — `devices["Desktop Chrome"]` in `playwright.config.ts` resolves to `chromium-headless-shell`, not full chromium. The `--no-shell` flag added in v0.109.5 was skipping it; extended `install_browser()` to also pre-install `chromium-headless-shell` via curl + system `unzip` + `INSTALLATION_COMPLETE` marker (same yauzl bypass pattern). Removed `--no-shell` from the final `playwright install` call — all three artifacts (chromium, chromium-headless-shell, ffmpeg) are now pre-installed so playwright finds all markers and exits in < 1s. Applied to `e2e-nightly.yml` and both jobs in `qa-nightly.yml`.
+
 ## 0.109.7 - 2026-06-15
 
 ### Fixed

--- a/docs/plans/ci-playwright-headless-shell-review.md
+++ b/docs/plans/ci-playwright-headless-shell-review.md
@@ -1,0 +1,48 @@
+# /review report — ci-playwright-headless-shell
+
+**Branch:** `fix/ci-playwright-headless-shell`
+**Generated:** 2026-06-16
+**Iterations to reach verified:** 1
+
+## Verdict
+
+Clear — pure CI infrastructure patch, no product code touched.
+
+## Deliverables ↔ Code
+
+| Deliverable | Implementation | Status |
+|-------------|----------------|--------|
+| Pre-install `chromium-headless-shell` in `e2e-nightly.yml` | `install_browser chromium-headless-shell` added; `--no-shell` removed | ✓ shipped |
+| Pre-install `chromium-headless-shell` in `qa-nightly.yml` (`qa` job) | Same pattern | ✓ shipped |
+| Pre-install `chromium-headless-shell` in `qa-nightly.yml` (`self-heal` job) | Same pattern | ✓ shipped |
+
+### Code changes not tied to any deliverable
+
+- `package.json` / `package-lock.json` / `CHANGELOG.md` — version bump, expected
+
+## Root cause (confirmed from v0.109.7 run log)
+
+v0.109.7 fixed the install hang — all three install steps passed. But the E2E tests failed immediately with:
+
+```text
+Error: browserType.launch: Executable doesn't exist at
+  /home/runner/.cache/ms-playwright/chromium_headless_shell-1208/
+  chrome-headless-shell-linux64/chrome-headless-shell
+```
+
+`playwright.config.ts` uses `devices["Desktop Chrome"]` which in Playwright 1.58 resolves to `chromium-headless-shell` (not the full chromium binary). The `--no-shell` flag added in v0.109.5 was designed to skip the headless-shell download (because it was silent and looked like a hang), but the tests actually need it.
+
+**Fix:** extend `install_browser()` to call `install_browser chromium-headless-shell` and remove `--no-shell`. All three artifacts (chromium, chromium-headless-shell, ffmpeg) are now pre-installed via curl + system `unzip` + `INSTALLATION_COMPLETE` marker before `npx playwright install chromium` runs. Playwright finds all three markers and exits in < 1s.
+
+## ACs ↔ Tests
+
+No plan doc or ACs — infrastructure patch. Verified observationally: next manual E2E run should install all three artifacts and proceed to running the actual test suite.
+
+## Docs drift
+
+None.
+
+## Inputs for /retro
+
+- **Owning role:** `/devops`
+- **Lesson:** `devices["Desktop Chrome"]` in Playwright config maps to `chromium-headless-shell`, not full chromium. The complete pre-install list for a Playwright chromium project is: chromium, chromium-headless-shell, ffmpeg — all three need the yauzl bypass. `--no-shell` is WRONG for projects that use `devices["Desktop Chrome"]`; it should only be used if the config explicitly avoids headless-shell.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.109.7",
+  "version": "0.109.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.109.7",
+      "version": "0.109.8",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.109.7",
+  "version": "0.109.8",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

v0.109.7 fixed the playwright install hang (all install steps passed) but E2E tests failed immediately:

```
Error: browserType.launch: Executable doesn't exist at
  /home/runner/.cache/ms-playwright/chromium_headless_shell-1208/chrome-headless-shell-linux64/chrome-headless-shell
```

Root cause: `playwright.config.ts` uses `devices["Desktop Chrome"]` which resolves to `chromium-headless-shell`. The `--no-shell` flag (added in v0.109.5) was skipping it.

Fix: add `install_browser chromium-headless-shell` to the pre-install sequence and remove `--no-shell`. All three artifacts (chromium, chromium-headless-shell, ffmpeg) are now pre-installed via curl + system unzip + INSTALLATION_COMPLETE marker — playwright finds all markers and exits in < 1s.

Applied to `e2e-nightly.yml` and both jobs in `qa-nightly.yml`.

## Review doc

`docs/plans/ci-playwright-headless-shell-review.md`

## Test plan

- [ ] Trigger manual E2E nightly run — install step passes, all three artifacts found as "already downloaded"
- [ ] E2E tests actually run (no missing executable error)