### PR TITLE
chore: bump version to 0.109.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.109.10 - 2026-06-27
+
+### Fixed
+
+- **Plans page — Priority Support subscribe CTA in demo mode** — `action.endpoint` path in `handleAction` was missing an `IS_DEMO` guard. The priority-support plan's `checkoutUrl` (`/api/checkout?planSlug=priority-support`) starts with `/api/` and is classified as an endpoint by the platform's materializer, so it bypassed the existing demo-bypass guard and attempted to POST to the store's cart checkout route (wrong). Now routes checkout endpoints (`/api/checkout*`) through the demo-bypass flow (toast: "Purchase complete — Demo mode, no charge made.") and shows "Not available in demo mode" for any other endpoint action. Added contract tests covering both paths.
+- **Plans page not loading on demo site** — `LICENSE_KEY` was missing from the Vercel production environment, causing `fetchResolvedPlans()` to silently return `[]`. Added `LICENSE_KEY` to the `artisan-roast` Vercel project's production env.
+
 ## 0.109.9 - 2026-06-26
 
 ### Fixed

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,9 +6,9 @@
 
 ---
 
-## Now — v0.100.9
+## Now — v0.109.10
 
-_Patch — Counter SRP refactor: route.ts split into extraction, prompts, catalog, and types modules (395 lines, orchestration-only). No behavior change._
+_Patch — Priority Support subscribe CTA in demo mode now shows toast via demo-bypass; LICENSE_KEY added to Vercel prod so plans page loads._
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.109.9",
+  "version": "0.109.10",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Syncs `package.json` to v0.109.10 (required for Vercel build — git tags unavailable at build time).

Also updates `CHANGELOG.md` and `docs/ROADMAP.md` for the release.

**Changes in this release (v0.109.10):**
- Fix: Priority Support subscribe CTA in demo mode now shows "Purchase complete — Demo mode, no charge made." toast via demo-bypass; non-checkout endpoint actions show "Not available in demo mode"
- Fix: `LICENSE_KEY` added to Vercel prod so the plans page loads on `demo.artisanroast.app`
- Test: contract tests added for IS_DEMO endpoint guard behavior