### PR TITLE
fix(security): bump @anthropic-ai/sdk, close moderate advisory (v0.109.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.109.14 - 2026-07-10
+
+### Fixed
+
+- **`@anthropic-ai/sdk` moderate security advisory** — bumped 0.82.0 → 0.111.0, closing `GHSA-p7fg-763f-g4gf` (insecure default file permissions in the beta Local Filesystem Memory Tool). Neither `scripts/qa-agent.js` nor `scripts/qa-repair-agent.js` uses the `client.beta.*` namespace this bug lives in, so it wasn't actually exploitable in our usage, but the vulnerable code shipped in the installed package regardless. Verified no breaking changes across the ~55 releases in range: the stable Messages API surface these scripts use (`client.messages.create`, `response.usage`, `response.stop_reason`, tool-use content blocks, env-driven `ANTHROPIC_BASE_URL`/`ANTHROPIC_API_KEY` resolution) is unchanged, and neither referenced model (`claude-sonnet-4-6`, `claude-haiku-4-5-20251001`) was retired.
+
 ## 0.109.13 - 2026-07-10
 
 ### Chore

--- a/docs/plans/bump-anthropic-sdk-review.md
+++ b/docs/plans/bump-anthropic-sdk-review.md
@@ -1,0 +1,48 @@
+# /review report — bump-anthropic-sdk
+
+**Branch:** `chore/bump-anthropic-sdk`
+**Generated:** 2026-07-10
+**Iterations to reach verified:** 1
+
+## Structural exception
+
+No in-repo plan or ACs doc exists for this work. Per `docs/AGENTIC-WORKFLOW.md`: "Skip for: Docs-only changes, single-line fixes, config tweaks, dependency updates." This is a single-package security-motivated bump, scoped down from the medium-risk tier at the user's explicit request ("just do anthropic-ai/sdk and leave the rest alone... no need to do unnecessary work"). Step 0's role-discovery falls back to the de-facto owning role: **`/devops`**. No project-local override exists; the global baseline applies.
+
+## Verdict
+
+**Clear.** Motivated by an actual moderate `npm audit` finding (`GHSA-p7fg-763f-g4gf`), not just version-freshness. Pre-verified via a dedicated research agent (full changelog read across ~55 releases + grep confirming this codebase doesn't use the affected beta namespace) before any install happened — reversing the order used for `archiver` in an earlier session, where the surprise was caught only after installing.
+
+## Deliverables ↔ Code
+
+| Item | Implementation | Status |
+|---|---|---|
+| `@anthropic-ai/sdk` 0.82.0 → 0.111.0 | `package.json` (devDependency, used only by `scripts/qa-agent.js` and `scripts/qa-repair-agent.js`) | ✓ shipped |
+| CHANGELOG + version bump | `CHANGELOG.md`, `package.json` (0.109.14) | ✓ shipped |
+
+### Code changes not tied to any deliverable
+
+None — no source changes required, confirmed both before installing (changelog research) and after (typecheck/build/test all clean with zero diffs to `scripts/qa-agent.js` or `scripts/qa-repair-agent.js`).
+
+## ACs ↔ Tests (Gate 3 spot-check)
+
+Not applicable — no `AC-TST-*` rows. Verification:
+
+- `npm run precheck` (typecheck + lint): 0 errors
+- `npm run test:ci`: 128 suites / 1437 tests passing
+- `npm run build`: succeeds
+- `npm audit`: the `@anthropic-ai/sdk` advisory is gone (6 moderate → 5 moderate; the remaining 5 are unrelated, pre-existing, and have no sane fix path — see conversation record)
+- **Live verification pending**: dispatching `qa-nightly.yml` against this branch to exercise `client.messages.create()` for real against the bumped SDK (the actual runtime surface, not just static analysis) before merge.
+
+## Docs drift
+
+None found.
+
+## Recommendations
+
+None outstanding for this fix. The rest of the medium-risk tier (`recharts`, `react-day-picker`, `puppeteer`, `@vercel/analytics`, `@vercel/speed-insights`) and the blocked `eslint`/`eslint-plugin-react-hooks` items remain queued per the user's explicit choice to isolate only the security-motivated bump this round.
+
+## Inputs for /retro
+
+- **Route:** `/devops` → `~/.claude/commands/devops.md`
+  **Draft principle:** *"When a major/minor bump is motivated by a real `npm audit` finding (not just staleness), research the changelog and grep for the affected API surface in this codebase's own usage BEFORE installing — not after, the way `archiver` was handled. For a security-motivated bump the goal is confidence the fix is real and safe, not just 'nothing broke locally'; pair the static check with a live dispatch of whatever workflow actually exercises the changed code path in production-like conditions (here: `qa-nightly.yml`, which runs the exact `client.messages.create()` call site this bump touches) before merging."*
+  **Triggered by:** This bump's process — research-before-install, confirmed via a dedicated agent that grepped for `.beta.` usage and read the actual GitHub changelog, then a live workflow dispatch as the final confidence check.

--- a/docs/plans/bump-anthropic-sdk-review.md
+++ b/docs/plans/bump-anthropic-sdk-review.md
@@ -31,7 +31,7 @@ Not applicable — no `AC-TST-*` rows. Verification:
 - `npm run test:ci`: 128 suites / 1437 tests passing
 - `npm run build`: succeeds
 - `npm audit`: the `@anthropic-ai/sdk` advisory is gone (6 moderate → 5 moderate; the remaining 5 are unrelated, pre-existing, and have no sane fix path — see conversation record)
-- **Live verification pending**: dispatching `qa-nightly.yml` against this branch to exercise `client.messages.create()` for real against the bumped SDK (the actual runtime surface, not just static analysis) before merge.
+- **Live verification complete**: dispatched `qa-nightly.yml` against this branch to exercise `client.messages.create()` for real against the bumped SDK (the actual runtime surface, not just static analysis) — passed (all 18 ACs green).
 
 ## Docs drift
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artisan-roast",
-  "version": "0.109.13",
+  "version": "0.109.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artisan-roast",
-      "version": "0.109.13",
+      "version": "0.109.14",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",
@@ -91,7 +91,7 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "^0.82.0",
+        "@anthropic-ai/sdk": "^0.111.0",
         "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@testing-library/dom": "^10.4.1",
@@ -148,13 +148,14 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.82.0.tgz",
-      "integrity": "sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==",
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.111.0.tgz",
+      "integrity": "sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artisan-roast",
-  "version": "0.109.13",
+  "version": "0.109.14",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -125,7 +125,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.82.0",
+    "@anthropic-ai/sdk": "^0.111.0",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
## Summary

Closes a real `npm audit` finding: `@anthropic-ai/sdk` 0.82.0 fell inside the vulnerable range (0.79.0-0.91.0) for `GHSA-p7fg-763f-g4gf` (insecure default file permissions in the beta Local Filesystem Memory Tool). Bumped to 0.111.0.

Neither `scripts/qa-agent.js` nor `scripts/qa-repair-agent.js` touches the `client.beta.*` namespace this bug lives in, so it wasn't actually exploitable in our usage — but the vulnerable code shipped in the installed package regardless, so the fix is real, not cosmetic.

Scoped down from the medium-risk tier at explicit request — the rest of that batch (`recharts`, `react-day-picker`, `puppeteer`, Vercel components) and the blocked items (`eslint`, `eslint-plugin-react-hooks`) are intentionally left alone this round.

## Verification

Researched before installing, not after (learned from an earlier `archiver` surprise this week): a dedicated research pass read the actual SDK changelog across ~55 releases in range and confirmed zero breaking changes to the stable Messages API surface these scripts use (`client.messages.create`, `response.usage`, `response.stop_reason`, tool-use content blocks, env-driven `ANTHROPIC_BASE_URL`/`ANTHROPIC_API_KEY` resolution), and neither referenced model was retired.

Then verified for real:

- `npm run precheck` (typecheck + lint): 0 errors
- `npm run test:ci`: 128 suites / 1437 tests passing
- `npm run build`: succeeds
- `npm audit`: the SDK's advisory is gone (6 moderate → 5 moderate; remaining 5 are unrelated, pre-existing, no sane fix path — see conversation record)
- **Dispatched `qa-nightly.yml` against this branch** — exercised the real `client.messages.create()` call against the bumped SDK in production-like conditions. Passed.

`/review` report: `docs/plans/bump-anthropic-sdk-review.md`

## Test plan

- [ ] Copilot review addressed
- [ ] Merge, then `npm run release:patch -- -y --push --sync-package` (no `--github-release`, internal fix)
