### PR TITLE
fix: demo-bypass endpoint-action CTAs on plans page

### DIFF
--- a/app/admin/support/plans/PlanPageClient.tsx
+++ b/app/admin/support/plans/PlanPageClient.tsx
@@ -328,7 +328,11 @@ export function PlanPageClient({ license, plans }: PlanPageClientProps) {
     }
     if (action.endpoint) {
       if (IS_DEMO) {
-        handleSubscribe(plan.slug);
+        if (action.endpoint.startsWith("/api/checkout")) {
+          handleSubscribe(plan.slug);
+        } else {
+          toast({ title: "Not available in demo mode" });
+        }
         return;
       }
       startTransition(async () => {

--- a/app/admin/support/plans/PlanPageClient.tsx
+++ b/app/admin/support/plans/PlanPageClient.tsx
@@ -327,6 +327,10 @@ export function PlanPageClient({ license, plans }: PlanPageClientProps) {
       return;
     }
     if (action.endpoint) {
+      if (IS_DEMO) {
+        handleSubscribe(plan.slug);
+        return;
+      }
       startTransition(async () => {
         try {
           const resp = await fetch(action.endpoint!, { method: "POST" });

--- a/app/admin/support/plans/__tests__/contract/demo-cta-endpoint.test.tsx
+++ b/app/admin/support/plans/__tests__/contract/demo-cta-endpoint.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * IS_DEMO guard on endpoint-only CTAs.
+ *
+ * Verifies that clicking an endpoint-backed action in demo mode:
+ *   - Does NOT call fetch (no real mutation)
+ *   - Routes checkout endpoints through the checkout/demo-bypass path
+ *   - Shows a "not available" toast for non-checkout endpoints
+ */
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(""),
+}));
+jest.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast: toastMock }) }));
+jest.mock("../../actions", () => ({ startCheckout: jest.fn().mockResolvedValue({ success: false }) }));
+jest.mock("../../../actions", () => ({ refreshLicense: jest.fn().mockResolvedValue({ success: false }) }));
+jest.mock("@/lib/demo", () => ({ IS_DEMO: true }));
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { startCheckout } from "../../actions";
+import { makeNone, makePlan, renderPlans } from "./_helpers";
+
+const toastMock = jest.fn();
+const startCheckoutMock = startCheckout as jest.Mock;
+
+let fetchMock: jest.Mock;
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  fetchMock = jest.fn();
+  global.fetch = fetchMock as unknown as typeof fetch;
+  toastMock.mockClear();
+  startCheckoutMock.mockClear();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("IS_DEMO endpoint guard", () => {
+  test("checkout endpoint CTA calls startCheckout and does NOT call fetch", async () => {
+    const user = userEvent.setup();
+    renderPlans([
+      makePlan(
+        makeNone({
+          actions: [{ slug: "subscribe", label: "Subscribe", variant: "primary", endpoint: "/api/checkout?planSlug=priority-support" }],
+        }),
+        { slug: "priority-support", name: "Priority Support" }
+      ),
+    ]);
+
+    await user.click(screen.getByRole("button", { name: /subscribe/i }));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(startCheckoutMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("non-checkout endpoint CTA shows toast and does NOT call fetch", async () => {
+    const user = userEvent.setup();
+    renderPlans([
+      makePlan(
+        makeNone({
+          actions: [{ slug: "portal", label: "Open Portal", variant: "primary", endpoint: "/api/billing/portal" }],
+        }),
+        { slug: "priority-support", name: "Priority Support" }
+      ),
+    ]);
+
+    await user.click(screen.getByRole("button", { name: /open portal/i }));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Not available in demo mode" })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- The priority support plan's subscribe CTA uses `action.endpoint` (because the platform sets `checkoutUrl` to `/api/checkout?planSlug=priority-support`, which starts with `/api/` and is classified as an endpoint in `materialize.ts`).
- The `action.endpoint` branch in `handleAction` had no `IS_DEMO` guard, so clicking the CTA in demo mode would POST to the store's cart checkout API instead of showing the demo toast.
- Added `if (IS_DEMO) { handleSubscribe(plan.slug); return; }` at the top of the endpoint branch, matching the existing guard in the `action.url` branch.

## Test plan

- [ ] On `demo.artisanroast.app/admin/support/plans`, click the Priority Support plan CTA — should show "Purchase complete — Demo mode, no charge made." toast (not open Stripe or fail silently)
- [ ] Verify Community Roast plan (free) is also visible after `LICENSE_KEY` redeploy
- [ ] On a real (non-demo) build, clicking an endpoint-action CTA still calls the endpoint as before